### PR TITLE
test: Phase 0 test foundation and migration harness

### DIFF
--- a/lib/core/services/db_service.dart
+++ b/lib/core/services/db_service.dart
@@ -21,6 +21,9 @@ part 'db_service.g.dart';
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(driftDatabase(name: 'focus.sqlite'));
 
+  /// In-memory / injected executor for tests and migration harnesses.
+  AppDatabase.forTesting(super.e);
+
   @override
   int get schemaVersion => 5;
 
@@ -71,9 +74,8 @@ class AppDatabase extends _$AppDatabase {
         // 5) Recreate indexes
         // This preserves existing rows while updating the schema.
 
-        await customStatement('BEGIN TRANSACTION');
-
-        // Rename current tables to temporary names
+        // Drift already wraps onUpgrade in a transaction. Do not issue
+        // nested BEGIN/COMMIT here — that can fail on some sqlite builds.
         await customStatement('ALTER TABLE task_table RENAME TO task_table_old');
         await customStatement('ALTER TABLE focus_session_table RENAME TO focus_session_table_old');
 
@@ -142,8 +144,6 @@ class AppDatabase extends _$AppDatabase {
         await customStatement(
           'CREATE INDEX IF NOT EXISTS focus_session_start_time_idx ON focus_session_table(start_time)',
         );
-
-        await customStatement('COMMIT');
       }
 
       // v2 → v3: Add focus_phase_ended_at column to focus_session_table

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1219,7 +1219,7 @@ packages:
     source: hosted
     version: "0.7.0+eol"
   sqlite3:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: sqlite3
       sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -837,6 +837,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.6.4"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "5e1bf53cc7baa8062a33b84424deb61513858ea05c601b8509e683815b5914aa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.5"
   native_toolchain_c:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
   mocktail: ^1.0.4
+  sqlite3: ^2.9.4
 
   # Code generation
   # Capped to the analyzer 12 line. flutter_test pins test_api 0.7.11 exactly, the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
   mocktail: ^1.0.4
-  sqlite3: ^2.9.4
+  sqlite3: ^3.5.0
 
   # Code generation
   # Capped to the analyzer 12 line. flutter_test pins test_api 0.7.11 exactly, the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,6 +62,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  mocktail: ^1.0.4
 
   # Code generation
   # Capped to the analyzer 12 line. flutter_test pins test_api 0.7.11 exactly, the

--- a/test/core/db/migration_harness_test.dart
+++ b/test/core/db/migration_harness_test.dart
@@ -1,0 +1,129 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/core/services/db_service.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+/// Phase 0 migration harness.
+///
+/// Captures the current (v5) schema via [AppDatabase.forTesting] and verifies
+/// that upgrading from a hand-built v1 schema reaches v5 without nested
+/// transaction statements and without losing rows.
+void main() {
+  test('onCreate produces schema version 5 with expected tables', () async {
+    final db = AppDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    final version = await db.customSelect('PRAGMA user_version').getSingle();
+    expect(version.read<int>('user_version'), 5);
+
+    final tables = await db.customSelect("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").get();
+    final names = tables.map((row) => row.read<String>('name')).toSet();
+    expect(
+      names,
+      containsAll({
+        'project_table',
+        'task_table',
+        'focus_session_table',
+        'daily_session_stats_table',
+        'settings_table',
+        'notification_inbox_table',
+      }),
+    );
+  });
+
+  test('migrates v1 schema to v5 and preserves task rows', () async {
+    final raw = sqlite3.openInMemory();
+    _createV1Schema(raw);
+    raw.execute('INSERT INTO project_table (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)', [
+      1,
+      'Legacy Project',
+      1700000000,
+      1700000000,
+    ]);
+    raw.execute(
+      'INSERT INTO task_table (id, project_id, title, priority, depth, is_completed, created_at, updated_at) '
+      'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+      [1, 1, 'Legacy Task', 1, 0, 0, 1700000000, 1700000000],
+    );
+    raw.execute('PRAGMA user_version = 1');
+
+    final db = AppDatabase.forTesting(NativeDatabase.opened(raw));
+    addTearDown(() async {
+      await db.close();
+    });
+
+    final version = await db.customSelect('PRAGMA user_version').getSingle();
+    expect(version.read<int>('user_version'), 5);
+
+    final tasks = await db.select(db.taskTable).get();
+    expect(tasks, hasLength(1));
+    expect(tasks.single.title, 'Legacy Task');
+    expect(tasks.single.projectId, 1);
+
+    // reminder columns added in v4
+    expect(tasks.single.reminderMode.index, 0);
+
+    // notification inbox created in v5
+    final inbox = await db.select(db.notificationInboxTable).get();
+    expect(inbox, isEmpty);
+  });
+}
+
+void _createV1Schema(Database raw) {
+  raw.execute('''
+    CREATE TABLE project_table (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL,
+      description TEXT,
+      start_date INTEGER,
+      deadline INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  ''');
+  raw.execute('''
+    CREATE TABLE task_table (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      project_id INTEGER NOT NULL,
+      parent_task_id INTEGER,
+      title TEXT NOT NULL,
+      description TEXT,
+      priority INTEGER NOT NULL,
+      start_date INTEGER,
+      end_date INTEGER,
+      depth INTEGER NOT NULL,
+      is_completed INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(project_id) REFERENCES project_table(id),
+      FOREIGN KEY(parent_task_id) REFERENCES task_table(id)
+    )
+  ''');
+  raw.execute('''
+    CREATE TABLE focus_session_table (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id INTEGER,
+      focus_duration_minutes INTEGER NOT NULL,
+      break_duration_minutes INTEGER NOT NULL,
+      start_time INTEGER NOT NULL,
+      end_time INTEGER,
+      state INTEGER NOT NULL,
+      elapsed_seconds INTEGER NOT NULL DEFAULT 0,
+      FOREIGN KEY(task_id) REFERENCES task_table(id)
+    )
+  ''');
+  raw.execute('''
+    CREATE TABLE daily_session_stats_table (
+      date TEXT NOT NULL PRIMARY KEY,
+      completed_sessions INTEGER NOT NULL,
+      total_sessions INTEGER NOT NULL,
+      focus_seconds INTEGER NOT NULL
+    )
+  ''');
+  raw.execute('''
+    CREATE TABLE settings_table (
+      key TEXT NOT NULL PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  ''');
+}

--- a/test/domain/projects/project_service_test.dart
+++ b/test/domain/projects/project_service_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/core/utils/result.dart';
+import 'package:focus/features/projects/domain/entities/project.dart';
+import 'package:focus/features/projects/domain/entities/project_extensions.dart';
+import 'package:focus/features/projects/domain/repositories/i_project_repository.dart';
+import 'package:focus/features/projects/domain/services/project_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../helpers/fixtures.dart';
+
+class _MockProjectRepository extends Mock implements IProjectRepository {}
+
+void main() {
+  late _MockProjectRepository repository;
+  late ProjectService service;
+
+  setUpAll(() {
+    registerFallbackValue(buildProject());
+  });
+
+  setUp(() {
+    repository = _MockProjectRepository();
+    service = ProjectService(repository);
+  });
+
+  test('createProject stamps timestamps and returns Success', () async {
+    when(() => repository.createProject(any())).thenAnswer((invocation) async {
+      final project = invocation.positionalArguments.first as Project;
+      return project.copyWith(id: 42);
+    });
+
+    final result = await service.createProject(title: 'Ship Phase 0');
+    expect(result, isA<Success<Project>>());
+    final created = (result as Success<Project>).value;
+    expect(created.id, 42);
+    expect(created.title, 'Ship Phase 0');
+    verify(() => repository.createProject(any())).called(1);
+  });
+
+  test('createProject returns Failure when repository throws', () async {
+    when(() => repository.createProject(any())).thenThrow(Exception('db down'));
+    final result = await service.createProject(title: 'Broken');
+    expect(result, isA<Failure<Project>>());
+    expect((result as Failure<Project>).failure, isA<DatabaseFailure>());
+  });
+
+  test('updateProject refreshes updatedAt', () async {
+    when(() => repository.updateProject(any())).thenAnswer((_) async {});
+    final project = buildProject(id: 7);
+    final result = await service.updateProject(project);
+    expect(result, isA<Success<void>>());
+    final captured = verify(() => repository.updateProject(captureAny())).captured.single as Project;
+    expect(captured.id, 7);
+    expect(
+      captured.updatedAt.isAfter(project.updatedAt) || captured.updatedAt.isAtSameMomentAs(project.updatedAt),
+      isTrue,
+    );
+  });
+
+  test('deleteProject returns Failure when repository throws', () async {
+    when(() => repository.deleteProject(9)).thenThrow(Exception('fk'));
+    final result = await service.deleteProject(9);
+    expect(result, isA<Failure<void>>());
+  });
+}

--- a/test/domain/session/focus_session_state_machine_test.dart
+++ b/test/domain/session/focus_session_state_machine_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/features/session/domain/entities/session_state.dart';
+import 'package:focus/features/session/domain/services/focus_session_state_machine.dart';
+
+import '../../helpers/fixtures.dart';
+
+void main() {
+  const machine = FocusSessionStateMachine();
+
+  group('tick', () {
+    test('increments elapsed during a running focus phase', () {
+      final session = buildSession(elapsedSeconds: 10);
+      final result = machine.tick(session);
+      expect(result, isA<TickUpdate>());
+      final update = result as TickUpdate;
+      expect(update.session.elapsedSeconds, 11);
+      expect(update.shouldPersist, isFalse);
+    });
+
+    test('requests persistence every 10 seconds', () {
+      final session = buildSession(elapsedSeconds: 19);
+      final result = machine.tick(session) as TickUpdate;
+      expect(result.shouldPersist, isTrue);
+      expect(result.session.elapsedSeconds, 20);
+    });
+
+    test('transitions to break when focus duration is exhausted', () {
+      final session = buildSession(focusDurationMinutes: 1, elapsedSeconds: 59);
+      final result = machine.tick(session);
+      expect(result, isA<FocusPhaseCompleted>());
+      final completed = result as FocusPhaseCompleted;
+      expect(completed.session.state, SessionState.onBreak);
+      expect(completed.session.elapsedSeconds, 60);
+      expect(completed.session.focusPhaseEndedAt, 60);
+    });
+
+    test('completes the cycle when break duration ends', () {
+      final session = buildSession(
+        focusDurationMinutes: 1,
+        breakDurationMinutes: 1,
+        state: SessionState.onBreak,
+        elapsedSeconds: 119,
+        focusPhaseEndedAt: 60,
+      );
+      final result = machine.tick(session);
+      expect(result, isA<CycleCompleted>());
+      expect(result.session.state, SessionState.completed);
+      expect(result.session.endTime, isNotNull);
+    });
+
+    test('is a no-op tick in idle', () {
+      final session = buildSession(state: SessionState.idle, elapsedSeconds: 0);
+      final result = machine.tick(session) as TickUpdate;
+      expect(result.session.elapsedSeconds, 0);
+    });
+  });
+
+  group('skip', () {
+    test('skips focus into break while preserving elapsed', () {
+      final session = buildSession(focusDurationMinutes: 25, elapsedSeconds: 30);
+      final result = machine.skip(session);
+      expect(result, isA<FocusPhaseCompleted>());
+      expect(result!.session.state, SessionState.onBreak);
+      expect(result.session.elapsedSeconds, 30);
+      expect(result.session.focusPhaseEndedAt, 30);
+    });
+
+    test('skips break into completed', () {
+      final session = buildSession(state: SessionState.onBreak, elapsedSeconds: 70, focusPhaseEndedAt: 60);
+      final result = machine.skip(session);
+      expect(result, isA<CycleCompleted>());
+      expect(result!.session.state, SessionState.completed);
+    });
+
+    test('returns null for non-skippable states', () {
+      expect(machine.skip(buildSession(state: SessionState.idle)), isNull);
+      expect(machine.skip(buildSession(state: SessionState.completed)), isNull);
+      expect(machine.skip(buildSession(state: SessionState.cancelled)), isNull);
+    });
+  });
+
+  group('pause and resume', () {
+    test('pauses a running session', () {
+      final paused = machine.pause(buildSession(state: SessionState.running));
+      expect(paused?.state, SessionState.paused);
+    });
+
+    test('pauses an on-break session', () {
+      final paused = machine.pause(buildSession(state: SessionState.onBreak, focusPhaseEndedAt: 60));
+      expect(paused?.state, SessionState.paused);
+    });
+
+    test('refuses to pause idle sessions', () {
+      expect(machine.pause(buildSession(state: SessionState.idle)), isNull);
+    });
+
+    test('resumes into running when still in focus window', () {
+      final resumed = machine.resume(
+        buildSession(state: SessionState.paused, elapsedSeconds: 20, focusPhaseEndedAt: 60),
+      );
+      expect(resumed?.state, SessionState.running);
+    });
+
+    test('resumes into onBreak when past focus end', () {
+      final resumed = machine.resume(
+        buildSession(state: SessionState.paused, elapsedSeconds: 70, focusPhaseEndedAt: 60),
+      );
+      expect(resumed?.state, SessionState.onBreak);
+    });
+
+    test('refuses to resume non-paused sessions', () {
+      expect(machine.resume(buildSession(state: SessionState.running)), isNull);
+    });
+  });
+}

--- a/test/domain/tasks/task_reminder_planner_test.dart
+++ b/test/domain/tasks/task_reminder_planner_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/features/tasks/domain/entities/task_reminder_mode.dart';
+import 'package:focus/features/tasks/domain/services/task_reminder_planner.dart';
+
+import '../../helpers/fixtures.dart';
+
+void main() {
+  group('TaskReminderPlanner.computeReminderTime', () {
+    test('returns null when task has no id', () {
+      final task = buildTask(id: null);
+      expect(TaskReminderPlanner.computeReminderTime(task, now: testNow), isNull);
+    });
+
+    test('returns null when task has no deadline', () {
+      final task = buildTask(endDate: null);
+      expect(TaskReminderPlanner.computeReminderTime(task, now: testNow), isNull);
+    });
+
+    test('returns null when task is completed', () {
+      final task = buildTask(isCompleted: true);
+      expect(TaskReminderPlanner.computeReminderTime(task, now: testNow), isNull);
+    });
+
+    test('returns null when reminder mode is none', () {
+      final task = buildTask(reminderMode: TaskReminderMode.none);
+      expect(TaskReminderPlanner.computeReminderTime(task, now: testNow), isNull);
+    });
+
+    test('schedules one day before for dayBefore mode', () {
+      final deadline = testNow.add(const Duration(days: 3));
+      final task = buildTask(reminderMode: TaskReminderMode.dayBefore, endDate: deadline);
+      final reminder = TaskReminderPlanner.computeReminderTime(task, now: testNow);
+      expect(reminder, deadline.subtract(const Duration(days: 1)));
+    });
+
+    test('schedules one week before for weekBefore mode', () {
+      final deadline = testNow.add(const Duration(days: 14));
+      final task = buildTask(reminderMode: TaskReminderMode.weekBefore, endDate: deadline);
+      final reminder = TaskReminderPlanner.computeReminderTime(task, now: testNow);
+      expect(reminder, deadline.subtract(const Duration(days: 7)));
+    });
+
+    test('uses custom minutes when custom mode is set', () {
+      final deadline = testNow.add(const Duration(hours: 5));
+      final task = buildTask(reminderMode: TaskReminderMode.custom, customReminderMinutesBefore: 90, endDate: deadline);
+      final reminder = TaskReminderPlanner.computeReminderTime(task, now: testNow);
+      expect(reminder, deadline.subtract(const Duration(minutes: 90)));
+    });
+
+    test('returns null for invalid custom minutes', () {
+      final task = buildTask(reminderMode: TaskReminderMode.custom, customReminderMinutesBefore: 0);
+      expect(TaskReminderPlanner.computeReminderTime(task, now: testNow), isNull);
+    });
+
+    test('falls back to now+2s when planned reminder is already past', () {
+      final deadline = testNow.add(const Duration(hours: 6));
+      final task = buildTask(reminderMode: TaskReminderMode.dayBefore, endDate: deadline);
+      final reminder = TaskReminderPlanner.computeReminderTime(task, now: testNow);
+      expect(reminder, testNow.add(const Duration(seconds: 2)));
+    });
+
+    test('smart mode uses a week lead for long spans', () {
+      final created = testNow.subtract(const Duration(days: 20));
+      final deadline = testNow.add(const Duration(days: 10));
+      final task = buildTask(
+        reminderMode: TaskReminderMode.smart,
+        createdAt: created,
+        startDate: created,
+        endDate: deadline,
+      );
+      final reminder = TaskReminderPlanner.computeReminderTime(task, now: testNow);
+      expect(reminder, deadline.subtract(const Duration(days: 7)));
+    });
+
+    test('smart mode uses a day lead for short remaining windows', () {
+      final created = testNow.subtract(const Duration(days: 1));
+      final deadline = testNow.add(const Duration(days: 2));
+      final task = buildTask(
+        reminderMode: TaskReminderMode.smart,
+        createdAt: created,
+        startDate: created,
+        endDate: deadline,
+      );
+      final reminder = TaskReminderPlanner.computeReminderTime(task, now: testNow);
+      expect(reminder, deadline.subtract(const Duration(days: 1)));
+    });
+  });
+}

--- a/test/domain/tasks/task_service_test.dart
+++ b/test/domain/tasks/task_service_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/core/utils/result.dart';
+import 'package:focus/features/tasks/domain/entities/task.dart';
+import 'package:focus/features/tasks/domain/entities/task_extensions.dart';
+import 'package:focus/features/tasks/domain/repositories/i_task_repository.dart';
+import 'package:focus/features/tasks/domain/services/task_notification_service.dart';
+import 'package:focus/features/tasks/domain/services/task_service.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../helpers/fixtures.dart';
+
+class _MockTaskRepository extends Mock implements ITaskRepository {}
+
+class _MockTaskNotificationService extends Mock implements TaskNotificationService {}
+
+void main() {
+  late _MockTaskRepository repository;
+  late _MockTaskNotificationService notifications;
+  late TaskService service;
+
+  setUpAll(() {
+    registerFallbackValue(buildTask());
+  });
+
+  setUp(() {
+    repository = _MockTaskRepository();
+    notifications = _MockTaskNotificationService();
+    service = TaskService(repository, notifications);
+    when(() => notifications.scheduleTaskReminder(any())).thenAnswer((_) async => const Success(null));
+    when(() => notifications.cancelTaskReminder(any())).thenAnswer((_) async => const Success(null));
+  });
+
+  test('createTask persists and schedules a reminder', () async {
+    when(() => repository.createTask(any())).thenAnswer((invocation) async {
+      final task = invocation.positionalArguments.first as Task;
+      return task.copyWith(id: 11);
+    });
+
+    final result = await service.createTask(projectId: 1, title: 'Write Phase 0', depth: 0);
+    expect(result, isA<Success<Task>>());
+    final created = (result as Success<Task>).value;
+    expect(created.id, 11);
+    verify(() => repository.createTask(any())).called(1);
+    verify(() => notifications.scheduleTaskReminder(created)).called(1);
+  });
+
+  test('updateTask cancels then reschedules reminders', () async {
+    when(() => repository.updateTask(any())).thenAnswer((_) async {});
+    final task = buildTask(id: 5, title: 'Updated');
+    final result = await service.updateTask(task);
+    expect(result, isA<Success<void>>());
+    verifyInOrder([
+      () => notifications.cancelTaskReminder(5),
+      () => repository.updateTask(any()),
+      () => notifications.scheduleTaskReminder(any()),
+    ]);
+  });
+
+  test('deleteTask cancels reminder then deletes', () async {
+    when(() => repository.deleteTask(3)).thenAnswer((_) async {});
+    final result = await service.deleteTask(3);
+    expect(result, isA<Success<void>>());
+    verifyInOrder([() => notifications.cancelTaskReminder(3), () => repository.deleteTask(3)]);
+  });
+
+  test('toggleTaskCompletion cancels reminder when completing', () async {
+    when(() => repository.updateTask(any())).thenAnswer((_) async {});
+    final task = buildTask(id: 8, isCompleted: false);
+    final result = await service.toggleTaskCompletion(task);
+    expect(result, isA<Success<void>>());
+    final captured = verify(() => repository.updateTask(captureAny())).captured.single as Task;
+    expect(captured.isCompleted, isTrue);
+    verify(() => notifications.cancelTaskReminder(8)).called(1);
+    verifyNever(() => notifications.scheduleTaskReminder(any()));
+  });
+
+  test('toggleTaskCompletion reschedules when reopening', () async {
+    when(() => repository.updateTask(any())).thenAnswer((_) async {});
+    final task = buildTask(id: 8, isCompleted: true);
+    final result = await service.toggleTaskCompletion(task);
+    expect(result, isA<Success<void>>());
+    verify(() => notifications.scheduleTaskReminder(any())).called(1);
+  });
+
+  test('createTask returns Failure when repository throws', () async {
+    when(() => repository.createTask(any())).thenThrow(Exception('disk full'));
+    final result = await service.createTask(projectId: 1, title: 'Fail', depth: 0);
+    expect(result, isA<Failure<Task>>());
+  });
+}

--- a/test/helpers/fixtures.dart
+++ b/test/helpers/fixtures.dart
@@ -1,0 +1,78 @@
+import 'package:focus/features/projects/domain/entities/project.dart';
+import 'package:focus/features/session/domain/entities/focus_session.dart';
+import 'package:focus/features/session/domain/entities/session_state.dart';
+import 'package:focus/features/tasks/domain/entities/task.dart';
+import 'package:focus/features/tasks/domain/entities/task_priority.dart';
+import 'package:focus/features/tasks/domain/entities/task_reminder_mode.dart';
+
+/// Shared fixed clock for deterministic domain tests.
+final testNow = DateTime.utc(2026, 8, 2, 12);
+
+Task buildTask({
+  int? id = 1,
+  int projectId = 1,
+  String title = 'Write tests',
+  TaskPriority priority = TaskPriority.medium,
+  TaskReminderMode reminderMode = TaskReminderMode.dayBefore,
+  int? customReminderMinutesBefore,
+  DateTime? startDate,
+  Object? endDate = _sentinel,
+  int depth = 0,
+  bool isCompleted = false,
+  DateTime? createdAt,
+  DateTime? updatedAt,
+}) {
+  final created = createdAt ?? testNow.subtract(const Duration(days: 3));
+  final resolvedEndDate = identical(endDate, _sentinel) ? testNow.add(const Duration(days: 2)) : endDate as DateTime?;
+  return Task(
+    id: id,
+    projectId: projectId,
+    title: title,
+    priority: priority,
+    reminderMode: reminderMode,
+    customReminderMinutesBefore: customReminderMinutesBefore,
+    startDate: startDate,
+    endDate: resolvedEndDate,
+    depth: depth,
+    isCompleted: isCompleted,
+    createdAt: created,
+    updatedAt: updatedAt ?? created,
+  );
+}
+
+const _sentinel = Object();
+
+Project buildProject({
+  int? id = 1,
+  String title = 'Focus',
+  String? description,
+  DateTime? createdAt,
+  DateTime? updatedAt,
+}) {
+  final created = createdAt ?? testNow.subtract(const Duration(days: 7));
+  return Project(id: id, title: title, description: description, createdAt: created, updatedAt: updatedAt ?? created);
+}
+
+FocusSession buildSession({
+  int? id = 1,
+  int? taskId = 1,
+  int focusDurationMinutes = 25,
+  int breakDurationMinutes = 5,
+  SessionState state = SessionState.running,
+  int elapsedSeconds = 0,
+  int? focusPhaseEndedAt,
+  DateTime? startTime,
+  DateTime? endTime,
+}) {
+  return FocusSession(
+    id: id,
+    taskId: taskId,
+    focusDurationMinutes: focusDurationMinutes,
+    breakDurationMinutes: breakDurationMinutes,
+    startTime: startTime ?? testNow,
+    endTime: endTime,
+    state: state,
+    elapsedSeconds: elapsedSeconds,
+    focusPhaseEndedAt: focusPhaseEndedAt,
+  );
+}


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch test/phase-0-test-foundation into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
a973c42 test(foundation): add domain tests and Drift migration harness
a360273 chore(deps): upgrade Flutter, ForUI, and related packages to current majors
66dfbd0 docs(agents): add Dart/Flutter style rules for shorthands and opacity

### Files
- .agents/docs/coding_style.md
- .agents/docs/commands.md
- .fvmrc
- AGENTS.md
- lib/core/app.dart
- lib/core/config/theme/app_theme.dart
- lib/core/config/theme/card_style.dart
- lib/core/config/theme/theme_builder.dart
- lib/core/config/theme/typography/typography.dart
- lib/core/providers/expansion_provider.g.dart
- lib/core/services/db_service.dart
- lib/core/services/db_service.g.dart
- lib/core/services/log_service.dart
- lib/core/utils/date_time_utils.dart
- lib/core/widgets/action_menu_button.dart
- lib/core/widgets/adaptive_shell.dart
- lib/core/widgets/app_card.dart
- lib/core/widgets/app_search_bar.dart
- lib/core/widgets/base_form_screen.dart
- lib/core/widgets/confirmation_dialog.dart
- lib/core/widgets/sort_filter_chips.dart
- lib/core/widgets/time_field.dart
- lib/features/home/presentation/pages/home_screen.dart
- lib/features/home/presentation/providers/activity_graph_providers.g.dart
- lib/features/home/presentation/providers/upcoming_calendar_state_provider.g.dart
- lib/features/home/presentation/providers/upcoming_calendar_view_provider.g.dart
- lib/features/home/presentation/widgets/calendar_content.dart
- lib/features/home/presentation/widgets/calendar_view_toggle.dart
- lib/features/home/presentation/widgets/global_stats_row.dart
- lib/features/home/presentation/widgets/overlay_task_tile.dart
- lib/features/home/presentation/widgets/quick_session_button.dart
- lib/features/home/presentation/widgets/recent_project_tile.dart
- lib/features/home/presentation/widgets/recent_task_tile.dart
- lib/features/home/presentation/widgets/section_header.dart
- lib/features/home/presentation/widgets/streak_badge.dart
- lib/features/home/presentation/widgets/task_popup_content.dart
- lib/features/home/presentation/widgets/today_summary_card.dart
- lib/features/projects/domain/entities/project.dart
- lib/features/projects/presentation/providers/project_provider.g.dart
- lib/features/projects/presentation/screens/create_project_screen.dart
- lib/features/projects/presentation/screens/edit_project_screen.dart
- lib/features/projects/presentation/screens/project_detail_screen.dart
- lib/features/projects/presentation/screens/project_list_screen.dart
- lib/features/projects/presentation/screens/projects_screen.g.dart
- lib/features/projects/presentation/widgets/project_card.dart
- lib/features/projects/presentation/widgets/project_detail_header.dart
- lib/features/projects/presentation/widgets/project_meta_section.dart
- lib/features/reports/presentation/providers/reports_insights_window_provider.g.dart
- lib/features/reports/presentation/widgets/focus_ratio_chart.dart
- lib/features/reports/presentation/widgets/insights_window_toggle.dart
- lib/features/reports/presentation/widgets/productivity_insights_section.dart
- lib/features/session/data/repositories/focus_session_repository_impl.dart
- lib/features/session/domain/entities/focus_session_extensions.dart
- lib/features/session/domain/services/focus_session_state_machine.dart
- lib/features/session/presentation/commands/focus_commands.dart
- lib/features/session/presentation/providers/ambience_mute_provider.g.dart
- lib/features/session/presentation/providers/focus_progress_provider.g.dart
- lib/features/session/presentation/providers/focus_providers.g.dart
- lib/features/session/presentation/providers/focus_screen_provider.g.dart
- lib/features/session/presentation/providers/focus_session_provider.g.dart
- lib/features/session/presentation/screens/focus_session_screen.dart
- lib/features/session/presentation/widgets/ambience_marquee_row.dart
- lib/features/session/presentation/widgets/circular_timer.dart
- lib/features/session/presentation/widgets/focus_controls_with_callback.dart
- lib/features/session/presentation/widgets/focus_task_info.dart
- lib/features/session/presentation/widgets/mini_player_overlay.dart
- lib/features/settings/presentation/providers/settings_provider.g.dart
- lib/features/settings/presentation/widgets/expandable_section.dart
- lib/features/settings/presentation/widgets/sound_item_tile.dart
- lib/features/settings/presentation/widgets/timer_settings_card.dart
- lib/features/sync/data/services/google_drive_service.dart
- lib/features/sync/presentation/providers/sync_provider.g.dart
- lib/features/sync/presentation/screens/sync_conflict_screen.dart
- lib/features/sync/presentation/widgets/sync_settings_card.dart
- lib/features/tasks/domain/entities/daily_session_stats.dart
- lib/features/tasks/domain/entities/global_stats.dart
- lib/features/tasks/domain/entities/task_stats.dart
- lib/features/tasks/presentation/providers/all_tasks_provider.g.dart
- lib/features/tasks/presentation/providers/selected_task_selection.g.dart
- lib/features/tasks/presentation/providers/task_provider.g.dart
- lib/features/tasks/presentation/screens/all_tasks_screen.dart
- lib/features/tasks/presentation/screens/create_task_screen.dart
- lib/features/tasks/presentation/screens/create_task_with_project_screen.dart
- lib/features/tasks/presentation/screens/edit_task_screen.dart
- lib/features/tasks/presentation/screens/task_detail_screen.dart
- lib/features/tasks/presentation/widgets/add_subtask_chip.dart
- lib/features/tasks/presentation/widgets/all_tasks_filters.dart
- lib/features/tasks/presentation/widgets/all_tasks_list.dart
- lib/features/tasks/presentation/widgets/create_task_new_project_hint.dart
- lib/features/tasks/presentation/widgets/create_task_project_autocomplete.dart
- lib/features/tasks/presentation/widgets/embedded_create_task_button.dart
- lib/features/tasks/presentation/widgets/inline_add_subtask.dart
- lib/features/tasks/presentation/widgets/recent_session_tile.dart
- lib/features/tasks/presentation/widgets/subtask_count_chip.dart
- lib/features/tasks/presentation/widgets/subtasks_section.dart
- lib/features/tasks/presentation/widgets/task_date_row.dart
- lib/features/tasks/presentation/widgets/task_priority_badge.dart
- lib/features/tasks/presentation/widgets/task_quick_actions.dart
- lib/features/tasks/presentation/widgets/task_stats_row.dart
- lib/features/tasks/presentation/widgets/task_summary_section.dart
- linux/flutter/generated_plugin_registrant.cc
- linux/flutter/generated_plugins.cmake
- macos/Flutter/GeneratedPluginRegistrant.swift
- macos/Podfile.lock
- macos/Runner.xcodeproj/project.pbxproj
- macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
- macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
- macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
- pubspec.lock
- pubspec.yaml
- test/core/db/migration_harness_test.dart
- test/domain/projects/project_service_test.dart
- test/domain/session/focus_session_state_machine_test.dart
- test/domain/tasks/task_reminder_planner_test.dart
- test/domain/tasks/task_service_test.dart
- test/helpers/fixtures.dart
- windows/flutter/generated_plugin_registrant.cc
- windows/flutter/generated_plugins.cmake

### Diffstat
 .agents/docs/coding_style.md                       |    5 +
 .agents/docs/commands.md                           |   12 +
 .fvmrc                                             |    2 +-
 AGENTS.md                                          |    2 +-
 lib/core/app.dart                                  |    5 +-
 lib/core/config/theme/app_theme.dart               |    4 +-
 lib/core/config/theme/card_style.dart              |    8 +-
 lib/core/config/theme/theme_builder.dart           |   25 +-
 lib/core/config/theme/typography/typography.dart   |   13 +-
 lib/core/providers/expansion_provider.g.dart       |   12 +-
 lib/core/services/db_service.dart                  |   10 +-
 lib/core/services/db_service.g.dart                | 2538 ++++++--------------
 lib/core/services/log_service.dart                 |    8 +-
 lib/core/utils/date_time_utils.dart                |    2 +-
 lib/core/widgets/action_menu_button.dart           |   16 +-
 lib/core/widgets/adaptive_shell.dart               |   22 +-
 lib/core/widgets/app_card.dart                     |    4 +-
 lib/core/widgets/app_search_bar.dart               |    2 +-
 lib/core/widgets/base_form_screen.dart             |    2 +-
 lib/core/widgets/confirmation_dialog.dart          |   47 +-
 lib/core/widgets/sort_filter_chips.dart            |    2 +-
 lib/core/widgets/time_field.dart                   |    6 +-
 .../home/presentation/pages/home_screen.dart       |    8 +-
 .../providers/activity_graph_providers.g.dart      |   48 +-
 .../upcoming_calendar_state_provider.g.dart        |   27 +-
 .../upcoming_calendar_view_provider.g.dart         |   25 +-
 .../presentation/widgets/calendar_content.dart     |    9 +-
 .../presentation/widgets/calendar_view_toggle.dart |    4 +-
 .../presentation/widgets/global_stats_row.dart     |    6 +-
 .../presentation/widgets/overlay_task_tile.dart    |    2 +-
 .../presentation/widgets/quick_session_button.dart |   24 +-
 .../presentation/widgets/recent_project_tile.dart  |    8 +-
 .../presentation/widgets/recent_task_tile.dart     |    4 +-
 .../home/presentation/widgets/section_header.dart  |    2 +-
 .../home/presentation/widgets/streak_badge.dart    |    2 +-
 .../presentation/widgets/task_popup_content.dart   |    6 +-
 .../presentation/widgets/today_summary_card.dart   |    2 +-
 lib/features/projects/domain/entities/project.dart |    4 +-
 .../presentation/providers/project_provider.g.dart |  123 +-
 .../screens/create_project_screen.dart             |   15 +-
 .../presentation/screens/edit_project_screen.dart  |   13 +-
 .../screens/project_detail_screen.dart             |   10 +-
 .../presentation/screens/project_list_screen.dart  |    6 +-
 .../presentation/screens/projects_screen.g.dart    |   21 +-
 .../presentation/widgets/project_card.dart         |    6 +-
 .../widgets/project_detail_header.dart             |    2 +-
 .../presentation/widgets/project_meta_section.dart |   12 +-
 .../reports_insights_window_provider.g.dart        |   19 +-
 .../presentation/widgets/focus_ratio_chart.dart    |    7 +-
 .../widgets/insights_window_toggle.dart            |    4 +-
 .../widgets/productivity_insights_section.dart     |    2 +-
 .../focus_session_repository_impl.dart             |    7 +-
 .../domain/entities/focus_session_extensions.dart  |    4 +-
 .../services/focus_session_state_machine.dart      |   18 +-
 .../presentation/commands/focus_commands.dart      |    2 +-
 .../providers/ambience_mute_provider.g.dart        |   34 +-
 .../providers/focus_progress_provider.g.dart       |   11 +-
 .../presentation/providers/focus_providers.g.dart  |  103 +-
 .../providers/focus_screen_provider.g.dart         |   15 +-
 .../providers/focus_session_provider.g.dart        |   19 +-
 .../presentation/screens/focus_session_screen.dart |    2 +-
 .../presentation/widgets/ambience_marquee_row.dart |    4 +-
 .../presentation/widgets/circular_timer.dart       |    4 +-
 .../widgets/focus_controls_with_callback.dart      |   62 +-
 .../presentation/widgets/focus_task_info.dart      |    2 +-
 .../presentation/widgets/mini_player_overlay.dart  |    2 +-
 .../providers/settings_provider.g.dart             |   64 +-
 .../presentation/widgets/expandable_section.dart   |    2 +-
 .../presentation/widgets/sound_item_tile.dart      |    4 +-
 .../presentation/widgets/timer_settings_card.dart  |    6 +-
 .../sync/data/services/google_drive_service.dart   |   73 +-
 .../presentation/providers/sync_provider.g.dart    |   50 +-
 .../presentation/screens/sync_conflict_screen.dart |    6 +-
 .../presentation/widgets/sync_settings_card.dart   |    4 +-
 .../tasks/domain/entities/daily_session_stats.dart |    4 +-
 .../tasks/domain/entities/global_stats.dart        |   13 +-
 lib/features/tasks/domain/entities/task_stats.dart |    9 +-
 .../providers/all_tasks_provider.g.dart            |   12 +-
 .../providers/selected_task_selection.g.dart       |   22 +-
 .../presentation/providers/task_provider.g.dart    |  155 +-
 .../presentation/screens/all_tasks_screen.dart     |    2 +-
 .../presentation/screens/create_task_screen.dart   |   15 +-
 .../screens/create_task_with_project_screen.dart   |   15 +-
 .../presentation/screens/edit_task_screen.dart     |   13 +-
 .../presentation/screens/task_detail_screen.dart   |   12 +-
 .../presentation/widgets/add_subtask_chip.dart     |    4 +-
 .../presentation/widgets/all_tasks_filters.dart    |    2 +-
 .../tasks/presentation/widgets/all_tasks_list.dart |    2 +-
 .../widgets/create_task_new_project_hint.dart      |    2 +-
 .../widgets/create_task_project_autocomplete.dart  |    2 +-
 .../widgets/embedded_create_task_button.dart       |    2 +-
 .../presentation/widgets/inline_add_subtask.dart   |    2 +-
 .../presentation/widgets/recent_session_tile.dart  |    8 +-
 .../presentation/widgets/subtask_count_chip.dart   |    7 +-
 .../presentation/widgets/subtasks_section.dart     |    4 +-
 .../tasks/presentation/widgets/task_date_row.dart  |    4 +-
 .../presentation/widgets/task_priority_badge.dart  |   10 +-
 .../presentation/widgets/task_quick_actions.dart   |   14 +-
 .../tasks/presentation/widgets/task_stats_row.dart |   18 +-
 .../presentation/widgets/task_summary_section.dart |   13 +-
 linux/flutter/generated_plugin_registrant.cc       |    4 -
 linux/flutter/generated_plugins.cmake              |    2 +-
 macos/Flutter/GeneratedPluginRegistrant.swift      |    4 -
 macos/Podfile.lock                                 |   92 -
 macos/Runner.xcodeproj/project.pbxproj             |   42 +-
 .../xcshareddata/swiftpm/Package.resolved          |   77 +
 .../xcshareddata/xcschemes/Runner.xcscheme         |   18 +
 .../xcshareddata/swiftpm/Package.resolved          |   77 +
 pubspec.lock                                       |  442 ++--
 pubspec.yaml                                       |   66 +-
 test/core/db/migration_harness_test.dart           |  129 +
 test/domain/projects/project_service_test.dart     |   65 +
 .../session/focus_session_state_machine_test.dart  |  115 +
 test/domain/tasks/task_reminder_planner_test.dart  |   88 +
 test/domain/tasks/task_service_test.dart           |   90 +
 test/helpers/fixtures.dart                         |   78 +
 windows/flutter/generated_plugin_registrant.cc     |    3 -
 windows/flutter/generated_plugins.cmake            |    2 +-
 118 files changed, 2401 insertions(+), 3025 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
