### PR TITLE
feat(sync): Phase 1 UUID identity and soft deletes

### DIFF
--- a/.agents/docs/architecture.md
+++ b/.agents/docs/architecture.md
@@ -158,7 +158,16 @@ Rules for schema changes:
 4. Regenerate code.
 5. Verify migration behavior with existing user data.
 
-Current task schema includes reminder configuration fields:
+Current sync-ready schema (v6) includes on `project_table`, `task_table`, and `focus_session_table`:
+- `uuid` (TEXT, unique) — stable sync identity, generated on create and backfilled on migration
+- `deleted_at` (nullable DateTime) — soft-delete tombstone; all reads filter `deletedAt IS NULL`
+
+Deletes are soft deletes. `ON DELETE CASCADE` no longer fires for app-level deletes, so project/task
+deletion must cascade soft-deletes to dependents inside a transaction. `SyncPurgeService` hard-deletes
+tombstones older than the retention window (default 30 days). A stable `device_id` setting UUID is
+generated once on first launch for sync provenance.
+
+Current task schema also includes reminder configuration fields:
 - `reminder_mode` (enum-backed)
 - `custom_reminder_minutes_before` (nullable int)
 

--- a/.agents/docs/patterns.md
+++ b/.agents/docs/patterns.md
@@ -281,6 +281,27 @@ Guidelines:
 - `custom` stores minutes-before as an integer.
 - Keep reminder computation in a pure planner utility so UI and services share logic.
 
+## Soft Delete + UUID Sync Identity
+
+Projects, tasks, and focus sessions carry a `uuid` and optional `deletedAt`.
+
+```dart
+// Soft delete in datasource (never hard DELETE for user-facing removes)
+await (_db.update(_db.projectTable)..where((t) => t.id.equals(id))).write(
+  ProjectTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
+);
+
+// Every read/watch filters tombstones
+..where((t) => t.deletedAt.isNull())
+```
+
+Gotchas:
+- Soft-deleting a project must transactionally soft-delete its tasks and their sessions.
+- Soft-deleting a task must soft-delete descendants and their sessions.
+- Generate `uuid` on create via `generateUuid()`; migration backfills existing rows.
+- `SyncPurgeService` permanently removes tombstones past the retention window.
+- Persist `SettingsKeys.deviceId` once via `SettingsService.ensureDeviceId()`.
+
 ## Mandatory Follow-Up
 
 When a new pattern is introduced in production code, add it here with:

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -22,6 +22,7 @@ import '../../features/settings/domain/services/settings_service.dart';
 import '../../features/sync/data/services/google_drive_service.dart';
 import '../../features/sync/domain/services/i_cloud_storage_service.dart';
 import '../../features/sync/domain/services/sync_engine.dart';
+import '../../features/sync/domain/services/sync_purge_service.dart';
 import '../../features/tasks/data/datasources/task_local_datasource.dart';
 import '../../features/tasks/data/datasources/task_stats_local_datasource.dart';
 import '../../features/tasks/data/repositories/task_repository_impl.dart';
@@ -147,6 +148,7 @@ void _initSessionDi() {
 void _initSyncDi() {
   getIt
     ..registerLazySingleton<ICloudStorageService>(() => GoogleDriveService())
+    ..registerLazySingleton<SyncPurgeService>(() => SyncPurgeService(getIt<AppDatabase>()))
     ..registerLazySingleton<SyncEngine>(
       () => SyncEngine(
         getIt<ICloudStorageService>(),

--- a/lib/core/services/db_service.dart
+++ b/lib/core/services/db_service.dart
@@ -12,6 +12,7 @@ import '../../features/notifications/domain/entities/notification_inbox_item.dar
 import '../../features/tasks/domain/entities/task_priority.dart';
 import '../../features/tasks/domain/entities/task_reminder_mode.dart';
 import '../utils/datetime_formatter.dart';
+import '../utils/id_utils.dart';
 
 part 'db_service.g.dart';
 
@@ -25,7 +26,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 5;
+  int get schemaVersion => 6;
 
   /// Recalculates the [dailySessionStatsTable] row for the given
   /// local calendar [dateKey] (format `YYYY-MM-DD`).
@@ -41,7 +42,7 @@ class AppDatabase extends _$AppDatabase {
       "COUNT(*), "
       "COALESCE(SUM(MIN(elapsed_seconds, focus_duration_minutes * 60)), 0) "
       "FROM focus_session_table "
-      "WHERE date(start_time, 'unixepoch', 'localtime') = ?",
+      "WHERE deleted_at IS NULL AND date(start_time, 'unixepoch', 'localtime') = ?",
       [dateKey, dateKey],
     );
     // customStatement does not notify Drift stream watchers.
@@ -163,6 +164,29 @@ class AppDatabase extends _$AppDatabase {
       if (from < 5) {
         await m.createTable(notificationInboxTable);
       }
+
+      // v5 → v6: Sync-ready identity (uuid) + soft-delete tombstones.
+      if (from < 6) {
+        await customStatement('ALTER TABLE project_table ADD COLUMN uuid TEXT');
+        await customStatement('ALTER TABLE project_table ADD COLUMN deleted_at INTEGER');
+        await customStatement('ALTER TABLE task_table ADD COLUMN uuid TEXT');
+        await customStatement('ALTER TABLE task_table ADD COLUMN deleted_at INTEGER');
+        await customStatement('ALTER TABLE focus_session_table ADD COLUMN uuid TEXT');
+        await customStatement('ALTER TABLE focus_session_table ADD COLUMN deleted_at INTEGER');
+
+        await _backfillUuids('project_table');
+        await _backfillUuids('task_table');
+        await _backfillUuids('focus_session_table');
+
+        await customStatement('CREATE UNIQUE INDEX IF NOT EXISTS project_uuid_idx ON project_table(uuid)');
+        await customStatement('CREATE INDEX IF NOT EXISTS project_deleted_at_idx ON project_table(deleted_at)');
+        await customStatement('CREATE UNIQUE INDEX IF NOT EXISTS task_uuid_idx ON task_table(uuid)');
+        await customStatement('CREATE INDEX IF NOT EXISTS task_deleted_at_idx ON task_table(deleted_at)');
+        await customStatement('CREATE UNIQUE INDEX IF NOT EXISTS focus_session_uuid_idx ON focus_session_table(uuid)');
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS focus_session_deleted_at_idx ON focus_session_table(deleted_at)',
+        );
+      }
     },
     beforeOpen: (details) async {
       // SQLite requires this pragma to be enabled per connection.
@@ -170,4 +194,13 @@ class AppDatabase extends _$AppDatabase {
       await customStatement('PRAGMA foreign_keys = ON');
     },
   );
+
+  /// Assigns a UUID to every row in [tableName] that still has a null uuid.
+  Future<void> _backfillUuids(String tableName) async {
+    final rows = await customSelect('SELECT id FROM $tableName WHERE uuid IS NULL').get();
+    for (final row in rows) {
+      final id = row.read<int>('id');
+      await customStatement('UPDATE $tableName SET uuid = ? WHERE id = ?', [generateUuid(), id]);
+    }
+  }
 }

--- a/lib/core/services/db_service.g.dart
+++ b/lib/core/services/db_service.g.dart
@@ -19,6 +19,16 @@ class $ProjectTableTable extends ProjectTable with TableInfo<$ProjectTableTable,
     requiredDuringInsert: false,
     defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'),
   );
+  static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
+  @override
+  late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
+    'uuid',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
+  );
   static const VerificationMeta _titleMeta = const VerificationMeta('title');
   @override
   late final GeneratedColumn<String> title = GeneratedColumn<String>(
@@ -73,8 +83,27 @@ class $ProjectTableTable extends ProjectTable with TableInfo<$ProjectTableTable,
     type: DriftSqlType.dateTime,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _deletedAtMeta = const VerificationMeta('deletedAt');
   @override
-  List<GeneratedColumn> get $columns => [id, title, description, startDate, deadline, createdAt, updatedAt];
+  late final GeneratedColumn<DateTime> deletedAt = GeneratedColumn<DateTime>(
+    'deleted_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    uuid,
+    title,
+    description,
+    startDate,
+    deadline,
+    createdAt,
+    updatedAt,
+    deletedAt,
+  ];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -86,6 +115,11 @@ class $ProjectTableTable extends ProjectTable with TableInfo<$ProjectTableTable,
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('uuid')) {
+      context.handle(_uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
+    } else if (isInserting) {
+      context.missing(_uuidMeta);
     }
     if (data.containsKey('title')) {
       context.handle(_titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
@@ -111,6 +145,9 @@ class $ProjectTableTable extends ProjectTable with TableInfo<$ProjectTableTable,
     } else if (isInserting) {
       context.missing(_updatedAtMeta);
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta, deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -121,12 +158,14 @@ class $ProjectTableTable extends ProjectTable with TableInfo<$ProjectTableTable,
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return ProjectTableData(
       id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
       title: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}title'])!,
       description: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}description']),
       startDate: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}start_date']),
       deadline: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}deadline']),
       createdAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
       updatedAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -138,25 +177,30 @@ class $ProjectTableTable extends ProjectTable with TableInfo<$ProjectTableTable,
 
 class ProjectTableData extends DataClass implements Insertable<ProjectTableData> {
   final int id;
+  final String uuid;
   final String title;
   final String? description;
   final DateTime? startDate;
   final DateTime? deadline;
   final DateTime createdAt;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
   const ProjectTableData({
     required this.id,
+    required this.uuid,
     required this.title,
     this.description,
     this.startDate,
     this.deadline,
     required this.createdAt,
     required this.updatedAt,
+    this.deletedAt,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
+    map['uuid'] = Variable<String>(uuid);
     map['title'] = Variable<String>(title);
     if (!nullToAbsent || description != null) {
       map['description'] = Variable<String>(description);
@@ -169,18 +213,23 @@ class ProjectTableData extends DataClass implements Insertable<ProjectTableData>
     }
     map['created_at'] = Variable<DateTime>(createdAt);
     map['updated_at'] = Variable<DateTime>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<DateTime>(deletedAt);
+    }
     return map;
   }
 
   ProjectTableCompanion toCompanion(bool nullToAbsent) {
     return ProjectTableCompanion(
       id: Value(id),
+      uuid: Value(uuid),
       title: Value(title),
       description: description == null && nullToAbsent ? const Value.absent() : Value(description),
       startDate: startDate == null && nullToAbsent ? const Value.absent() : Value(startDate),
       deadline: deadline == null && nullToAbsent ? const Value.absent() : Value(deadline),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent ? const Value.absent() : Value(deletedAt),
     );
   }
 
@@ -188,12 +237,14 @@ class ProjectTableData extends DataClass implements Insertable<ProjectTableData>
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return ProjectTableData(
       id: serializer.fromJson<int>(json['id']),
+      uuid: serializer.fromJson<String>(json['uuid']),
       title: serializer.fromJson<String>(json['title']),
       description: serializer.fromJson<String?>(json['description']),
       startDate: serializer.fromJson<DateTime?>(json['startDate']),
       deadline: serializer.fromJson<DateTime?>(json['deadline']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+      deletedAt: serializer.fromJson<DateTime?>(json['deletedAt']),
     );
   }
   @override
@@ -201,41 +252,49 @@ class ProjectTableData extends DataClass implements Insertable<ProjectTableData>
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
+      'uuid': serializer.toJson<String>(uuid),
       'title': serializer.toJson<String>(title),
       'description': serializer.toJson<String?>(description),
       'startDate': serializer.toJson<DateTime?>(startDate),
       'deadline': serializer.toJson<DateTime?>(deadline),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
+      'deletedAt': serializer.toJson<DateTime?>(deletedAt),
     };
   }
 
   ProjectTableData copyWith({
     int? id,
+    String? uuid,
     String? title,
     Value<String?> description = const Value.absent(),
     Value<DateTime?> startDate = const Value.absent(),
     Value<DateTime?> deadline = const Value.absent(),
     DateTime? createdAt,
     DateTime? updatedAt,
+    Value<DateTime?> deletedAt = const Value.absent(),
   }) => ProjectTableData(
     id: id ?? this.id,
+    uuid: uuid ?? this.uuid,
     title: title ?? this.title,
     description: description.present ? description.value : this.description,
     startDate: startDate.present ? startDate.value : this.startDate,
     deadline: deadline.present ? deadline.value : this.deadline,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
+    deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
   );
   ProjectTableData copyWithCompanion(ProjectTableCompanion data) {
     return ProjectTableData(
       id: data.id.present ? data.id.value : this.id,
+      uuid: data.uuid.present ? data.uuid.value : this.uuid,
       title: data.title.present ? data.title.value : this.title,
       description: data.description.present ? data.description.value : this.description,
       startDate: data.startDate.present ? data.startDate.value : this.startDate,
       deadline: data.deadline.present ? data.deadline.value : this.deadline,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -243,96 +302,115 @@ class ProjectTableData extends DataClass implements Insertable<ProjectTableData>
   String toString() {
     return (StringBuffer('ProjectTableData(')
           ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
           ..write('title: $title, ')
           ..write('description: $description, ')
           ..write('startDate: $startDate, ')
           ..write('deadline: $deadline, ')
           ..write('createdAt: $createdAt, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, title, description, startDate, deadline, createdAt, updatedAt);
+  int get hashCode => Object.hash(id, uuid, title, description, startDate, deadline, createdAt, updatedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is ProjectTableData &&
           other.id == this.id &&
+          other.uuid == this.uuid &&
           other.title == this.title &&
           other.description == this.description &&
           other.startDate == this.startDate &&
           other.deadline == this.deadline &&
           other.createdAt == this.createdAt &&
-          other.updatedAt == this.updatedAt);
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class ProjectTableCompanion extends UpdateCompanion<ProjectTableData> {
   final Value<int> id;
+  final Value<String> uuid;
   final Value<String> title;
   final Value<String?> description;
   final Value<DateTime?> startDate;
   final Value<DateTime?> deadline;
   final Value<DateTime> createdAt;
   final Value<DateTime> updatedAt;
+  final Value<DateTime?> deletedAt;
   const ProjectTableCompanion({
     this.id = const Value.absent(),
+    this.uuid = const Value.absent(),
     this.title = const Value.absent(),
     this.description = const Value.absent(),
     this.startDate = const Value.absent(),
     this.deadline = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
   });
   ProjectTableCompanion.insert({
     this.id = const Value.absent(),
+    required String uuid,
     required String title,
     this.description = const Value.absent(),
     this.startDate = const Value.absent(),
     this.deadline = const Value.absent(),
     required DateTime createdAt,
     required DateTime updatedAt,
-  }) : title = Value(title),
+    this.deletedAt = const Value.absent(),
+  }) : uuid = Value(uuid),
+       title = Value(title),
        createdAt = Value(createdAt),
        updatedAt = Value(updatedAt);
   static Insertable<ProjectTableData> custom({
     Expression<int>? id,
+    Expression<String>? uuid,
     Expression<String>? title,
     Expression<String>? description,
     Expression<DateTime>? startDate,
     Expression<DateTime>? deadline,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? updatedAt,
+    Expression<DateTime>? deletedAt,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
+      if (uuid != null) 'uuid': uuid,
       if (title != null) 'title': title,
       if (description != null) 'description': description,
       if (startDate != null) 'start_date': startDate,
       if (deadline != null) 'deadline': deadline,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
     });
   }
 
   ProjectTableCompanion copyWith({
     Value<int>? id,
+    Value<String>? uuid,
     Value<String>? title,
     Value<String?>? description,
     Value<DateTime?>? startDate,
     Value<DateTime?>? deadline,
     Value<DateTime>? createdAt,
     Value<DateTime>? updatedAt,
+    Value<DateTime?>? deletedAt,
   }) {
     return ProjectTableCompanion(
       id: id ?? this.id,
+      uuid: uuid ?? this.uuid,
       title: title ?? this.title,
       description: description ?? this.description,
       startDate: startDate ?? this.startDate,
       deadline: deadline ?? this.deadline,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
     );
   }
 
@@ -341,6 +419,9 @@ class ProjectTableCompanion extends UpdateCompanion<ProjectTableData> {
     final map = <String, Expression>{};
     if (id.present) {
       map['id'] = Variable<int>(id.value);
+    }
+    if (uuid.present) {
+      map['uuid'] = Variable<String>(uuid.value);
     }
     if (title.present) {
       map['title'] = Variable<String>(title.value);
@@ -360,6 +441,9 @@ class ProjectTableCompanion extends UpdateCompanion<ProjectTableData> {
     if (updatedAt.present) {
       map['updated_at'] = Variable<DateTime>(updatedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<DateTime>(deletedAt.value);
+    }
     return map;
   }
 
@@ -367,12 +451,14 @@ class ProjectTableCompanion extends UpdateCompanion<ProjectTableData> {
   String toString() {
     return (StringBuffer('ProjectTableCompanion(')
           ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
           ..write('title: $title, ')
           ..write('description: $description, ')
           ..write('startDate: $startDate, ')
           ..write('deadline: $deadline, ')
           ..write('createdAt: $createdAt, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
@@ -393,6 +479,16 @@ class $TaskTableTable extends TaskTable with TableInfo<$TaskTableTable, TaskTabl
     type: DriftSqlType.int,
     requiredDuringInsert: false,
     defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'),
+  );
+  static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
+  @override
+  late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
+    'uuid',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
   );
   static const VerificationMeta _projectIdMeta = const VerificationMeta('projectId');
   @override
@@ -516,9 +612,19 @@ class $TaskTableTable extends TaskTable with TableInfo<$TaskTableTable, TaskTabl
     type: DriftSqlType.dateTime,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _deletedAtMeta = const VerificationMeta('deletedAt');
+  @override
+  late final GeneratedColumn<DateTime> deletedAt = GeneratedColumn<DateTime>(
+    'deleted_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
+    uuid,
     projectId,
     parentTaskId,
     title,
@@ -532,6 +638,7 @@ class $TaskTableTable extends TaskTable with TableInfo<$TaskTableTable, TaskTabl
     isCompleted,
     createdAt,
     updatedAt,
+    deletedAt,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -544,6 +651,11 @@ class $TaskTableTable extends TaskTable with TableInfo<$TaskTableTable, TaskTabl
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('uuid')) {
+      context.handle(_uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
+    } else if (isInserting) {
+      context.missing(_uuidMeta);
     }
     if (data.containsKey('project_id')) {
       context.handle(_projectIdMeta, projectId.isAcceptableOrUnknown(data['project_id']!, _projectIdMeta));
@@ -594,6 +706,9 @@ class $TaskTableTable extends TaskTable with TableInfo<$TaskTableTable, TaskTabl
     } else if (isInserting) {
       context.missing(_updatedAtMeta);
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta, deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -604,6 +719,7 @@ class $TaskTableTable extends TaskTable with TableInfo<$TaskTableTable, TaskTabl
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return TaskTableData(
       id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
       projectId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}project_id'])!,
       parentTaskId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}parent_task_id']),
       title: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}title'])!,
@@ -624,6 +740,7 @@ class $TaskTableTable extends TaskTable with TableInfo<$TaskTableTable, TaskTabl
       isCompleted: attachedDatabase.typeMapping.read(DriftSqlType.bool, data['${effectivePrefix}is_completed'])!,
       createdAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
       updatedAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -641,6 +758,7 @@ class $TaskTableTable extends TaskTable with TableInfo<$TaskTableTable, TaskTabl
 
 class TaskTableData extends DataClass implements Insertable<TaskTableData> {
   final int id;
+  final String uuid;
   final int projectId;
   final int? parentTaskId;
   final String title;
@@ -654,8 +772,10 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
   final bool isCompleted;
   final DateTime createdAt;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
   const TaskTableData({
     required this.id,
+    required this.uuid,
     required this.projectId,
     this.parentTaskId,
     required this.title,
@@ -669,11 +789,13 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     required this.isCompleted,
     required this.createdAt,
     required this.updatedAt,
+    this.deletedAt,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
+    map['uuid'] = Variable<String>(uuid);
     map['project_id'] = Variable<int>(projectId);
     if (!nullToAbsent || parentTaskId != null) {
       map['parent_task_id'] = Variable<int>(parentTaskId);
@@ -701,12 +823,16 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     map['is_completed'] = Variable<bool>(isCompleted);
     map['created_at'] = Variable<DateTime>(createdAt);
     map['updated_at'] = Variable<DateTime>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<DateTime>(deletedAt);
+    }
     return map;
   }
 
   TaskTableCompanion toCompanion(bool nullToAbsent) {
     return TaskTableCompanion(
       id: Value(id),
+      uuid: Value(uuid),
       projectId: Value(projectId),
       parentTaskId: parentTaskId == null && nullToAbsent ? const Value.absent() : Value(parentTaskId),
       title: Value(title),
@@ -722,6 +848,7 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
       isCompleted: Value(isCompleted),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent ? const Value.absent() : Value(deletedAt),
     );
   }
 
@@ -729,6 +856,7 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return TaskTableData(
       id: serializer.fromJson<int>(json['id']),
+      uuid: serializer.fromJson<String>(json['uuid']),
       projectId: serializer.fromJson<int>(json['projectId']),
       parentTaskId: serializer.fromJson<int?>(json['parentTaskId']),
       title: serializer.fromJson<String>(json['title']),
@@ -742,6 +870,7 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
       isCompleted: serializer.fromJson<bool>(json['isCompleted']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+      deletedAt: serializer.fromJson<DateTime?>(json['deletedAt']),
     );
   }
   @override
@@ -749,6 +878,7 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
+      'uuid': serializer.toJson<String>(uuid),
       'projectId': serializer.toJson<int>(projectId),
       'parentTaskId': serializer.toJson<int?>(parentTaskId),
       'title': serializer.toJson<String>(title),
@@ -762,11 +892,13 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
       'isCompleted': serializer.toJson<bool>(isCompleted),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
+      'deletedAt': serializer.toJson<DateTime?>(deletedAt),
     };
   }
 
   TaskTableData copyWith({
     int? id,
+    String? uuid,
     int? projectId,
     Value<int?> parentTaskId = const Value.absent(),
     String? title,
@@ -780,8 +912,10 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     bool? isCompleted,
     DateTime? createdAt,
     DateTime? updatedAt,
+    Value<DateTime?> deletedAt = const Value.absent(),
   }) => TaskTableData(
     id: id ?? this.id,
+    uuid: uuid ?? this.uuid,
     projectId: projectId ?? this.projectId,
     parentTaskId: parentTaskId.present ? parentTaskId.value : this.parentTaskId,
     title: title ?? this.title,
@@ -797,10 +931,12 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     isCompleted: isCompleted ?? this.isCompleted,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
+    deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
   );
   TaskTableData copyWithCompanion(TaskTableCompanion data) {
     return TaskTableData(
       id: data.id.present ? data.id.value : this.id,
+      uuid: data.uuid.present ? data.uuid.value : this.uuid,
       projectId: data.projectId.present ? data.projectId.value : this.projectId,
       parentTaskId: data.parentTaskId.present ? data.parentTaskId.value : this.parentTaskId,
       title: data.title.present ? data.title.value : this.title,
@@ -816,6 +952,7 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
       isCompleted: data.isCompleted.present ? data.isCompleted.value : this.isCompleted,
       createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
       updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -823,6 +960,7 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
   String toString() {
     return (StringBuffer('TaskTableData(')
           ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
           ..write('projectId: $projectId, ')
           ..write('parentTaskId: $parentTaskId, ')
           ..write('title: $title, ')
@@ -835,7 +973,8 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
           ..write('depth: $depth, ')
           ..write('isCompleted: $isCompleted, ')
           ..write('createdAt: $createdAt, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
@@ -843,6 +982,7 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
   @override
   int get hashCode => Object.hash(
     id,
+    uuid,
     projectId,
     parentTaskId,
     title,
@@ -856,12 +996,14 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     isCompleted,
     createdAt,
     updatedAt,
+    deletedAt,
   );
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is TaskTableData &&
           other.id == this.id &&
+          other.uuid == this.uuid &&
           other.projectId == this.projectId &&
           other.parentTaskId == this.parentTaskId &&
           other.title == this.title &&
@@ -874,11 +1016,13 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
           other.depth == this.depth &&
           other.isCompleted == this.isCompleted &&
           other.createdAt == this.createdAt &&
-          other.updatedAt == this.updatedAt);
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
   final Value<int> id;
+  final Value<String> uuid;
   final Value<int> projectId;
   final Value<int?> parentTaskId;
   final Value<String> title;
@@ -892,8 +1036,10 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
   final Value<bool> isCompleted;
   final Value<DateTime> createdAt;
   final Value<DateTime> updatedAt;
+  final Value<DateTime?> deletedAt;
   const TaskTableCompanion({
     this.id = const Value.absent(),
+    this.uuid = const Value.absent(),
     this.projectId = const Value.absent(),
     this.parentTaskId = const Value.absent(),
     this.title = const Value.absent(),
@@ -907,9 +1053,11 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     this.isCompleted = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
   });
   TaskTableCompanion.insert({
     this.id = const Value.absent(),
+    required String uuid,
     required int projectId,
     this.parentTaskId = const Value.absent(),
     required String title,
@@ -923,7 +1071,9 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     this.isCompleted = const Value.absent(),
     required DateTime createdAt,
     required DateTime updatedAt,
-  }) : projectId = Value(projectId),
+    this.deletedAt = const Value.absent(),
+  }) : uuid = Value(uuid),
+       projectId = Value(projectId),
        title = Value(title),
        priority = Value(priority),
        depth = Value(depth),
@@ -931,6 +1081,7 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
        updatedAt = Value(updatedAt);
   static Insertable<TaskTableData> custom({
     Expression<int>? id,
+    Expression<String>? uuid,
     Expression<int>? projectId,
     Expression<int>? parentTaskId,
     Expression<String>? title,
@@ -944,9 +1095,11 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     Expression<bool>? isCompleted,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? updatedAt,
+    Expression<DateTime>? deletedAt,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
+      if (uuid != null) 'uuid': uuid,
       if (projectId != null) 'project_id': projectId,
       if (parentTaskId != null) 'parent_task_id': parentTaskId,
       if (title != null) 'title': title,
@@ -960,11 +1113,13 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
       if (isCompleted != null) 'is_completed': isCompleted,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
     });
   }
 
   TaskTableCompanion copyWith({
     Value<int>? id,
+    Value<String>? uuid,
     Value<int>? projectId,
     Value<int?>? parentTaskId,
     Value<String>? title,
@@ -978,9 +1133,11 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     Value<bool>? isCompleted,
     Value<DateTime>? createdAt,
     Value<DateTime>? updatedAt,
+    Value<DateTime?>? deletedAt,
   }) {
     return TaskTableCompanion(
       id: id ?? this.id,
+      uuid: uuid ?? this.uuid,
       projectId: projectId ?? this.projectId,
       parentTaskId: parentTaskId ?? this.parentTaskId,
       title: title ?? this.title,
@@ -994,6 +1151,7 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
       isCompleted: isCompleted ?? this.isCompleted,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
     );
   }
 
@@ -1002,6 +1160,9 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     final map = <String, Expression>{};
     if (id.present) {
       map['id'] = Variable<int>(id.value);
+    }
+    if (uuid.present) {
+      map['uuid'] = Variable<String>(uuid.value);
     }
     if (projectId.present) {
       map['project_id'] = Variable<int>(projectId.value);
@@ -1042,6 +1203,9 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     if (updatedAt.present) {
       map['updated_at'] = Variable<DateTime>(updatedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<DateTime>(deletedAt.value);
+    }
     return map;
   }
 
@@ -1049,6 +1213,7 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
   String toString() {
     return (StringBuffer('TaskTableCompanion(')
           ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
           ..write('projectId: $projectId, ')
           ..write('parentTaskId: $parentTaskId, ')
           ..write('title: $title, ')
@@ -1061,7 +1226,8 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
           ..write('depth: $depth, ')
           ..write('isCompleted: $isCompleted, ')
           ..write('createdAt: $createdAt, ')
-          ..write('updatedAt: $updatedAt')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
@@ -1082,6 +1248,16 @@ class $FocusSessionTableTable extends FocusSessionTable with TableInfo<$FocusSes
     type: DriftSqlType.int,
     requiredDuringInsert: false,
     defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'),
+  );
+  static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
+  @override
+  late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
+    'uuid',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
   );
   static const VerificationMeta _taskIdMeta = const VerificationMeta('taskId');
   @override
@@ -1156,9 +1332,19 @@ class $FocusSessionTableTable extends FocusSessionTable with TableInfo<$FocusSes
     type: DriftSqlType.int,
     requiredDuringInsert: false,
   );
+  static const VerificationMeta _deletedAtMeta = const VerificationMeta('deletedAt');
+  @override
+  late final GeneratedColumn<DateTime> deletedAt = GeneratedColumn<DateTime>(
+    'deleted_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
   @override
   List<GeneratedColumn> get $columns => [
     id,
+    uuid,
     taskId,
     focusDurationMinutes,
     breakDurationMinutes,
@@ -1167,6 +1353,7 @@ class $FocusSessionTableTable extends FocusSessionTable with TableInfo<$FocusSes
     state,
     elapsedSeconds,
     focusPhaseEndedAt,
+    deletedAt,
   ];
   @override
   String get aliasedName => _alias ?? actualTableName;
@@ -1179,6 +1366,11 @@ class $FocusSessionTableTable extends FocusSessionTable with TableInfo<$FocusSes
     final data = instance.toColumns(true);
     if (data.containsKey('id')) {
       context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('uuid')) {
+      context.handle(_uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
+    } else if (isInserting) {
+      context.missing(_uuidMeta);
     }
     if (data.containsKey('task_id')) {
       context.handle(_taskIdMeta, taskId.isAcceptableOrUnknown(data['task_id']!, _taskIdMeta));
@@ -1219,6 +1411,9 @@ class $FocusSessionTableTable extends FocusSessionTable with TableInfo<$FocusSes
         focusPhaseEndedAt.isAcceptableOrUnknown(data['focus_phase_ended_at']!, _focusPhaseEndedAtMeta),
       );
     }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta, deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
@@ -1229,6 +1424,7 @@ class $FocusSessionTableTable extends FocusSessionTable with TableInfo<$FocusSes
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
     return FocusSessionData(
       id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
       taskId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}task_id']),
       focusDurationMinutes: attachedDatabase.typeMapping.read(
         DriftSqlType.int,
@@ -1248,6 +1444,7 @@ class $FocusSessionTableTable extends FocusSessionTable with TableInfo<$FocusSes
         DriftSqlType.int,
         data['${effectivePrefix}focus_phase_ended_at'],
       ),
+      deletedAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -1263,6 +1460,7 @@ class $FocusSessionTableTable extends FocusSessionTable with TableInfo<$FocusSes
 
 class FocusSessionData extends DataClass implements Insertable<FocusSessionData> {
   final int id;
+  final String uuid;
   final int? taskId;
   final int focusDurationMinutes;
   final int breakDurationMinutes;
@@ -1275,8 +1473,10 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
   /// Stored to preserve accurate focus time across app restarts.
   /// Null while focus is still running; set when transitioning to break.
   final int? focusPhaseEndedAt;
+  final DateTime? deletedAt;
   const FocusSessionData({
     required this.id,
+    required this.uuid,
     this.taskId,
     required this.focusDurationMinutes,
     required this.breakDurationMinutes,
@@ -1285,11 +1485,13 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
     required this.state,
     required this.elapsedSeconds,
     this.focusPhaseEndedAt,
+    this.deletedAt,
   });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
+    map['uuid'] = Variable<String>(uuid);
     if (!nullToAbsent || taskId != null) {
       map['task_id'] = Variable<int>(taskId);
     }
@@ -1306,12 +1508,16 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
     if (!nullToAbsent || focusPhaseEndedAt != null) {
       map['focus_phase_ended_at'] = Variable<int>(focusPhaseEndedAt);
     }
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<DateTime>(deletedAt);
+    }
     return map;
   }
 
   FocusSessionTableCompanion toCompanion(bool nullToAbsent) {
     return FocusSessionTableCompanion(
       id: Value(id),
+      uuid: Value(uuid),
       taskId: taskId == null && nullToAbsent ? const Value.absent() : Value(taskId),
       focusDurationMinutes: Value(focusDurationMinutes),
       breakDurationMinutes: Value(breakDurationMinutes),
@@ -1320,6 +1526,7 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
       state: Value(state),
       elapsedSeconds: Value(elapsedSeconds),
       focusPhaseEndedAt: focusPhaseEndedAt == null && nullToAbsent ? const Value.absent() : Value(focusPhaseEndedAt),
+      deletedAt: deletedAt == null && nullToAbsent ? const Value.absent() : Value(deletedAt),
     );
   }
 
@@ -1327,6 +1534,7 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return FocusSessionData(
       id: serializer.fromJson<int>(json['id']),
+      uuid: serializer.fromJson<String>(json['uuid']),
       taskId: serializer.fromJson<int?>(json['taskId']),
       focusDurationMinutes: serializer.fromJson<int>(json['focusDurationMinutes']),
       breakDurationMinutes: serializer.fromJson<int>(json['breakDurationMinutes']),
@@ -1335,6 +1543,7 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
       state: $FocusSessionTableTable.$converterstate.fromJson(serializer.fromJson<int>(json['state'])),
       elapsedSeconds: serializer.fromJson<int>(json['elapsedSeconds']),
       focusPhaseEndedAt: serializer.fromJson<int?>(json['focusPhaseEndedAt']),
+      deletedAt: serializer.fromJson<DateTime?>(json['deletedAt']),
     );
   }
   @override
@@ -1342,6 +1551,7 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
     serializer ??= driftRuntimeOptions.defaultSerializer;
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
+      'uuid': serializer.toJson<String>(uuid),
       'taskId': serializer.toJson<int?>(taskId),
       'focusDurationMinutes': serializer.toJson<int>(focusDurationMinutes),
       'breakDurationMinutes': serializer.toJson<int>(breakDurationMinutes),
@@ -1350,11 +1560,13 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
       'state': serializer.toJson<int>($FocusSessionTableTable.$converterstate.toJson(state)),
       'elapsedSeconds': serializer.toJson<int>(elapsedSeconds),
       'focusPhaseEndedAt': serializer.toJson<int?>(focusPhaseEndedAt),
+      'deletedAt': serializer.toJson<DateTime?>(deletedAt),
     };
   }
 
   FocusSessionData copyWith({
     int? id,
+    String? uuid,
     Value<int?> taskId = const Value.absent(),
     int? focusDurationMinutes,
     int? breakDurationMinutes,
@@ -1363,8 +1575,10 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
     SessionState? state,
     int? elapsedSeconds,
     Value<int?> focusPhaseEndedAt = const Value.absent(),
+    Value<DateTime?> deletedAt = const Value.absent(),
   }) => FocusSessionData(
     id: id ?? this.id,
+    uuid: uuid ?? this.uuid,
     taskId: taskId.present ? taskId.value : this.taskId,
     focusDurationMinutes: focusDurationMinutes ?? this.focusDurationMinutes,
     breakDurationMinutes: breakDurationMinutes ?? this.breakDurationMinutes,
@@ -1373,10 +1587,12 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
     state: state ?? this.state,
     elapsedSeconds: elapsedSeconds ?? this.elapsedSeconds,
     focusPhaseEndedAt: focusPhaseEndedAt.present ? focusPhaseEndedAt.value : this.focusPhaseEndedAt,
+    deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
   );
   FocusSessionData copyWithCompanion(FocusSessionTableCompanion data) {
     return FocusSessionData(
       id: data.id.present ? data.id.value : this.id,
+      uuid: data.uuid.present ? data.uuid.value : this.uuid,
       taskId: data.taskId.present ? data.taskId.value : this.taskId,
       focusDurationMinutes: data.focusDurationMinutes.present
           ? data.focusDurationMinutes.value
@@ -1389,6 +1605,7 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
       state: data.state.present ? data.state.value : this.state,
       elapsedSeconds: data.elapsedSeconds.present ? data.elapsedSeconds.value : this.elapsedSeconds,
       focusPhaseEndedAt: data.focusPhaseEndedAt.present ? data.focusPhaseEndedAt.value : this.focusPhaseEndedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
@@ -1396,6 +1613,7 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
   String toString() {
     return (StringBuffer('FocusSessionData(')
           ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
           ..write('taskId: $taskId, ')
           ..write('focusDurationMinutes: $focusDurationMinutes, ')
           ..write('breakDurationMinutes: $breakDurationMinutes, ')
@@ -1403,7 +1621,8 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
           ..write('endTime: $endTime, ')
           ..write('state: $state, ')
           ..write('elapsedSeconds: $elapsedSeconds, ')
-          ..write('focusPhaseEndedAt: $focusPhaseEndedAt')
+          ..write('focusPhaseEndedAt: $focusPhaseEndedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
@@ -1411,6 +1630,7 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
   @override
   int get hashCode => Object.hash(
     id,
+    uuid,
     taskId,
     focusDurationMinutes,
     breakDurationMinutes,
@@ -1419,12 +1639,14 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
     state,
     elapsedSeconds,
     focusPhaseEndedAt,
+    deletedAt,
   );
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is FocusSessionData &&
           other.id == this.id &&
+          other.uuid == this.uuid &&
           other.taskId == this.taskId &&
           other.focusDurationMinutes == this.focusDurationMinutes &&
           other.breakDurationMinutes == this.breakDurationMinutes &&
@@ -1432,11 +1654,13 @@ class FocusSessionData extends DataClass implements Insertable<FocusSessionData>
           other.endTime == this.endTime &&
           other.state == this.state &&
           other.elapsedSeconds == this.elapsedSeconds &&
-          other.focusPhaseEndedAt == this.focusPhaseEndedAt);
+          other.focusPhaseEndedAt == this.focusPhaseEndedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
 class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
   final Value<int> id;
+  final Value<String> uuid;
   final Value<int?> taskId;
   final Value<int> focusDurationMinutes;
   final Value<int> breakDurationMinutes;
@@ -1445,8 +1669,10 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
   final Value<SessionState> state;
   final Value<int> elapsedSeconds;
   final Value<int?> focusPhaseEndedAt;
+  final Value<DateTime?> deletedAt;
   const FocusSessionTableCompanion({
     this.id = const Value.absent(),
+    this.uuid = const Value.absent(),
     this.taskId = const Value.absent(),
     this.focusDurationMinutes = const Value.absent(),
     this.breakDurationMinutes = const Value.absent(),
@@ -1455,9 +1681,11 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
     this.state = const Value.absent(),
     this.elapsedSeconds = const Value.absent(),
     this.focusPhaseEndedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
   });
   FocusSessionTableCompanion.insert({
     this.id = const Value.absent(),
+    required String uuid,
     this.taskId = const Value.absent(),
     required int focusDurationMinutes,
     required int breakDurationMinutes,
@@ -1466,12 +1694,15 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
     required SessionState state,
     this.elapsedSeconds = const Value.absent(),
     this.focusPhaseEndedAt = const Value.absent(),
-  }) : focusDurationMinutes = Value(focusDurationMinutes),
+    this.deletedAt = const Value.absent(),
+  }) : uuid = Value(uuid),
+       focusDurationMinutes = Value(focusDurationMinutes),
        breakDurationMinutes = Value(breakDurationMinutes),
        startTime = Value(startTime),
        state = Value(state);
   static Insertable<FocusSessionData> custom({
     Expression<int>? id,
+    Expression<String>? uuid,
     Expression<int>? taskId,
     Expression<int>? focusDurationMinutes,
     Expression<int>? breakDurationMinutes,
@@ -1480,9 +1711,11 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
     Expression<int>? state,
     Expression<int>? elapsedSeconds,
     Expression<int>? focusPhaseEndedAt,
+    Expression<DateTime>? deletedAt,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
+      if (uuid != null) 'uuid': uuid,
       if (taskId != null) 'task_id': taskId,
       if (focusDurationMinutes != null) 'focus_duration_minutes': focusDurationMinutes,
       if (breakDurationMinutes != null) 'break_duration_minutes': breakDurationMinutes,
@@ -1491,11 +1724,13 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
       if (state != null) 'state': state,
       if (elapsedSeconds != null) 'elapsed_seconds': elapsedSeconds,
       if (focusPhaseEndedAt != null) 'focus_phase_ended_at': focusPhaseEndedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
     });
   }
 
   FocusSessionTableCompanion copyWith({
     Value<int>? id,
+    Value<String>? uuid,
     Value<int?>? taskId,
     Value<int>? focusDurationMinutes,
     Value<int>? breakDurationMinutes,
@@ -1504,9 +1739,11 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
     Value<SessionState>? state,
     Value<int>? elapsedSeconds,
     Value<int?>? focusPhaseEndedAt,
+    Value<DateTime?>? deletedAt,
   }) {
     return FocusSessionTableCompanion(
       id: id ?? this.id,
+      uuid: uuid ?? this.uuid,
       taskId: taskId ?? this.taskId,
       focusDurationMinutes: focusDurationMinutes ?? this.focusDurationMinutes,
       breakDurationMinutes: breakDurationMinutes ?? this.breakDurationMinutes,
@@ -1515,6 +1752,7 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
       state: state ?? this.state,
       elapsedSeconds: elapsedSeconds ?? this.elapsedSeconds,
       focusPhaseEndedAt: focusPhaseEndedAt ?? this.focusPhaseEndedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
     );
   }
 
@@ -1523,6 +1761,9 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
     final map = <String, Expression>{};
     if (id.present) {
       map['id'] = Variable<int>(id.value);
+    }
+    if (uuid.present) {
+      map['uuid'] = Variable<String>(uuid.value);
     }
     if (taskId.present) {
       map['task_id'] = Variable<int>(taskId.value);
@@ -1548,6 +1789,9 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
     if (focusPhaseEndedAt.present) {
       map['focus_phase_ended_at'] = Variable<int>(focusPhaseEndedAt.value);
     }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<DateTime>(deletedAt.value);
+    }
     return map;
   }
 
@@ -1555,6 +1799,7 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
   String toString() {
     return (StringBuffer('FocusSessionTableCompanion(')
           ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
           ..write('taskId: $taskId, ')
           ..write('focusDurationMinutes: $focusDurationMinutes, ')
           ..write('breakDurationMinutes: $breakDurationMinutes, ')
@@ -1562,7 +1807,8 @@ class FocusSessionTableCompanion extends UpdateCompanion<FocusSessionData> {
           ..write('endTime: $endTime, ')
           ..write('state: $state, ')
           ..write('elapsedSeconds: $elapsedSeconds, ')
-          ..write('focusPhaseEndedAt: $focusPhaseEndedAt')
+          ..write('focusPhaseEndedAt: $focusPhaseEndedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
@@ -2630,6 +2876,14 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'project_updated_at_idx',
     'CREATE INDEX project_updated_at_idx ON project_table (updated_at)',
   );
+  late final Index projectUuidIdx = Index(
+    'project_uuid_idx',
+    'CREATE UNIQUE INDEX project_uuid_idx ON project_table (uuid)',
+  );
+  late final Index projectDeletedAtIdx = Index(
+    'project_deleted_at_idx',
+    'CREATE INDEX project_deleted_at_idx ON project_table (deleted_at)',
+  );
   late final Index taskProjectIdIdx = Index(
     'task_project_id_idx',
     'CREATE INDEX task_project_id_idx ON task_table (project_id)',
@@ -2654,6 +2908,11 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'task_updated_at_idx',
     'CREATE INDEX task_updated_at_idx ON task_table (updated_at)',
   );
+  late final Index taskUuidIdx = Index('task_uuid_idx', 'CREATE UNIQUE INDEX task_uuid_idx ON task_table (uuid)');
+  late final Index taskDeletedAtIdx = Index(
+    'task_deleted_at_idx',
+    'CREATE INDEX task_deleted_at_idx ON task_table (deleted_at)',
+  );
   late final Index focusSessionTaskIdIdx = Index(
     'focus_session_task_id_idx',
     'CREATE INDEX focus_session_task_id_idx ON focus_session_table (task_id)',
@@ -2661,6 +2920,14 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final Index focusSessionStartTimeIdx = Index(
     'focus_session_start_time_idx',
     'CREATE INDEX focus_session_start_time_idx ON focus_session_table (start_time)',
+  );
+  late final Index focusSessionUuidIdx = Index(
+    'focus_session_uuid_idx',
+    'CREATE UNIQUE INDEX focus_session_uuid_idx ON focus_session_table (uuid)',
+  );
+  late final Index focusSessionDeletedAtIdx = Index(
+    'focus_session_deleted_at_idx',
+    'CREATE INDEX focus_session_deleted_at_idx ON focus_session_table (deleted_at)',
   );
   late final Index dailyStatsDateIdx = Index(
     'daily_stats_date_idx',
@@ -2690,14 +2957,20 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     notificationInboxTable,
     projectCreatedAtIdx,
     projectUpdatedAtIdx,
+    projectUuidIdx,
+    projectDeletedAtIdx,
     taskProjectIdIdx,
     taskParentIdIdx,
     taskPriorityIdx,
     taskDeadlineIdx,
     taskCompletedIdx,
     taskUpdatedAtIdx,
+    taskUuidIdx,
+    taskDeletedAtIdx,
     focusSessionTaskIdIdx,
     focusSessionStartTimeIdx,
+    focusSessionUuidIdx,
+    focusSessionDeletedAtIdx,
     dailyStatsDateIdx,
     notificationInboxNotificationIdIdx,
     notificationInboxUpdatedAtIdx,
@@ -2723,22 +2996,26 @@ abstract class _$AppDatabase extends GeneratedDatabase {
 typedef $$ProjectTableTableCreateCompanionBuilder =
     ProjectTableCompanion Function({
       Value<int> id,
+      required String uuid,
       required String title,
       Value<String?> description,
       Value<DateTime?> startDate,
       Value<DateTime?> deadline,
       required DateTime createdAt,
       required DateTime updatedAt,
+      Value<DateTime?> deletedAt,
     });
 typedef $$ProjectTableTableUpdateCompanionBuilder =
     ProjectTableCompanion Function({
       Value<int> id,
+      Value<String> uuid,
       Value<String> title,
       Value<String?> description,
       Value<DateTime?> startDate,
       Value<DateTime?> deadline,
       Value<DateTime> createdAt,
       Value<DateTime> updatedAt,
+      Value<DateTime?> deletedAt,
     });
 
 final class $$ProjectTableTableReferences extends BaseReferences<_$AppDatabase, $ProjectTableTable, ProjectTableData> {
@@ -2768,6 +3045,8 @@ class $$ProjectTableTableFilterComposer extends Composer<_$AppDatabase, $Project
   });
   ColumnFilters<int> get id => $composableBuilder(column: $table.id, builder: (column) => ColumnFilters(column));
 
+  ColumnFilters<String> get uuid => $composableBuilder(column: $table.uuid, builder: (column) => ColumnFilters(column));
+
   ColumnFilters<String> get title =>
       $composableBuilder(column: $table.title, builder: (column) => ColumnFilters(column));
 
@@ -2785,6 +3064,9 @@ class $$ProjectTableTableFilterComposer extends Composer<_$AppDatabase, $Project
 
   ColumnFilters<DateTime> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 
   Expression<bool> taskTableRefs(Expression<bool> Function($$TaskTableTableFilterComposer f) f) {
     final $$TaskTableTableFilterComposer composer = $composerBuilder(
@@ -2815,6 +3097,9 @@ class $$ProjectTableTableOrderingComposer extends Composer<_$AppDatabase, $Proje
   });
   ColumnOrderings<int> get id => $composableBuilder(column: $table.id, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get uuid =>
+      $composableBuilder(column: $table.uuid, builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<String> get title =>
       $composableBuilder(column: $table.title, builder: (column) => ColumnOrderings(column));
 
@@ -2832,6 +3117,9 @@ class $$ProjectTableTableOrderingComposer extends Composer<_$AppDatabase, $Proje
 
   ColumnOrderings<DateTime> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
 }
 
 class $$ProjectTableTableAnnotationComposer extends Composer<_$AppDatabase, $ProjectTableTable> {
@@ -2843,6 +3131,8 @@ class $$ProjectTableTableAnnotationComposer extends Composer<_$AppDatabase, $Pro
     super.$removeJoinBuilderFromRootComposer,
   });
   GeneratedColumn<int> get id => $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get uuid => $composableBuilder(column: $table.uuid, builder: (column) => column);
 
   GeneratedColumn<String> get title => $composableBuilder(column: $table.title, builder: (column) => column);
 
@@ -2856,6 +3146,8 @@ class $$ProjectTableTableAnnotationComposer extends Composer<_$AppDatabase, $Pro
   GeneratedColumn<DateTime> get createdAt => $composableBuilder(column: $table.createdAt, builder: (column) => column);
 
   GeneratedColumn<DateTime> get updatedAt => $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get deletedAt => $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 
   Expression<T> taskTableRefs<T extends Object>(Expression<T> Function($$TaskTableTableAnnotationComposer a) f) {
     final $$TaskTableTableAnnotationComposer composer = $composerBuilder(
@@ -2902,38 +3194,46 @@ class $$ProjectTableTableTableManager
           updateCompanionCallback:
               ({
                 Value<int> id = const Value.absent(),
+                Value<String> uuid = const Value.absent(),
                 Value<String> title = const Value.absent(),
                 Value<String?> description = const Value.absent(),
                 Value<DateTime?> startDate = const Value.absent(),
                 Value<DateTime?> deadline = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
+                Value<DateTime?> deletedAt = const Value.absent(),
               }) => ProjectTableCompanion(
                 id: id,
+                uuid: uuid,
                 title: title,
                 description: description,
                 startDate: startDate,
                 deadline: deadline,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
+                deletedAt: deletedAt,
               ),
           createCompanionCallback:
               ({
                 Value<int> id = const Value.absent(),
+                required String uuid,
                 required String title,
                 Value<String?> description = const Value.absent(),
                 Value<DateTime?> startDate = const Value.absent(),
                 Value<DateTime?> deadline = const Value.absent(),
                 required DateTime createdAt,
                 required DateTime updatedAt,
+                Value<DateTime?> deletedAt = const Value.absent(),
               }) => ProjectTableCompanion.insert(
                 id: id,
+                uuid: uuid,
                 title: title,
                 description: description,
                 startDate: startDate,
                 deadline: deadline,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
+                deletedAt: deletedAt,
               ),
           withReferenceMapper: (p0) =>
               p0.map((e) => (e.readTable(table), $$ProjectTableTableReferences(db, table, e))).toList(),
@@ -2978,6 +3278,7 @@ typedef $$ProjectTableTableProcessedTableManager =
 typedef $$TaskTableTableCreateCompanionBuilder =
     TaskTableCompanion Function({
       Value<int> id,
+      required String uuid,
       required int projectId,
       Value<int?> parentTaskId,
       required String title,
@@ -2991,10 +3292,12 @@ typedef $$TaskTableTableCreateCompanionBuilder =
       Value<bool> isCompleted,
       required DateTime createdAt,
       required DateTime updatedAt,
+      Value<DateTime?> deletedAt,
     });
 typedef $$TaskTableTableUpdateCompanionBuilder =
     TaskTableCompanion Function({
       Value<int> id,
+      Value<String> uuid,
       Value<int> projectId,
       Value<int?> parentTaskId,
       Value<String> title,
@@ -3008,6 +3311,7 @@ typedef $$TaskTableTableUpdateCompanionBuilder =
       Value<bool> isCompleted,
       Value<DateTime> createdAt,
       Value<DateTime> updatedAt,
+      Value<DateTime?> deletedAt,
     });
 
 final class $$TaskTableTableReferences extends BaseReferences<_$AppDatabase, $TaskTableTable, TaskTableData> {
@@ -3062,6 +3366,8 @@ class $$TaskTableTableFilterComposer extends Composer<_$AppDatabase, $TaskTableT
   });
   ColumnFilters<int> get id => $composableBuilder(column: $table.id, builder: (column) => ColumnFilters(column));
 
+  ColumnFilters<String> get uuid => $composableBuilder(column: $table.uuid, builder: (column) => ColumnFilters(column));
+
   ColumnFilters<String> get title =>
       $composableBuilder(column: $table.title, builder: (column) => ColumnFilters(column));
 
@@ -3093,6 +3399,9 @@ class $$TaskTableTableFilterComposer extends Composer<_$AppDatabase, $TaskTableT
 
   ColumnFilters<DateTime> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 
   $$ProjectTableTableFilterComposer get projectId {
     final $$ProjectTableTableFilterComposer composer = $composerBuilder(
@@ -3159,6 +3468,9 @@ class $$TaskTableTableOrderingComposer extends Composer<_$AppDatabase, $TaskTabl
   });
   ColumnOrderings<int> get id => $composableBuilder(column: $table.id, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get uuid =>
+      $composableBuilder(column: $table.uuid, builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<String> get title =>
       $composableBuilder(column: $table.title, builder: (column) => ColumnOrderings(column));
 
@@ -3191,6 +3503,9 @@ class $$TaskTableTableOrderingComposer extends Composer<_$AppDatabase, $TaskTabl
 
   ColumnOrderings<DateTime> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
 
   $$ProjectTableTableOrderingComposer get projectId {
     final $$ProjectTableTableOrderingComposer composer = $composerBuilder(
@@ -3239,6 +3554,8 @@ class $$TaskTableTableAnnotationComposer extends Composer<_$AppDatabase, $TaskTa
   });
   GeneratedColumn<int> get id => $composableBuilder(column: $table.id, builder: (column) => column);
 
+  GeneratedColumn<String> get uuid => $composableBuilder(column: $table.uuid, builder: (column) => column);
+
   GeneratedColumn<String> get title => $composableBuilder(column: $table.title, builder: (column) => column);
 
   GeneratedColumn<String> get description =>
@@ -3264,6 +3581,8 @@ class $$TaskTableTableAnnotationComposer extends Composer<_$AppDatabase, $TaskTa
   GeneratedColumn<DateTime> get createdAt => $composableBuilder(column: $table.createdAt, builder: (column) => column);
 
   GeneratedColumn<DateTime> get updatedAt => $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get deletedAt => $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 
   $$ProjectTableTableAnnotationComposer get projectId {
     final $$ProjectTableTableAnnotationComposer composer = $composerBuilder(
@@ -3348,6 +3667,7 @@ class $$TaskTableTableTableManager
           updateCompanionCallback:
               ({
                 Value<int> id = const Value.absent(),
+                Value<String> uuid = const Value.absent(),
                 Value<int> projectId = const Value.absent(),
                 Value<int?> parentTaskId = const Value.absent(),
                 Value<String> title = const Value.absent(),
@@ -3361,8 +3681,10 @@ class $$TaskTableTableTableManager
                 Value<bool> isCompleted = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
+                Value<DateTime?> deletedAt = const Value.absent(),
               }) => TaskTableCompanion(
                 id: id,
+                uuid: uuid,
                 projectId: projectId,
                 parentTaskId: parentTaskId,
                 title: title,
@@ -3376,10 +3698,12 @@ class $$TaskTableTableTableManager
                 isCompleted: isCompleted,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
+                deletedAt: deletedAt,
               ),
           createCompanionCallback:
               ({
                 Value<int> id = const Value.absent(),
+                required String uuid,
                 required int projectId,
                 Value<int?> parentTaskId = const Value.absent(),
                 required String title,
@@ -3393,8 +3717,10 @@ class $$TaskTableTableTableManager
                 Value<bool> isCompleted = const Value.absent(),
                 required DateTime createdAt,
                 required DateTime updatedAt,
+                Value<DateTime?> deletedAt = const Value.absent(),
               }) => TaskTableCompanion.insert(
                 id: id,
+                uuid: uuid,
                 projectId: projectId,
                 parentTaskId: parentTaskId,
                 title: title,
@@ -3408,6 +3734,7 @@ class $$TaskTableTableTableManager
                 isCompleted: isCompleted,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
+                deletedAt: deletedAt,
               ),
           withReferenceMapper: (p0) =>
               p0.map((e) => (e.readTable(table), $$TaskTableTableReferences(db, table, e))).toList(),
@@ -3490,6 +3817,7 @@ typedef $$TaskTableTableProcessedTableManager =
 typedef $$FocusSessionTableTableCreateCompanionBuilder =
     FocusSessionTableCompanion Function({
       Value<int> id,
+      required String uuid,
       Value<int?> taskId,
       required int focusDurationMinutes,
       required int breakDurationMinutes,
@@ -3498,10 +3826,12 @@ typedef $$FocusSessionTableTableCreateCompanionBuilder =
       required SessionState state,
       Value<int> elapsedSeconds,
       Value<int?> focusPhaseEndedAt,
+      Value<DateTime?> deletedAt,
     });
 typedef $$FocusSessionTableTableUpdateCompanionBuilder =
     FocusSessionTableCompanion Function({
       Value<int> id,
+      Value<String> uuid,
       Value<int?> taskId,
       Value<int> focusDurationMinutes,
       Value<int> breakDurationMinutes,
@@ -3510,6 +3840,7 @@ typedef $$FocusSessionTableTableUpdateCompanionBuilder =
       Value<SessionState> state,
       Value<int> elapsedSeconds,
       Value<int?> focusPhaseEndedAt,
+      Value<DateTime?> deletedAt,
     });
 
 final class $$FocusSessionTableTableReferences
@@ -3539,6 +3870,8 @@ class $$FocusSessionTableTableFilterComposer extends Composer<_$AppDatabase, $Fo
   });
   ColumnFilters<int> get id => $composableBuilder(column: $table.id, builder: (column) => ColumnFilters(column));
 
+  ColumnFilters<String> get uuid => $composableBuilder(column: $table.uuid, builder: (column) => ColumnFilters(column));
+
   ColumnFilters<int> get focusDurationMinutes =>
       $composableBuilder(column: $table.focusDurationMinutes, builder: (column) => ColumnFilters(column));
 
@@ -3559,6 +3892,9 @@ class $$FocusSessionTableTableFilterComposer extends Composer<_$AppDatabase, $Fo
 
   ColumnFilters<int> get focusPhaseEndedAt =>
       $composableBuilder(column: $table.focusPhaseEndedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => ColumnFilters(column));
 
   $$TaskTableTableFilterComposer get taskId {
     final $$TaskTableTableFilterComposer composer = $composerBuilder(
@@ -3589,6 +3925,9 @@ class $$FocusSessionTableTableOrderingComposer extends Composer<_$AppDatabase, $
   });
   ColumnOrderings<int> get id => $composableBuilder(column: $table.id, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get uuid =>
+      $composableBuilder(column: $table.uuid, builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<int> get focusDurationMinutes =>
       $composableBuilder(column: $table.focusDurationMinutes, builder: (column) => ColumnOrderings(column));
 
@@ -3609,6 +3948,9 @@ class $$FocusSessionTableTableOrderingComposer extends Composer<_$AppDatabase, $
 
   ColumnOrderings<int> get focusPhaseEndedAt =>
       $composableBuilder(column: $table.focusPhaseEndedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
 
   $$TaskTableTableOrderingComposer get taskId {
     final $$TaskTableTableOrderingComposer composer = $composerBuilder(
@@ -3639,6 +3981,8 @@ class $$FocusSessionTableTableAnnotationComposer extends Composer<_$AppDatabase,
   });
   GeneratedColumn<int> get id => $composableBuilder(column: $table.id, builder: (column) => column);
 
+  GeneratedColumn<String> get uuid => $composableBuilder(column: $table.uuid, builder: (column) => column);
+
   GeneratedColumn<int> get focusDurationMinutes =>
       $composableBuilder(column: $table.focusDurationMinutes, builder: (column) => column);
 
@@ -3657,6 +4001,8 @@ class $$FocusSessionTableTableAnnotationComposer extends Composer<_$AppDatabase,
 
   GeneratedColumn<int> get focusPhaseEndedAt =>
       $composableBuilder(column: $table.focusPhaseEndedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get deletedAt => $composableBuilder(column: $table.deletedAt, builder: (column) => column);
 
   $$TaskTableTableAnnotationComposer get taskId {
     final $$TaskTableTableAnnotationComposer composer = $composerBuilder(
@@ -3703,6 +4049,7 @@ class $$FocusSessionTableTableTableManager
           updateCompanionCallback:
               ({
                 Value<int> id = const Value.absent(),
+                Value<String> uuid = const Value.absent(),
                 Value<int?> taskId = const Value.absent(),
                 Value<int> focusDurationMinutes = const Value.absent(),
                 Value<int> breakDurationMinutes = const Value.absent(),
@@ -3711,8 +4058,10 @@ class $$FocusSessionTableTableTableManager
                 Value<SessionState> state = const Value.absent(),
                 Value<int> elapsedSeconds = const Value.absent(),
                 Value<int?> focusPhaseEndedAt = const Value.absent(),
+                Value<DateTime?> deletedAt = const Value.absent(),
               }) => FocusSessionTableCompanion(
                 id: id,
+                uuid: uuid,
                 taskId: taskId,
                 focusDurationMinutes: focusDurationMinutes,
                 breakDurationMinutes: breakDurationMinutes,
@@ -3721,10 +4070,12 @@ class $$FocusSessionTableTableTableManager
                 state: state,
                 elapsedSeconds: elapsedSeconds,
                 focusPhaseEndedAt: focusPhaseEndedAt,
+                deletedAt: deletedAt,
               ),
           createCompanionCallback:
               ({
                 Value<int> id = const Value.absent(),
+                required String uuid,
                 Value<int?> taskId = const Value.absent(),
                 required int focusDurationMinutes,
                 required int breakDurationMinutes,
@@ -3733,8 +4084,10 @@ class $$FocusSessionTableTableTableManager
                 required SessionState state,
                 Value<int> elapsedSeconds = const Value.absent(),
                 Value<int?> focusPhaseEndedAt = const Value.absent(),
+                Value<DateTime?> deletedAt = const Value.absent(),
               }) => FocusSessionTableCompanion.insert(
                 id: id,
+                uuid: uuid,
                 taskId: taskId,
                 focusDurationMinutes: focusDurationMinutes,
                 breakDurationMinutes: breakDurationMinutes,
@@ -3743,6 +4096,7 @@ class $$FocusSessionTableTableTableManager
                 state: state,
                 elapsedSeconds: elapsedSeconds,
                 focusPhaseEndedAt: focusPhaseEndedAt,
+                deletedAt: deletedAt,
               ),
           withReferenceMapper: (p0) =>
               p0.map((e) => (e.readTable(table), $$FocusSessionTableTableReferences(db, table, e))).toList(),

--- a/lib/core/utils/id_utils.dart
+++ b/lib/core/utils/id_utils.dart
@@ -1,0 +1,6 @@
+import 'package:uuid/uuid.dart';
+
+const _uuid = Uuid();
+
+/// Generates a random UUID v4 string for sync identity and device provenance.
+String generateUuid() => _uuid.v4();

--- a/lib/features/projects/data/datasources/project_local_datasource.dart
+++ b/lib/features/projects/data/datasources/project_local_datasource.dart
@@ -34,12 +34,12 @@ class ProjectLocalDataSourceImpl implements IProjectLocalDataSource {
 
   @override
   Future<List<ProjectTableData>> getAllProjects() async {
-    return await _db.select(_db.projectTable).get();
+    return await (_db.select(_db.projectTable)..where((t) => t.deletedAt.isNull())).get();
   }
 
   @override
   Future<ProjectTableData?> getProjectById(int id) async {
-    final query = _db.select(_db.projectTable)..where((t) => t.id.equals(id));
+    final query = _db.select(_db.projectTable)..where((t) => t.id.equals(id) & t.deletedAt.isNull());
     return await query.getSingleOrNull();
   }
 
@@ -65,10 +65,32 @@ class ProjectLocalDataSourceImpl implements IProjectLocalDataSource {
 
   @override
   Future<void> deleteProject(int id) async {
-    // ON DELETE CASCADE on TaskTable.projectId propagates the delete to all
-    // tasks (and transitively to their focus sessions). A single statement suffices.
+    // Soft-delete: ON DELETE CASCADE no longer applies, so tombstone the project,
+    // all of its tasks, and their focus sessions in one transaction.
     try {
-      await (_db.delete(_db.projectTable)..where((t) => t.id.equals(id))).go();
+      await _db.transaction(() async {
+        final now = DateTime.now();
+        final taskIds =
+            await (_db.selectOnly(_db.taskTable)
+                  ..addColumns([_db.taskTable.id])
+                  ..where(_db.taskTable.projectId.equals(id) & _db.taskTable.deletedAt.isNull()))
+                .map((row) => row.read(_db.taskTable.id)!)
+                .get();
+
+        if (taskIds.isNotEmpty) {
+          await (_db.update(_db.focusSessionTable)..where((t) => t.taskId.isIn(taskIds) & t.deletedAt.isNull())).write(
+            FocusSessionTableCompanion(deletedAt: Value(now)),
+          );
+
+          await (_db.update(_db.taskTable)..where((t) => t.projectId.equals(id) & t.deletedAt.isNull())).write(
+            TaskTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
+          );
+        }
+
+        await (_db.update(_db.projectTable)..where((t) => t.id.equals(id) & t.deletedAt.isNull())).write(
+          ProjectTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
+        );
+      });
     } catch (e, st) {
       _log.error('deleteProject failed', tag: 'ProjectLocalDS', error: e, stackTrace: st);
       rethrow;
@@ -77,12 +99,12 @@ class ProjectLocalDataSourceImpl implements IProjectLocalDataSource {
 
   @override
   Stream<ProjectTableData?> watchProjectById(int id) {
-    return (_db.select(_db.projectTable)..where((t) => t.id.equals(id))).watchSingleOrNull();
+    return (_db.select(_db.projectTable)..where((t) => t.id.equals(id) & t.deletedAt.isNull())).watchSingleOrNull();
   }
 
   @override
   Stream<List<ProjectTableData>> watchAllProjects() {
-    return _db.select(_db.projectTable).watch();
+    return (_db.select(_db.projectTable)..where((t) => t.deletedAt.isNull())).watch();
   }
 
   @override
@@ -91,7 +113,7 @@ class ProjectLocalDataSourceImpl implements IProjectLocalDataSource {
     ProjectSortCriteria sortCriteria = ProjectSortCriteria.recentlyModified,
     ProjectSortOrder sortOrder = ProjectSortOrder.none,
   }) {
-    final query = _db.select(_db.projectTable);
+    final query = _db.select(_db.projectTable)..where((t) => t.deletedAt.isNull());
 
     final q = searchQuery.trim().toLowerCase();
     if (q.isNotEmpty) {

--- a/lib/features/projects/data/mappers/project_extensions.dart
+++ b/lib/features/projects/data/mappers/project_extensions.dart
@@ -6,12 +6,14 @@ import '../../domain/entities/project.dart';
 extension DbProjectToDomain on ProjectTableData {
   Project toDomain() => Project(
     id: id,
+    uuid: uuid,
     title: title,
     description: description,
     startDate: startDate,
     deadline: deadline,
     createdAt: createdAt,
     updatedAt: updatedAt,
+    deletedAt: deletedAt,
   );
 }
 
@@ -20,21 +22,25 @@ extension DomainProjectToCompanion on Project {
     if (id != null) {
       return ProjectTableCompanion(
         id: Value(id!),
+        uuid: Value(uuid),
         title: Value(title),
         description: Value(description),
         startDate: Value(startDate),
         deadline: Value(deadline),
         createdAt: Value(createdAt),
         updatedAt: Value(updatedAt),
+        deletedAt: Value(deletedAt),
       );
     }
     return ProjectTableCompanion.insert(
+      uuid: uuid,
       title: title,
       description: Value<String?>(description),
       startDate: Value<DateTime?>(startDate),
       deadline: Value<DateTime?>(deadline),
       createdAt: createdAt,
       updatedAt: updatedAt,
+      deletedAt: Value<DateTime?>(deletedAt),
     );
   }
 }

--- a/lib/features/projects/data/models/project_model.dart
+++ b/lib/features/projects/data/models/project_model.dart
@@ -2,8 +2,12 @@ import 'package:drift/drift.dart';
 
 @TableIndex(name: 'project_created_at_idx', columns: {#createdAt})
 @TableIndex(name: 'project_updated_at_idx', columns: {#updatedAt})
+@TableIndex(name: 'project_uuid_idx', columns: {#uuid}, unique: true)
+@TableIndex(name: 'project_deleted_at_idx', columns: {#deletedAt})
 class ProjectTable extends Table {
   IntColumn get id => integer().autoIncrement()();
+
+  TextColumn get uuid => text().unique()();
 
   TextColumn get title => text()();
 
@@ -16,4 +20,6 @@ class ProjectTable extends Table {
   DateTimeColumn get createdAt => dateTime()();
 
   DateTimeColumn get updatedAt => dateTime()();
+
+  DateTimeColumn get deletedAt => dateTime().nullable()();
 }

--- a/lib/features/projects/domain/entities/project.dart
+++ b/lib/features/projects/domain/entities/project.dart
@@ -5,23 +5,27 @@ import 'package:meta/meta.dart';
 @immutable
 class Project extends Equatable {
   final int? id;
+  final String uuid;
   final String title;
   final String? description;
   final DateTime? startDate;
   final DateTime? deadline;
   final DateTime createdAt;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const Project({
     this.id,
+    required this.uuid,
     required this.title,
     this.description,
     this.startDate,
     this.deadline,
     required this.createdAt,
     required this.updatedAt,
+    this.deletedAt,
   });
 
   @override
-  List<Object?> get props => [id, title, description, startDate, deadline, createdAt, updatedAt];
+  List<Object?> get props => [id, uuid, title, description, startDate, deadline, createdAt, updatedAt, deletedAt];
 }

--- a/lib/features/projects/domain/entities/project_extensions.dart
+++ b/lib/features/projects/domain/entities/project_extensions.dart
@@ -13,21 +13,25 @@ class _ProjectCopyWithUnset {
 extension ProjectCopyWith on Project {
   Project copyWith({
     Object? id = _projectCopyWithUnset,
+    String? uuid,
     String? title,
     Object? description = _projectCopyWithUnset,
     Object? startDate = _projectCopyWithUnset,
     Object? deadline = _projectCopyWithUnset,
     DateTime? createdAt,
     DateTime? updatedAt,
+    Object? deletedAt = _projectCopyWithUnset,
   }) {
     return Project(
       id: id == _projectCopyWithUnset ? this.id : id as int?,
+      uuid: uuid ?? this.uuid,
       title: title ?? this.title,
       description: description == _projectCopyWithUnset ? this.description : description as String?,
       startDate: startDate == _projectCopyWithUnset ? this.startDate : startDate as DateTime?,
       deadline: deadline == _projectCopyWithUnset ? this.deadline : deadline as DateTime?,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt == _projectCopyWithUnset ? this.deletedAt : deletedAt as DateTime?,
     );
   }
 }

--- a/lib/features/projects/domain/services/project_service.dart
+++ b/lib/features/projects/domain/services/project_service.dart
@@ -1,4 +1,5 @@
 import '../../../../core/services/log_service.dart';
+import '../../../../core/utils/id_utils.dart';
 import '../../../../core/utils/result.dart';
 import '../entities/project.dart';
 import '../entities/project_extensions.dart';
@@ -48,6 +49,7 @@ class ProjectService {
     try {
       final now = DateTime.now();
       final project = Project(
+        uuid: generateUuid(),
         title: title,
         description: description,
         startDate: startDate,
@@ -75,10 +77,12 @@ class ProjectService {
     }
   }
 
+  /// Soft-deletes the project and transactionally cascades to its tasks and
+  /// focus sessions (hard FK cascade no longer applies with soft deletes).
   Future<Result<void>> deleteProject(int id) async {
     try {
       await _repository.deleteProject(id);
-      _log.info('Project $id deleted', tag: 'ProjectService');
+      _log.info('Project $id soft-deleted (cascaded to tasks/sessions)', tag: 'ProjectService');
       return const Success(null);
     } catch (e, st) {
       _log.error('Failed to delete project $id', tag: 'ProjectService', error: e, stackTrace: st);

--- a/lib/features/session/data/datasources/focus_local_datasource.dart
+++ b/lib/features/session/data/datasources/focus_local_datasource.dart
@@ -1,3 +1,5 @@
+import 'package:drift/drift.dart';
+
 import '../../../../core/services/db_service.dart';
 import '../../../../core/services/log_service.dart';
 import '../../domain/entities/session_state.dart';
@@ -28,13 +30,15 @@ class FocusLocalDataSourceImpl implements IFocusLocalDataSource {
 
   @override
   Future<List<FocusSessionData>> getAllSessions() async {
-    return await _db.select(_db.focusSessionTable).get();
+    return await (_db.select(_db.focusSessionTable)..where((t) => t.deletedAt.isNull())).get();
   }
 
   @override
   Future<FocusSessionData?> getSessionById(int id) async {
     try {
-      return await (_db.select(_db.focusSessionTable)..where((t) => t.id.equals(id))).getSingleOrNull();
+      return await (_db.select(
+        _db.focusSessionTable,
+      )..where((t) => t.id.equals(id) & t.deletedAt.isNull())).getSingleOrNull();
     } catch (e, st) {
       _log.error('getSessionById failed', tag: 'FocusLocalDS', error: e, stackTrace: st);
       rethrow;
@@ -44,7 +48,11 @@ class FocusLocalDataSourceImpl implements IFocusLocalDataSource {
   @override
   Future<FocusSessionData?> getActiveSession() async {
     final query = _db.select(_db.focusSessionTable)
-      ..where((t) => t.state.isIn([SessionState.running.index, SessionState.paused.index, SessionState.onBreak.index]))
+      ..where(
+        (t) =>
+            t.deletedAt.isNull() &
+            t.state.isIn([SessionState.running.index, SessionState.paused.index, SessionState.onBreak.index]),
+      )
       ..limit(1);
     try {
       return await query.getSingleOrNull();
@@ -86,10 +94,12 @@ class FocusLocalDataSourceImpl implements IFocusLocalDataSource {
 
   @override
   Future<void> deleteSession(int id) async {
-    // Fetch the session first so we know which date to recalculate.
     try {
       final session = await getSessionById(id);
-      await (_db.delete(_db.focusSessionTable)..where((t) => t.id.equals(id))).go();
+      final now = DateTime.now();
+      await (_db.update(
+        _db.focusSessionTable,
+      )..where((t) => t.id.equals(id) & t.deletedAt.isNull())).write(FocusSessionTableCompanion(deletedAt: Value(now)));
       if (session != null) {
         await _db.recalculateDailyStatsForDate(session.startTime);
       }
@@ -101,12 +111,12 @@ class FocusLocalDataSourceImpl implements IFocusLocalDataSource {
 
   @override
   Stream<List<FocusSessionData>> watchSessionsByTask(int taskId) {
-    return (_db.select(_db.focusSessionTable)..where((t) => t.taskId.equals(taskId))).watch();
+    return (_db.select(_db.focusSessionTable)..where((t) => t.taskId.equals(taskId) & t.deletedAt.isNull())).watch();
   }
 
   @override
   Stream<List<FocusSessionData>> watchAllSessions() {
-    return _db.select(_db.focusSessionTable).watch();
+    return (_db.select(_db.focusSessionTable)..where((t) => t.deletedAt.isNull())).watch();
   }
 
   /// Derives the session's start time from the companion and recalculates

--- a/lib/features/session/data/mappers/focus_session_mappers.dart
+++ b/lib/features/session/data/mappers/focus_session_mappers.dart
@@ -6,6 +6,7 @@ import '../../domain/entities/focus_session.dart';
 extension DbFocusSessionToDomain on FocusSessionData {
   FocusSession toDomain() => FocusSession(
     id: id,
+    uuid: uuid,
     taskId: taskId,
     focusDurationMinutes: focusDurationMinutes,
     breakDurationMinutes: breakDurationMinutes,
@@ -14,6 +15,7 @@ extension DbFocusSessionToDomain on FocusSessionData {
     state: state,
     elapsedSeconds: elapsedSeconds,
     focusPhaseEndedAt: focusPhaseEndedAt,
+    deletedAt: deletedAt,
   );
 }
 
@@ -22,6 +24,7 @@ extension DomainFocusSessionToCompanion on FocusSession {
     if (id != null) {
       return FocusSessionTableCompanion(
         id: Value(id!),
+        uuid: Value(uuid),
         taskId: Value(taskId),
         focusDurationMinutes: Value(focusDurationMinutes),
         breakDurationMinutes: Value(breakDurationMinutes),
@@ -30,9 +33,11 @@ extension DomainFocusSessionToCompanion on FocusSession {
         state: Value(state),
         elapsedSeconds: Value(elapsedSeconds),
         focusPhaseEndedAt: Value(focusPhaseEndedAt),
+        deletedAt: Value(deletedAt),
       );
     }
     return FocusSessionTableCompanion.insert(
+      uuid: uuid,
       taskId: Value(taskId),
       focusDurationMinutes: focusDurationMinutes,
       breakDurationMinutes: breakDurationMinutes,
@@ -41,6 +46,7 @@ extension DomainFocusSessionToCompanion on FocusSession {
       state: state,
       elapsedSeconds: Value(elapsedSeconds),
       focusPhaseEndedAt: Value(focusPhaseEndedAt),
+      deletedAt: Value(deletedAt),
     );
   }
 }

--- a/lib/features/session/data/models/focus_session_model.dart
+++ b/lib/features/session/data/models/focus_session_model.dart
@@ -6,8 +6,11 @@ import '../../domain/entities/session_state.dart';
 @DataClassName('FocusSessionData')
 @TableIndex(name: 'focus_session_task_id_idx', columns: {#taskId})
 @TableIndex(name: 'focus_session_start_time_idx', columns: {#startTime})
+@TableIndex(name: 'focus_session_uuid_idx', columns: {#uuid}, unique: true)
+@TableIndex(name: 'focus_session_deleted_at_idx', columns: {#deletedAt})
 class FocusSessionTable extends Table {
   IntColumn get id => integer().autoIncrement()();
+  TextColumn get uuid => text().unique()();
   IntColumn get taskId => integer().nullable().references(TaskTable, #id, onDelete: KeyAction.cascade)();
   IntColumn get focusDurationMinutes => integer()();
   IntColumn get breakDurationMinutes => integer()();
@@ -20,4 +23,6 @@ class FocusSessionTable extends Table {
   /// Stored to preserve accurate focus time across app restarts.
   /// Null while focus is still running; set when transitioning to break.
   IntColumn get focusPhaseEndedAt => integer().nullable()();
+
+  DateTimeColumn get deletedAt => dateTime().nullable()();
 }

--- a/lib/features/session/domain/entities/focus_session.dart
+++ b/lib/features/session/domain/entities/focus_session.dart
@@ -12,6 +12,7 @@ import 'session_state.dart';
 @immutable
 class FocusSession extends Equatable {
   final int? id;
+  final String uuid;
   final int? taskId;
   final int focusDurationMinutes;
   final int breakDurationMinutes;
@@ -31,6 +32,8 @@ class FocusSession extends Equatable {
   /// Persisted to the database to preserve accurate stats across app restarts.
   final int? focusPhaseEndedAt;
 
+  final DateTime? deletedAt;
+
   /// Elapsed seconds at which the focus phase ended.
   /// Falls back to [focusDurationMinutes] * 60 when not explicitly set
   /// (e.g. session loaded from DB after an app restart).
@@ -41,6 +44,7 @@ class FocusSession extends Equatable {
 
   const FocusSession({
     this.id,
+    required this.uuid,
     this.taskId,
     required this.focusDurationMinutes,
     required this.breakDurationMinutes,
@@ -49,11 +53,13 @@ class FocusSession extends Equatable {
     required this.state,
     this.elapsedSeconds = 0,
     this.focusPhaseEndedAt,
+    this.deletedAt,
   });
 
   @override
   List<Object?> get props => [
     id,
+    uuid,
     taskId,
     focusDurationMinutes,
     breakDurationMinutes,
@@ -62,5 +68,6 @@ class FocusSession extends Equatable {
     state,
     elapsedSeconds,
     focusPhaseEndedAt,
+    deletedAt,
   ];
 }

--- a/lib/features/session/domain/entities/focus_session_extensions.dart
+++ b/lib/features/session/domain/entities/focus_session_extensions.dart
@@ -18,6 +18,7 @@ class _FocusSessionCopyWithUnset {
 extension FocusSessionCopyWith on FocusSession {
   FocusSession copyWith({
     int? id,
+    String? uuid,
     Object? taskId = _unset,
     int? focusDurationMinutes,
     int? breakDurationMinutes,
@@ -26,8 +27,10 @@ extension FocusSessionCopyWith on FocusSession {
     SessionState? state,
     int? elapsedSeconds,
     Object? focusPhaseEndedAt = _unset,
+    Object? deletedAt = _unset,
   }) => FocusSession(
     id: id ?? this.id,
+    uuid: uuid ?? this.uuid,
     taskId: taskId == _unset ? this.taskId : taskId as int?,
     focusDurationMinutes: focusDurationMinutes ?? this.focusDurationMinutes,
     breakDurationMinutes: breakDurationMinutes ?? this.breakDurationMinutes,
@@ -36,5 +39,6 @@ extension FocusSessionCopyWith on FocusSession {
     state: state ?? this.state,
     elapsedSeconds: elapsedSeconds ?? this.elapsedSeconds,
     focusPhaseEndedAt: focusPhaseEndedAt == _unset ? this.focusPhaseEndedAt : focusPhaseEndedAt as int?,
+    deletedAt: deletedAt == _unset ? this.deletedAt : deletedAt as DateTime?,
   );
 }

--- a/lib/features/session/presentation/providers/focus_session_provider.dart
+++ b/lib/features/session/presentation/providers/focus_session_provider.dart
@@ -4,6 +4,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../core/constants/notification_constants.dart';
 import '../../../../core/services/log_service.dart';
+import '../../../../core/utils/id_utils.dart';
 import '../../../settings/presentation/providers/settings_provider.dart';
 import '../../domain/entities/focus_session.dart';
 import '../../domain/entities/focus_session_extensions.dart';
@@ -101,6 +102,7 @@ class FocusTimer extends _$FocusTimer {
     _stopTicking();
 
     final session = FocusSession(
+      uuid: generateUuid(),
       taskId: taskId,
       focusDurationMinutes: focusMinutes,
       breakDurationMinutes: breakMinutes,
@@ -331,6 +333,7 @@ class FocusTimer extends _$FocusTimer {
 
   Future<void> _startNextCycle(int? taskId, int focusMinutes, int breakMinutes) async {
     final session = FocusSession(
+      uuid: generateUuid(),
       taskId: taskId,
       focusDurationMinutes: focusMinutes,
       breakDurationMinutes: breakMinutes,

--- a/lib/features/session/presentation/providers/focus_session_provider.g.dart
+++ b/lib/features/session/presentation/providers/focus_session_provider.g.dart
@@ -37,7 +37,7 @@ final class FocusTimerProvider extends $NotifierProvider<FocusTimer, FocusSessio
   }
 }
 
-String _$focusTimerHash() => r'691c936a9df509e8b3ca388986e864a0b004d6c2';
+String _$focusTimerHash() => r'e6ae3259b694ae11531de9fffe055732729d975f';
 
 abstract class _$FocusTimer extends $Notifier<FocusSession?> {
   FocusSession? build();

--- a/lib/features/settings/domain/entities/setting.dart
+++ b/lib/features/settings/domain/entities/setting.dart
@@ -34,6 +34,9 @@ abstract final class SettingsKeys {
 
   /// Reports productivity insights window (`weekly` or `monthly`).
   static const String reportsInsightsWindowMode = 'reports_insights_window_mode';
+
+  /// Stable per-install device UUID used for sync provenance.
+  static const String deviceId = 'device_id';
 }
 
 /// Domain entity representing a user preference.

--- a/lib/features/settings/domain/services/settings_service.dart
+++ b/lib/features/settings/domain/services/settings_service.dart
@@ -1,4 +1,5 @@
 import '../../../../core/services/log_service.dart';
+import '../../../../core/utils/id_utils.dart';
 import '../../../../core/utils/result.dart';
 import '../../domain/entities/setting.dart';
 import '../../domain/repositories/i_settings_repository.dart';
@@ -23,6 +24,17 @@ class SettingsService {
   Stream<String?> watchValue(String key) => _repository.watchValue(key);
 
   Future<Result<void>> setValue(String key, String value) => _writeValue(key, value, tag: 'setValue');
+
+  /// Returns the persisted device UUID, generating and storing one on first use.
+  Future<String> ensureDeviceId() async {
+    final existing = await _repository.getValue(SettingsKeys.deviceId);
+    if (existing != null && existing.isNotEmpty) return existing;
+
+    final id = generateUuid();
+    await _repository.setValue(SettingsKeys.deviceId, id);
+    _log.info('Generated device_id for this install', tag: 'SettingsService');
+    return id;
+  }
 
   //  Audio preferences
 

--- a/lib/features/sync/domain/entities/sync_data.dart
+++ b/lib/features/sync/domain/entities/sync_data.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import '../../../../core/utils/id_utils.dart';
 import '../../../tasks/domain/entities/task.dart';
 import '../../../tasks/domain/entities/task_priority.dart';
 import '../../../tasks/domain/entities/task_reminder_mode.dart';
@@ -44,71 +45,84 @@ class SyncData {
 /// Serializable project data for sync.
 class SyncProjectData {
   final int id;
+  final String uuid;
   final String title;
   final String? description;
   final DateTime? startDate;
   final DateTime? deadline;
   final DateTime createdAt;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const SyncProjectData({
     required this.id,
+    required this.uuid,
     required this.title,
     this.description,
     this.startDate,
     this.deadline,
     required this.createdAt,
     required this.updatedAt,
+    this.deletedAt,
   });
 
   factory SyncProjectData.fromJson(Map<String, dynamic> json) {
     return SyncProjectData(
       id: json['id'] as int,
+      uuid: (json['uuid'] as String?) ?? generateUuid(),
       title: json['title'] as String,
       description: json['description'] as String?,
       startDate: json['startDate'] != null ? DateTime.parse(json['startDate'] as String) : null,
       deadline: json['deadline'] != null ? DateTime.parse(json['deadline'] as String) : null,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
+      deletedAt: json['deletedAt'] != null ? DateTime.parse(json['deletedAt'] as String) : null,
     );
   }
 
   Map<String, dynamic> toJson() => {
     'id': id,
+    'uuid': uuid,
     'title': title,
     'description': description,
     'startDate': startDate?.toIso8601String(),
     'deadline': deadline?.toIso8601String(),
     'createdAt': createdAt.toIso8601String(),
     'updatedAt': updatedAt.toIso8601String(),
+    'deletedAt': deletedAt?.toIso8601String(),
   };
 
   factory SyncProjectData.fromProject(Project project) {
     return SyncProjectData(
       id: project.id!,
+      uuid: project.uuid,
       title: project.title,
       description: project.description,
       startDate: project.startDate,
       deadline: project.deadline,
       createdAt: project.createdAt,
       updatedAt: project.updatedAt,
+      deletedAt: project.deletedAt,
     );
   }
 
   Project toProject() => Project(
     id: id,
+    uuid: uuid,
     title: title,
     description: description,
     startDate: startDate,
     deadline: deadline,
     createdAt: createdAt,
     updatedAt: updatedAt,
+    deletedAt: deletedAt,
   );
 }
 
 /// Serializable task data for sync.
 class SyncTaskData {
   final int id;
+  final String uuid;
   final int projectId;
   final int? parentTaskId;
   final String title;
@@ -122,9 +136,11 @@ class SyncTaskData {
   final bool isCompleted;
   final DateTime createdAt;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const SyncTaskData({
     required this.id,
+    required this.uuid,
     required this.projectId,
     this.parentTaskId,
     required this.title,
@@ -138,11 +154,13 @@ class SyncTaskData {
     required this.isCompleted,
     required this.createdAt,
     required this.updatedAt,
+    this.deletedAt,
   });
 
   factory SyncTaskData.fromJson(Map<String, dynamic> json) {
     return SyncTaskData(
       id: json['id'] as int,
+      uuid: (json['uuid'] as String?) ?? generateUuid(),
       projectId: json['projectId'] as int,
       parentTaskId: json['parentTaskId'] as int?,
       title: json['title'] as String,
@@ -156,11 +174,13 @@ class SyncTaskData {
       isCompleted: json['isCompleted'] as bool,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
+      deletedAt: json['deletedAt'] != null ? DateTime.parse(json['deletedAt'] as String) : null,
     );
   }
 
   Map<String, dynamic> toJson() => {
     'id': id,
+    'uuid': uuid,
     'projectId': projectId,
     'parentTaskId': parentTaskId,
     'title': title,
@@ -174,11 +194,13 @@ class SyncTaskData {
     'isCompleted': isCompleted,
     'createdAt': createdAt.toIso8601String(),
     'updatedAt': updatedAt.toIso8601String(),
+    'deletedAt': deletedAt?.toIso8601String(),
   };
 
   factory SyncTaskData.fromTask(Task task) {
     return SyncTaskData(
       id: task.id!,
+      uuid: task.uuid,
       projectId: task.projectId,
       parentTaskId: task.parentTaskId,
       title: task.title,
@@ -192,11 +214,13 @@ class SyncTaskData {
       isCompleted: task.isCompleted,
       createdAt: task.createdAt,
       updatedAt: task.updatedAt,
+      deletedAt: task.deletedAt,
     );
   }
 
   Task toTask() => Task(
     id: id,
+    uuid: uuid,
     projectId: projectId,
     parentTaskId: parentTaskId,
     title: title,
@@ -212,5 +236,6 @@ class SyncTaskData {
     isCompleted: isCompleted,
     createdAt: createdAt,
     updatedAt: updatedAt,
+    deletedAt: deletedAt,
   );
 }

--- a/lib/features/sync/domain/services/sync_purge_service.dart
+++ b/lib/features/sync/domain/services/sync_purge_service.dart
@@ -1,0 +1,50 @@
+import 'package:drift/drift.dart';
+
+import '../../../../core/services/db_service.dart';
+import '../../../../core/services/log_service.dart';
+import '../../../../core/utils/result.dart';
+
+final _log = LogService.instance;
+
+/// Permanently removes soft-deleted rows older than a retention window.
+///
+/// Tombstones must stick around long enough for sync peers to observe them.
+/// After [retention], they are hard-deleted so the local DB does not grow
+/// unbounded.
+class SyncPurgeService {
+  SyncPurgeService(this._db, {this.retention = const Duration(days: 30)});
+
+  final AppDatabase _db;
+
+  /// How long soft-deleted rows are kept before permanent purge.
+  final Duration retention;
+
+  /// Hard-deletes projects, tasks, and focus sessions whose [deletedAt]
+  /// is older than [retention].
+  Future<Result<int>> purgeExpiredTombstones({DateTime? now}) async {
+    try {
+      final cutoff = (now ?? DateTime.now()).subtract(retention);
+      return await _db.transaction(() async {
+        // Sessions first (FK dependents), then tasks, then projects.
+        final sessions = await (_db.delete(
+          _db.focusSessionTable,
+        )..where((t) => t.deletedAt.isNotNull() & t.deletedAt.isSmallerThanValue(cutoff))).go();
+        final tasks = await (_db.delete(
+          _db.taskTable,
+        )..where((t) => t.deletedAt.isNotNull() & t.deletedAt.isSmallerThanValue(cutoff))).go();
+        final projects = await (_db.delete(
+          _db.projectTable,
+        )..where((t) => t.deletedAt.isNotNull() & t.deletedAt.isSmallerThanValue(cutoff))).go();
+        final total = sessions + tasks + projects;
+        _log.info(
+          'Purged $total expired tombstones (sessions=$sessions, tasks=$tasks, projects=$projects)',
+          tag: 'SyncPurgeService',
+        );
+        return Success(total);
+      });
+    } catch (e, st) {
+      _log.error('Failed to purge expired tombstones', tag: 'SyncPurgeService', error: e, stackTrace: st);
+      return Failure(DatabaseFailure('Failed to purge expired tombstones', error: e, stackTrace: st));
+    }
+  }
+}

--- a/lib/features/tasks/data/datasources/task_local_datasource.dart
+++ b/lib/features/tasks/data/datasources/task_local_datasource.dart
@@ -43,7 +43,9 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
   @override
   Future<List<TaskTableData>> getTasksByProjectId(int projectId) async {
     try {
-      return await (_db.select(_db.taskTable)..where((t) => t.projectId.equals(projectId))).get();
+      return await (_db.select(
+        _db.taskTable,
+      )..where((t) => t.projectId.equals(projectId) & t.deletedAt.isNull())).get();
     } catch (e, st) {
       _log.error('getTasksByProjectId failed', tag: 'TaskLocalDS', error: e, stackTrace: st);
       rethrow;
@@ -53,7 +55,7 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
   @override
   Future<TaskTableData?> getTaskById(int id) async {
     try {
-      return await (_db.select(_db.taskTable)..where((t) => t.id.equals(id))).getSingleOrNull();
+      return await (_db.select(_db.taskTable)..where((t) => t.id.equals(id) & t.deletedAt.isNull())).getSingleOrNull();
     } catch (e, st) {
       _log.error('getTaskById failed', tag: 'TaskLocalDS', error: e, stackTrace: st);
       rethrow;
@@ -63,7 +65,9 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
   @override
   Future<List<TaskTableData>> getSubtasks(int parentTaskId) async {
     try {
-      return await (_db.select(_db.taskTable)..where((t) => t.parentTaskId.equals(parentTaskId))).get();
+      return await (_db.select(
+        _db.taskTable,
+      )..where((t) => t.parentTaskId.equals(parentTaskId) & t.deletedAt.isNull())).get();
     } catch (e, st) {
       _log.error('getSubtasks failed', tag: 'TaskLocalDS', error: e, stackTrace: st);
       rethrow;
@@ -73,7 +77,9 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
   @override
   Future<List<TaskTableData>> getTasksWithDeadlines() async {
     try {
-      return await (_db.select(_db.taskTable)..where((t) => t.endDate.isNotNull() & t.isCompleted.equals(false))).get();
+      return await (_db.select(
+        _db.taskTable,
+      )..where((t) => t.endDate.isNotNull() & t.isCompleted.equals(false) & t.deletedAt.isNull())).get();
     } catch (e, st) {
       _log.error('getTasksWithDeadlines failed', tag: 'TaskLocalDS', error: e, stackTrace: st);
       rethrow;
@@ -102,26 +108,52 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
 
   @override
   Future<void> deleteTask(int id) async {
-    // ON DELETE CASCADE on parentTaskId propagates the delete to all
-    // descendant tasks automatically (and further to their sessions via
-    // FocusSessionTable.taskId cascade). A single statement suffices.
+    // Soft-delete the task, all descendants, and their focus sessions.
     try {
-      await (_db.delete(_db.taskTable)..where((t) => t.id.equals(id))).go();
+      await _db.transaction(() async {
+        final now = DateTime.now();
+        final idsToDelete = await _collectDescendantIds(id);
+        idsToDelete.add(id);
+
+        await (_db.update(_db.focusSessionTable)..where((t) => t.taskId.isIn(idsToDelete) & t.deletedAt.isNull()))
+            .write(FocusSessionTableCompanion(deletedAt: Value(now)));
+
+        await (_db.update(_db.taskTable)..where((t) => t.id.isIn(idsToDelete) & t.deletedAt.isNull())).write(
+          TaskTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
+        );
+      });
     } catch (e, st) {
       _log.error('deleteTask failed', tag: 'TaskLocalDS', error: e, stackTrace: st);
       rethrow;
     }
   }
 
+  /// BFS collect of all descendant task ids under [rootId].
+  Future<List<int>> _collectDescendantIds(int rootId) async {
+    final result = <int>[];
+    var frontier = [rootId];
+    while (frontier.isNotEmpty) {
+      final children =
+          await (_db.selectOnly(_db.taskTable)
+                ..addColumns([_db.taskTable.id])
+                ..where(_db.taskTable.parentTaskId.isIn(frontier) & _db.taskTable.deletedAt.isNull()))
+              .map((row) => row.read(_db.taskTable.id)!)
+              .get();
+      result.addAll(children);
+      frontier = children;
+    }
+    return result;
+  }
+
   @override
   Stream<List<TaskTableData>> watchTasksByProjectId(int projectId) {
-    return (_db.select(_db.taskTable)..where((t) => t.projectId.equals(projectId))).watch();
+    return (_db.select(_db.taskTable)..where((t) => t.projectId.equals(projectId) & t.deletedAt.isNull())).watch();
   }
 
   @override
   Stream<List<TaskTableData>> watchTasksWithDeadlines() {
     return (_db.select(_db.taskTable)
-          ..where((t) => t.endDate.isNotNull() & t.isCompleted.equals(false))
+          ..where((t) => t.endDate.isNotNull() & t.isCompleted.equals(false) & t.deletedAt.isNull())
           ..orderBy([(t) => OrderingTerm.asc(t.endDate)]))
         .watch();
   }
@@ -134,7 +166,7 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
     TaskSortOrder sortOrder = TaskSortOrder.none,
     TaskPriority? priorityFilter,
   }) {
-    final query = _db.select(_db.taskTable)..where((t) => t.projectId.equals(projectId));
+    final query = _db.select(_db.taskTable)..where((t) => t.projectId.equals(projectId) & t.deletedAt.isNull());
 
     final q = searchQuery.trim().toLowerCase();
     if (q.isNotEmpty) {
@@ -179,7 +211,7 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
     TaskPriority? priorityFilter,
     TaskCompletionFilter completionFilter = TaskCompletionFilter.all,
   }) {
-    final query = _db.select(_db.taskTable)..where((t) => t.depth.equals(0)); // root tasks only
+    final query = _db.select(_db.taskTable)..where((t) => t.depth.equals(0) & t.deletedAt.isNull());
 
     final q = searchQuery.trim().toLowerCase();
     if (q.isNotEmpty) {

--- a/lib/features/tasks/data/datasources/task_stats_local_datasource.dart
+++ b/lib/features/tasks/data/datasources/task_stats_local_datasource.dart
@@ -47,7 +47,7 @@ class TaskStatsLocalDataSourceImpl implements ITaskStatsLocalDataSource {
           'COALESCE(SUM(MIN(elapsed_seconds, focus_duration_minutes * 60)), 0) AS total_seconds, '
           'COUNT(*) AS total_sessions, '
           'COALESCE(SUM(CASE WHEN state = $_completedState THEN 1 ELSE 0 END), 0) AS completed_sessions '
-          'FROM focus_session_table WHERE task_id = ?',
+          'FROM focus_session_table WHERE task_id = ? AND deleted_at IS NULL',
           variables: [Variable<int>(taskId)],
           readsFrom: {_db.focusSessionTable},
         )
@@ -62,7 +62,7 @@ class TaskStatsLocalDataSourceImpl implements ITaskStatsLocalDataSource {
               .customSelect(
                 "SELECT date(start_time, 'unixepoch', 'localtime') AS d, COUNT(*) AS cnt "
                 'FROM focus_session_table '
-                'WHERE task_id = ? AND state = $_completedState '
+                'WHERE task_id = ? AND state = $_completedState AND deleted_at IS NULL '
                 'GROUP BY d',
                 variables: [Variable<int>(taskId)],
               )
@@ -95,7 +95,7 @@ class TaskStatsLocalDataSourceImpl implements ITaskStatsLocalDataSource {
   @override
   Stream<List<FocusSessionData>> watchRecentSessions(int taskId, {int limit = 10}) {
     return (_db.select(_db.focusSessionTable)
-          ..where((t) => t.taskId.equals(taskId))
+          ..where((t) => t.taskId.equals(taskId) & t.deletedAt.isNull())
           ..orderBy([(t) => OrderingTerm.desc(t.startTime)])
           ..limit(limit))
         .watch();
@@ -139,15 +139,15 @@ class TaskStatsLocalDataSourceImpl implements ITaskStatsLocalDataSource {
           'FROM '
           '(SELECT COALESCE(SUM(MIN(elapsed_seconds, focus_duration_minutes * 60)), 0) AS total_seconds, COUNT(*) AS total_sessions, '
           'SUM(CASE WHEN state = $_completedState THEN 1 ELSE 0 END) AS completed_sessions '
-          'FROM focus_session_table) s, '
+          'FROM focus_session_table WHERE deleted_at IS NULL) s, '
           '(SELECT COUNT(*) AS total_tasks, '
           'SUM(CASE WHEN is_completed = 1 THEN 1 ELSE 0 END) AS completed_tasks '
-          'FROM task_table WHERE depth = 0) t, '
+          'FROM task_table WHERE depth = 0 AND deleted_at IS NULL) t, '
           '(SELECT '
           'COALESCE(SUM(CASE WHEN state = $_completedState THEN 1 ELSE 0 END), 0) AS today_sessions, '
           'COALESCE(SUM(MIN(elapsed_seconds, focus_duration_minutes * 60)), 0) AS today_seconds '
           'FROM focus_session_table '
-          "WHERE date(start_time, 'unixepoch', 'localtime') = ?) td",
+          "WHERE deleted_at IS NULL AND date(start_time, 'unixepoch', 'localtime') = ?) td",
           variables: [Variable<String>(todayKey)],
           readsFrom: {_db.focusSessionTable, _db.taskTable, _db.dailySessionStatsTable},
         )
@@ -192,7 +192,7 @@ class TaskStatsLocalDataSourceImpl implements ITaskStatsLocalDataSource {
   @override
   Stream<List<TaskTableData>> watchRecentTasks({int limit = 5}) {
     return (_db.select(_db.taskTable)
-          ..where((t) => t.depth.equals(0))
+          ..where((t) => t.depth.equals(0) & t.deletedAt.isNull())
           ..orderBy([(t) => OrderingTerm.desc(t.updatedAt)])
           ..limit(limit))
         .watch();

--- a/lib/features/tasks/data/mappers/task_extensions.dart
+++ b/lib/features/tasks/data/mappers/task_extensions.dart
@@ -6,6 +6,7 @@ import '../../domain/entities/task.dart';
 extension DbTaskToDomain on TaskTableData {
   Task toDomain() => Task(
     id: id,
+    uuid: uuid,
     projectId: projectId,
     parentTaskId: parentTaskId,
     title: title,
@@ -19,6 +20,7 @@ extension DbTaskToDomain on TaskTableData {
     isCompleted: isCompleted,
     createdAt: createdAt,
     updatedAt: updatedAt,
+    deletedAt: deletedAt,
   );
 }
 
@@ -29,6 +31,7 @@ extension DomainTaskToCompanion on Task {
     if (id != null) {
       return TaskTableCompanion(
         id: Value(id!),
+        uuid: Value(uuid),
         projectId: Value(projectId),
         parentTaskId: Value(parentTaskId),
         title: Value(title),
@@ -42,9 +45,11 @@ extension DomainTaskToCompanion on Task {
         isCompleted: Value(isCompleted),
         createdAt: Value(createdAt),
         updatedAt: Value(updatedAt),
+        deletedAt: Value(deletedAt),
       );
     }
     return TaskTableCompanion.insert(
+      uuid: uuid,
       projectId: projectId,
       parentTaskId: Value(parentTaskId),
       title: title,
@@ -58,6 +63,7 @@ extension DomainTaskToCompanion on Task {
       isCompleted: Value(isCompleted),
       createdAt: createdAt,
       updatedAt: updatedAt,
+      deletedAt: Value(deletedAt),
     );
   }
 }

--- a/lib/features/tasks/data/models/task_model.dart
+++ b/lib/features/tasks/data/models/task_model.dart
@@ -10,8 +10,12 @@ import '../../domain/entities/task_reminder_mode.dart';
 @TableIndex(name: 'task_deadline_idx', columns: {#endDate})
 @TableIndex(name: 'task_completed_idx', columns: {#isCompleted})
 @TableIndex(name: 'task_updated_at_idx', columns: {#updatedAt})
+@TableIndex(name: 'task_uuid_idx', columns: {#uuid}, unique: true)
+@TableIndex(name: 'task_deleted_at_idx', columns: {#deletedAt})
 class TaskTable extends Table {
   IntColumn get id => integer().autoIncrement()();
+
+  TextColumn get uuid => text().unique()();
 
   IntColumn get projectId => integer().references(ProjectTable, #id, onDelete: KeyAction.cascade)();
 
@@ -38,4 +42,6 @@ class TaskTable extends Table {
   DateTimeColumn get createdAt => dateTime()();
 
   DateTimeColumn get updatedAt => dateTime()();
+
+  DateTimeColumn get deletedAt => dateTime().nullable()();
 }

--- a/lib/features/tasks/domain/entities/task.dart
+++ b/lib/features/tasks/domain/entities/task.dart
@@ -10,6 +10,7 @@ import 'task_reminder_mode.dart';
 @immutable
 class Task extends Equatable {
   final int? id;
+  final String uuid;
   final int projectId;
   final int? parentTaskId;
   final String title;
@@ -23,9 +24,11 @@ class Task extends Equatable {
   final bool isCompleted;
   final DateTime createdAt;
   final DateTime updatedAt;
+  final DateTime? deletedAt;
 
   const Task({
     this.id,
+    required this.uuid,
     required this.projectId,
     this.parentTaskId,
     required this.title,
@@ -39,11 +42,13 @@ class Task extends Equatable {
     this.isCompleted = false,
     required this.createdAt,
     required this.updatedAt,
+    this.deletedAt,
   });
 
   @override
   List<Object?> get props => [
     id,
+    uuid,
     projectId,
     parentTaskId,
     title,
@@ -57,5 +62,6 @@ class Task extends Equatable {
     isCompleted,
     createdAt,
     updatedAt,
+    deletedAt,
   ];
 }

--- a/lib/features/tasks/domain/entities/task_extensions.dart
+++ b/lib/features/tasks/domain/entities/task_extensions.dart
@@ -16,6 +16,7 @@ class _TaskCopyWithUnset {
 extension TaskCopyWith on Task {
   Task copyWith({
     int? id,
+    String? uuid,
     int? projectId,
     Object? parentTaskId = _taskCopyWithUnset,
     String? title,
@@ -29,8 +30,10 @@ extension TaskCopyWith on Task {
     bool? isCompleted,
     DateTime? createdAt,
     DateTime? updatedAt,
+    Object? deletedAt = _taskCopyWithUnset,
   }) => Task(
     id: id ?? this.id,
+    uuid: uuid ?? this.uuid,
     projectId: projectId ?? this.projectId,
     parentTaskId: parentTaskId == _taskCopyWithUnset ? this.parentTaskId : parentTaskId as int?,
     title: title ?? this.title,
@@ -46,5 +49,6 @@ extension TaskCopyWith on Task {
     isCompleted: isCompleted ?? this.isCompleted,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
+    deletedAt: deletedAt == _taskCopyWithUnset ? this.deletedAt : deletedAt as DateTime?,
   );
 }

--- a/lib/features/tasks/domain/services/task_service.dart
+++ b/lib/features/tasks/domain/services/task_service.dart
@@ -1,4 +1,5 @@
 import '../../../../core/services/log_service.dart';
+import '../../../../core/utils/id_utils.dart';
 import '../../../../core/utils/result.dart';
 import '../entities/task.dart';
 import '../entities/task_extensions.dart';
@@ -45,6 +46,7 @@ class TaskService {
     try {
       final now = DateTime.now();
       final task = Task(
+        uuid: generateUuid(),
         projectId: projectId,
         parentTaskId: parentTaskId,
         title: title,
@@ -88,7 +90,7 @@ class TaskService {
     try {
       await _taskNotificationService.cancelTaskReminder(id);
       await _repository.deleteTask(id);
-      _log.info('Task $id deleted', tag: 'TaskService');
+      _log.info('Task $id soft-deleted', tag: 'TaskService');
       return const Success(null);
     } catch (e, st) {
       _log.error('Failed to delete task $id', tag: 'TaskService', error: e, stackTrace: st);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,8 @@ import 'core/di/injection.dart';
 import 'core/services/desktop_lifecycle_service.dart';
 import 'core/utils/platform_utils.dart';
 import 'features/notifications/domain/services/notification_inbox_sync_service.dart';
+import 'features/settings/domain/services/settings_service.dart';
+import 'features/sync/domain/services/sync_purge_service.dart';
 import 'features/tasks/domain/services/task_notification_service.dart';
 
 void main(List<String> args) async {
@@ -35,6 +37,8 @@ void main(List<String> args) async {
     await getIt<DesktopLifecycleService>().init(startHidden: startHidden);
   }
 
+  await getIt<SettingsService>().ensureDeviceId();
+  await getIt<SyncPurgeService>().purgeExpiredTombstones();
   await getIt<TaskNotificationService>().rescheduleAllReminders();
   await getIt<NotificationInboxSyncService>().init();
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1363,7 +1363,7 @@ packages:
     source: hosted
     version: "1.4.0"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ dependencies:
   googleapis: ^16.0.0
   extension_google_sign_in_as_googleapis_auth: ^3.0.0
   http: ^1.6.0
+  uuid: ^4.6.0
 
 dev_dependencies:
   flutter_test:

--- a/test/core/db/migration_harness_test.dart
+++ b/test/core/db/migration_harness_test.dart
@@ -3,18 +3,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:focus/core/services/db_service.dart';
 import 'package:sqlite3/sqlite3.dart';
 
-/// Phase 0 migration harness.
+/// Phase 1 migration harness.
 ///
-/// Captures the current (v5) schema via [AppDatabase.forTesting] and verifies
-/// that upgrading from a hand-built v1 schema reaches v5 without nested
-/// transaction statements and without losing rows.
+/// Captures the current (v6) schema via [AppDatabase.forTesting] and verifies
+/// that upgrading from a hand-built v1 schema reaches v6 without nested
+/// transaction statements, without losing rows, and with uuid/deletedAt columns.
 void main() {
-  test('onCreate produces schema version 5 with expected tables', () async {
+  test('onCreate produces schema version 6 with expected tables', () async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 5);
+    expect(version.read<int>('user_version'), 6);
 
     final tables = await db.customSelect("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").get();
     final names = tables.map((row) => row.read<String>('name')).toSet();
@@ -29,9 +29,21 @@ void main() {
         'notification_inbox_table',
       }),
     );
+
+    final projectCols = await db.customSelect('PRAGMA table_info(project_table)').get();
+    final projectColNames = projectCols.map((r) => r.read<String>('name')).toSet();
+    expect(projectColNames, containsAll({'uuid', 'deleted_at'}));
+
+    final taskCols = await db.customSelect('PRAGMA table_info(task_table)').get();
+    final taskColNames = taskCols.map((r) => r.read<String>('name')).toSet();
+    expect(taskColNames, containsAll({'uuid', 'deleted_at'}));
+
+    final sessionCols = await db.customSelect('PRAGMA table_info(focus_session_table)').get();
+    final sessionColNames = sessionCols.map((r) => r.read<String>('name')).toSet();
+    expect(sessionColNames, containsAll({'uuid', 'deleted_at'}));
   });
 
-  test('migrates v1 schema to v5 and preserves task rows', () async {
+  test('migrates v1 schema to v6, preserves rows, and backfills uuids', () async {
     final raw = sqlite3.openInMemory();
     _createV1Schema(raw);
     raw.execute('INSERT INTO project_table (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)', [
@@ -45,6 +57,12 @@ void main() {
       'VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
       [1, 1, 'Legacy Task', 1, 0, 0, 1700000000, 1700000000],
     );
+    raw.execute(
+      'INSERT INTO focus_session_table '
+      '(id, task_id, focus_duration_minutes, break_duration_minutes, start_time, state, elapsed_seconds) '
+      'VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [1, 1, 25, 5, 1700000000, 0, 0],
+    );
     raw.execute('PRAGMA user_version = 1');
 
     final db = AppDatabase.forTesting(NativeDatabase.opened(raw));
@@ -53,12 +71,14 @@ void main() {
     });
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 5);
+    expect(version.read<int>('user_version'), 6);
 
     final tasks = await db.select(db.taskTable).get();
     expect(tasks, hasLength(1));
     expect(tasks.single.title, 'Legacy Task');
     expect(tasks.single.projectId, 1);
+    expect(tasks.single.uuid, isNotEmpty);
+    expect(tasks.single.deletedAt, isNull);
 
     // reminder columns added in v4
     expect(tasks.single.reminderMode.index, 0);
@@ -66,6 +86,52 @@ void main() {
     // notification inbox created in v5
     final inbox = await db.select(db.notificationInboxTable).get();
     expect(inbox, isEmpty);
+
+    final projects = await db.select(db.projectTable).get();
+    expect(projects.single.uuid, isNotEmpty);
+    expect(projects.single.deletedAt, isNull);
+
+    final sessions = await db.select(db.focusSessionTable).get();
+    expect(sessions.single.uuid, isNotEmpty);
+    expect(sessions.single.deletedAt, isNull);
+
+    final indexes = await db
+        .customSelect("SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE '%uuid%'")
+        .get();
+    final indexNames = indexes.map((r) => r.read<String>('name')).toSet();
+    expect(indexNames, containsAll({'project_uuid_idx', 'task_uuid_idx', 'focus_session_uuid_idx'}));
+  });
+
+  test('migrates v5 schema to v6 adding soft-delete columns', () async {
+    final raw = sqlite3.openInMemory();
+    _createV5Schema(raw);
+    raw.execute('INSERT INTO project_table (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)', [
+      1,
+      'V5 Project',
+      1700000000,
+      1700000000,
+    ]);
+    raw.execute(
+      'INSERT INTO task_table '
+      '(id, project_id, title, priority, depth, is_completed, reminder_mode, created_at, updated_at) '
+      'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [1, 1, 'V5 Task', 1, 0, 0, 0, 1700000000, 1700000000],
+    );
+    raw.execute('PRAGMA user_version = 5');
+
+    final db = AppDatabase.forTesting(NativeDatabase.opened(raw));
+    addTearDown(db.close);
+
+    final version = await db.customSelect('PRAGMA user_version').getSingle();
+    expect(version.read<int>('user_version'), 6);
+
+    final project = (await db.select(db.projectTable).get()).single;
+    expect(project.uuid, isNotEmpty);
+    expect(project.deletedAt, isNull);
+
+    final task = (await db.select(db.taskTable).get()).single;
+    expect(task.uuid, isNotEmpty);
+    expect(task.deletedAt, isNull);
   });
 }
 
@@ -124,6 +190,85 @@ void _createV1Schema(Database raw) {
     CREATE TABLE settings_table (
       key TEXT NOT NULL PRIMARY KEY,
       value TEXT NOT NULL
+    )
+  ''');
+}
+
+void _createV5Schema(Database raw) {
+  raw.execute('''
+    CREATE TABLE project_table (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      title TEXT NOT NULL,
+      description TEXT,
+      start_date INTEGER,
+      deadline INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  ''');
+  raw.execute('''
+    CREATE TABLE task_table (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      project_id INTEGER NOT NULL,
+      parent_task_id INTEGER,
+      title TEXT NOT NULL,
+      description TEXT,
+      priority INTEGER NOT NULL,
+      start_date INTEGER,
+      end_date INTEGER,
+      depth INTEGER NOT NULL,
+      is_completed INTEGER NOT NULL DEFAULT 0,
+      reminder_mode INTEGER NOT NULL DEFAULT 0,
+      custom_reminder_minutes_before INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      FOREIGN KEY(project_id) REFERENCES project_table(id) ON DELETE CASCADE,
+      FOREIGN KEY(parent_task_id) REFERENCES task_table(id) ON DELETE CASCADE
+    )
+  ''');
+  raw.execute('''
+    CREATE TABLE focus_session_table (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id INTEGER,
+      focus_duration_minutes INTEGER NOT NULL,
+      break_duration_minutes INTEGER NOT NULL,
+      start_time INTEGER NOT NULL,
+      end_time INTEGER,
+      state INTEGER NOT NULL,
+      elapsed_seconds INTEGER NOT NULL DEFAULT 0,
+      focus_phase_ended_at INTEGER,
+      FOREIGN KEY(task_id) REFERENCES task_table(id) ON DELETE CASCADE
+    )
+  ''');
+  raw.execute('''
+    CREATE TABLE daily_session_stats_table (
+      date TEXT NOT NULL PRIMARY KEY,
+      completed_sessions INTEGER NOT NULL,
+      total_sessions INTEGER NOT NULL,
+      focus_seconds INTEGER NOT NULL
+    )
+  ''');
+  raw.execute('''
+    CREATE TABLE settings_table (
+      key TEXT NOT NULL PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  ''');
+  raw.execute('''
+    CREATE TABLE notification_inbox_table (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      notification_id INTEGER NOT NULL,
+      type INTEGER NOT NULL,
+      state INTEGER NOT NULL,
+      title TEXT NOT NULL,
+      body TEXT,
+      payload TEXT,
+      task_id INTEGER,
+      project_id INTEGER,
+      scheduled_for INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      UNIQUE(notification_id, type)
     )
   ''');
 }

--- a/test/helpers/fixtures.dart
+++ b/test/helpers/fixtures.dart
@@ -1,3 +1,4 @@
+import 'package:focus/core/utils/id_utils.dart';
 import 'package:focus/features/projects/domain/entities/project.dart';
 import 'package:focus/features/session/domain/entities/focus_session.dart';
 import 'package:focus/features/session/domain/entities/session_state.dart';
@@ -10,6 +11,7 @@ final testNow = DateTime.utc(2026, 8, 2, 12);
 
 Task buildTask({
   int? id = 1,
+  String? uuid,
   int projectId = 1,
   String title = 'Write tests',
   TaskPriority priority = TaskPriority.medium,
@@ -21,11 +23,13 @@ Task buildTask({
   bool isCompleted = false,
   DateTime? createdAt,
   DateTime? updatedAt,
+  DateTime? deletedAt,
 }) {
   final created = createdAt ?? testNow.subtract(const Duration(days: 3));
   final resolvedEndDate = identical(endDate, _sentinel) ? testNow.add(const Duration(days: 2)) : endDate as DateTime?;
   return Task(
     id: id,
+    uuid: uuid ?? 'task-uuid-${id ?? 0}',
     projectId: projectId,
     title: title,
     priority: priority,
@@ -37,6 +41,7 @@ Task buildTask({
     isCompleted: isCompleted,
     createdAt: created,
     updatedAt: updatedAt ?? created,
+    deletedAt: deletedAt,
   );
 }
 
@@ -44,17 +49,28 @@ const _sentinel = Object();
 
 Project buildProject({
   int? id = 1,
+  String? uuid,
   String title = 'Focus',
   String? description,
   DateTime? createdAt,
   DateTime? updatedAt,
+  DateTime? deletedAt,
 }) {
   final created = createdAt ?? testNow.subtract(const Duration(days: 7));
-  return Project(id: id, title: title, description: description, createdAt: created, updatedAt: updatedAt ?? created);
+  return Project(
+    id: id,
+    uuid: uuid ?? 'project-uuid-${id ?? 0}',
+    title: title,
+    description: description,
+    createdAt: created,
+    updatedAt: updatedAt ?? created,
+    deletedAt: deletedAt,
+  );
 }
 
 FocusSession buildSession({
   int? id = 1,
+  String? uuid,
   int? taskId = 1,
   int focusDurationMinutes = 25,
   int breakDurationMinutes = 5,
@@ -63,9 +79,11 @@ FocusSession buildSession({
   int? focusPhaseEndedAt,
   DateTime? startTime,
   DateTime? endTime,
+  DateTime? deletedAt,
 }) {
   return FocusSession(
     id: id,
+    uuid: uuid ?? 'session-uuid-${id ?? 0}',
     taskId: taskId,
     focusDurationMinutes: focusDurationMinutes,
     breakDurationMinutes: breakDurationMinutes,
@@ -74,5 +92,9 @@ FocusSession buildSession({
     state: state,
     elapsedSeconds: elapsedSeconds,
     focusPhaseEndedAt: focusPhaseEndedAt,
+    deletedAt: deletedAt,
   );
 }
+
+/// Convenience for tests that need a real random UUID.
+String testUuid() => generateUuid();


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch feat/phase-1-sync-schema into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
b8c42ab feat(sync): add uuid identity and soft-delete tombstones
da236d4 feat(ui): collapse list filters and adopt ForUI desktop chrome
dfc058e fix(deps): pin sqlite3 to analyzer-compatible major
ffb349f chore(deps): declare sqlite3 for migration harness tests
a973c42 test(foundation): add domain tests and Drift migration harness
a360273 chore(deps): upgrade Flutter, ForUI, and related packages to current majors
66dfbd0 docs(agents): add Dart/Flutter style rules for shorthands and opacity

### Files
- .agents/docs/architecture.md
- .agents/docs/coding_style.md
- .agents/docs/commands.md
- .agents/docs/patterns.md
- .fvmrc
- AGENTS.md
- lib/core/app.dart
- lib/core/config/theme/app_theme.dart
- lib/core/config/theme/card_style.dart
- lib/core/config/theme/theme_builder.dart
- lib/core/config/theme/typography/typography.dart
- lib/core/di/injection.dart
- lib/core/providers/expansion_provider.g.dart
- lib/core/services/db_service.dart
- lib/core/services/db_service.g.dart
- lib/core/services/log_service.dart
- lib/core/utils/date_time_utils.dart
- lib/core/utils/id_utils.dart
- lib/core/widgets/action_menu_button.dart
- lib/core/widgets/adaptive_shell.dart
- lib/core/widgets/adaptive_shell_desktop_layout.dart
- lib/core/widgets/app_card.dart
- lib/core/widgets/app_search_bar.dart
- lib/core/widgets/base_form_screen.dart
- lib/core/widgets/confirmation_dialog.dart
- lib/core/widgets/list_toolbar.dart
- lib/core/widgets/master_detail_layout.dart
- lib/core/widgets/sort_filter_chips.dart
- lib/core/widgets/time_field.dart
- lib/features/home/presentation/pages/home_screen.dart
- lib/features/home/presentation/providers/activity_graph_providers.g.dart
- lib/features/home/presentation/providers/upcoming_calendar_state_provider.g.dart
- lib/features/home/presentation/providers/upcoming_calendar_view_provider.g.dart
- lib/features/home/presentation/widgets/calendar_content.dart
- lib/features/home/presentation/widgets/calendar_view_toggle.dart
- lib/features/home/presentation/widgets/global_stats_row.dart
- lib/features/home/presentation/widgets/overlay_task_tile.dart
- lib/features/home/presentation/widgets/quick_session_button.dart
- lib/features/home/presentation/widgets/recent_project_tile.dart
- lib/features/home/presentation/widgets/recent_task_tile.dart
- lib/features/home/presentation/widgets/section_header.dart
- lib/features/home/presentation/widgets/streak_badge.dart
- lib/features/home/presentation/widgets/task_popup_content.dart
- lib/features/home/presentation/widgets/today_summary_card.dart
- lib/features/projects/data/datasources/project_local_datasource.dart
- lib/features/projects/data/mappers/project_extensions.dart
- lib/features/projects/data/models/project_model.dart
- lib/features/projects/domain/entities/project.dart
- lib/features/projects/domain/entities/project_extensions.dart
- lib/features/projects/domain/services/project_service.dart
- lib/features/projects/presentation/providers/project_provider.g.dart
- lib/features/projects/presentation/screens/create_project_screen.dart
- lib/features/projects/presentation/screens/edit_project_screen.dart
- lib/features/projects/presentation/screens/project_detail_screen.dart
- lib/features/projects/presentation/screens/project_list_screen.dart
- lib/features/projects/presentation/screens/projects_screen.g.dart
- lib/features/projects/presentation/widgets/project_card.dart
- lib/features/projects/presentation/widgets/project_detail_header.dart
- lib/features/projects/presentation/widgets/project_filter_panel.dart
- lib/features/projects/presentation/widgets/project_meta_section.dart
- lib/features/reports/presentation/providers/reports_insights_window_provider.g.dart
- lib/features/reports/presentation/widgets/focus_ratio_chart.dart
- lib/features/reports/presentation/widgets/insights_window_toggle.dart
- lib/features/reports/presentation/widgets/productivity_insights_section.dart
- lib/features/session/data/datasources/focus_local_datasource.dart
- lib/features/session/data/mappers/focus_session_mappers.dart
- lib/features/session/data/models/focus_session_model.dart
- lib/features/session/data/repositories/focus_session_repository_impl.dart
- lib/features/session/domain/entities/focus_session.dart
- lib/features/session/domain/entities/focus_session_extensions.dart
- lib/features/session/domain/services/focus_session_state_machine.dart
- lib/features/session/presentation/commands/focus_commands.dart
- lib/features/session/presentation/providers/ambience_mute_provider.g.dart
- lib/features/session/presentation/providers/focus_progress_provider.g.dart
- lib/features/session/presentation/providers/focus_providers.g.dart
- lib/features/session/presentation/providers/focus_screen_provider.g.dart
- lib/features/session/presentation/providers/focus_session_provider.dart
- lib/features/session/presentation/providers/focus_session_provider.g.dart
- lib/features/session/presentation/screens/focus_session_screen.dart
- lib/features/session/presentation/widgets/ambience_marquee_row.dart
- lib/features/session/presentation/widgets/circular_timer.dart
- lib/features/session/presentation/widgets/focus_controls_with_callback.dart
- lib/features/session/presentation/widgets/focus_task_info.dart
- lib/features/session/presentation/widgets/mini_player_overlay.dart
- lib/features/settings/domain/entities/setting.dart
- lib/features/settings/domain/services/settings_service.dart
- lib/features/settings/presentation/providers/settings_provider.g.dart
- lib/features/settings/presentation/widgets/expandable_section.dart
- lib/features/settings/presentation/widgets/sound_item_tile.dart
- lib/features/settings/presentation/widgets/timer_settings_card.dart
- lib/features/sync/data/services/google_drive_service.dart
- lib/features/sync/domain/entities/sync_data.dart
- lib/features/sync/domain/services/sync_purge_service.dart
- lib/features/sync/presentation/providers/sync_provider.g.dart
- lib/features/sync/presentation/screens/sync_conflict_screen.dart
- lib/features/sync/presentation/widgets/sync_settings_card.dart
- lib/features/tasks/data/datasources/task_local_datasource.dart
- lib/features/tasks/data/datasources/task_stats_local_datasource.dart
- lib/features/tasks/data/mappers/task_extensions.dart
- lib/features/tasks/data/models/task_model.dart
- lib/features/tasks/domain/entities/daily_session_stats.dart
- lib/features/tasks/domain/entities/global_stats.dart
- lib/features/tasks/domain/entities/task.dart
- lib/features/tasks/domain/entities/task_extensions.dart
- lib/features/tasks/domain/entities/task_stats.dart
- lib/features/tasks/domain/services/task_service.dart
- lib/features/tasks/presentation/providers/all_tasks_provider.g.dart
- lib/features/tasks/presentation/providers/selected_task_selection.g.dart
- lib/features/tasks/presentation/providers/task_provider.g.dart
- lib/features/tasks/presentation/screens/all_tasks_screen.dart
- lib/features/tasks/presentation/screens/create_task_screen.dart
- lib/features/tasks/presentation/screens/create_task_with_project_screen.dart
- lib/features/tasks/presentation/screens/edit_task_screen.dart
- lib/features/tasks/presentation/screens/task_detail_screen.dart
- lib/features/tasks/presentation/widgets/add_subtask_chip.dart
- lib/features/tasks/presentation/widgets/all_tasks_content.dart
- lib/features/tasks/presentation/widgets/all_tasks_filter_panel.dart
- lib/features/tasks/presentation/widgets/all_tasks_filters.dart
- lib/features/tasks/presentation/widgets/all_tasks_list.dart
- lib/features/tasks/presentation/widgets/create_task_new_project_hint.dart
- lib/features/tasks/presentation/widgets/create_task_project_autocomplete.dart
- lib/features/tasks/presentation/widgets/embedded_create_task_button.dart
- lib/features/tasks/presentation/widgets/inline_add_subtask.dart
- lib/features/tasks/presentation/widgets/recent_session_tile.dart
- lib/features/tasks/presentation/widgets/subtask_count_chip.dart
- lib/features/tasks/presentation/widgets/subtasks_section.dart
- lib/features/tasks/presentation/widgets/task_date_row.dart
- lib/features/tasks/presentation/widgets/task_priority_badge.dart
- lib/features/tasks/presentation/widgets/task_quick_actions.dart
- lib/features/tasks/presentation/widgets/task_stats_row.dart
- lib/features/tasks/presentation/widgets/task_summary_section.dart
- lib/main.dart
- linux/flutter/generated_plugin_registrant.cc
- linux/flutter/generated_plugins.cmake
- macos/Flutter/GeneratedPluginRegistrant.swift
- macos/Podfile.lock
- macos/Runner.xcodeproj/project.pbxproj
- macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
- macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
- macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
- pubspec.lock
- pubspec.yaml
- test/core/db/migration_harness_test.dart
- test/domain/projects/project_service_test.dart
- test/domain/session/focus_session_state_machine_test.dart
- test/domain/tasks/task_reminder_planner_test.dart
- test/domain/tasks/task_service_test.dart
- test/helpers/fixtures.dart
- windows/flutter/generated_plugin_registrant.cc
- windows/flutter/generated_plugins.cmake

### Diffstat
 .agents/docs/architecture.md                       |   11 +-
 .agents/docs/coding_style.md                       |    5 +
 .agents/docs/commands.md                           |   12 +
 .agents/docs/patterns.md                           |   21 +
 .fvmrc                                             |    2 +-
 AGENTS.md                                          |    2 +-
 lib/core/app.dart                                  |    5 +-
 lib/core/config/theme/app_theme.dart               |    4 +-
 lib/core/config/theme/card_style.dart              |    8 +-
 lib/core/config/theme/theme_builder.dart           |   25 +-
 lib/core/config/theme/typography/typography.dart   |   13 +-
 lib/core/di/injection.dart                         |    2 +
 lib/core/providers/expansion_provider.g.dart       |   12 +-
 lib/core/services/db_service.dart                  |   47 +-
 lib/core/services/db_service.g.dart                | 2896 +++++++-------------
 lib/core/services/log_service.dart                 |    8 +-
 lib/core/utils/date_time_utils.dart                |    2 +-
 lib/core/utils/id_utils.dart                       |    6 +
 lib/core/widgets/action_menu_button.dart           |   16 +-
 lib/core/widgets/adaptive_shell.dart               |   26 +-
 .../widgets/adaptive_shell_desktop_layout.dart     |   50 +-
 lib/core/widgets/app_card.dart                     |    4 +-
 lib/core/widgets/app_search_bar.dart               |    2 +-
 lib/core/widgets/base_form_screen.dart             |   86 +-
 lib/core/widgets/confirmation_dialog.dart          |   47 +-
 lib/core/widgets/list_toolbar.dart                 |  133 +
 lib/core/widgets/master_detail_layout.dart         |   22 +-
 lib/core/widgets/sort_filter_chips.dart            |    2 +-
 lib/core/widgets/time_field.dart                   |    6 +-
 .../home/presentation/pages/home_screen.dart       |    8 +-
 .../providers/activity_graph_providers.g.dart      |   48 +-
 .../upcoming_calendar_state_provider.g.dart        |   27 +-
 .../upcoming_calendar_view_provider.g.dart         |   25 +-
 .../presentation/widgets/calendar_content.dart     |    9 +-
 .../presentation/widgets/calendar_view_toggle.dart |    4 +-
 .../presentation/widgets/global_stats_row.dart     |    6 +-
 .../presentation/widgets/overlay_task_tile.dart    |    2 +-
 .../presentation/widgets/quick_session_button.dart |   24 +-
 .../presentation/widgets/recent_project_tile.dart  |    8 +-
 .../presentation/widgets/recent_task_tile.dart     |    4 +-
 .../home/presentation/widgets/section_header.dart  |    2 +-
 .../home/presentation/widgets/streak_badge.dart    |    2 +-
 .../presentation/widgets/task_popup_content.dart   |    6 +-
 .../presentation/widgets/today_summary_card.dart   |    2 +-
 .../data/datasources/project_local_datasource.dart |   38 +-
 .../projects/data/mappers/project_extensions.dart  |    6 +
 .../projects/data/models/project_model.dart        |    6 +
 lib/features/projects/domain/entities/project.dart |    8 +-
 .../domain/entities/project_extensions.dart        |    4 +
 .../projects/domain/services/project_service.dart  |    6 +-
 .../presentation/providers/project_provider.g.dart |  123 +-
 .../screens/create_project_screen.dart             |   15 +-
 .../presentation/screens/edit_project_screen.dart  |   13 +-
 .../screens/project_detail_screen.dart             |   10 +-
 .../presentation/screens/project_list_screen.dart  |  105 +-
 .../presentation/screens/projects_screen.g.dart    |   21 +-
 .../presentation/widgets/project_card.dart         |    6 +-
 .../widgets/project_detail_header.dart             |    2 +-
 .../presentation/widgets/project_filter_panel.dart |   37 +
 .../presentation/widgets/project_meta_section.dart |   12 +-
 .../reports_insights_window_provider.g.dart        |   19 +-
 .../presentation/widgets/focus_ratio_chart.dart    |    7 +-
 .../widgets/insights_window_toggle.dart            |    4 +-
 .../widgets/productivity_insights_section.dart     |    2 +-
 .../data/datasources/focus_local_datasource.dart   |   24 +-
 .../data/mappers/focus_session_mappers.dart        |    6 +
 .../session/data/models/focus_session_model.dart   |    5 +
 .../focus_session_repository_impl.dart             |    7 +-
 .../session/domain/entities/focus_session.dart     |    7 +
 .../domain/entities/focus_session_extensions.dart  |    8 +-
 .../services/focus_session_state_machine.dart      |   18 +-
 .../presentation/commands/focus_commands.dart      |    2 +-
 .../providers/ambience_mute_provider.g.dart        |   34 +-
 .../providers/focus_progress_provider.g.dart       |   11 +-
 .../presentation/providers/focus_providers.g.dart  |  103 +-
 .../providers/focus_screen_provider.g.dart         |   15 +-
 .../providers/focus_session_provider.dart          |    3 +
 .../providers/focus_session_provider.g.dart        |   21 +-
 .../presentation/screens/focus_session_screen.dart |    2 +-
 .../presentation/widgets/ambience_marquee_row.dart |    4 +-
 .../presentation/widgets/circular_timer.dart       |    4 +-
 .../widgets/focus_controls_with_callback.dart      |   62 +-
 .../presentation/widgets/focus_task_info.dart      |    2 +-
 .../presentation/widgets/mini_player_overlay.dart  |    2 +-
 lib/features/settings/domain/entities/setting.dart |    3 +
 .../settings/domain/services/settings_service.dart |   12 +
 .../providers/settings_provider.g.dart             |   64 +-
 .../presentation/widgets/expandable_section.dart   |    2 +-
 .../presentation/widgets/sound_item_tile.dart      |    4 +-
 .../presentation/widgets/timer_settings_card.dart  |    6 +-
 .../sync/data/services/google_drive_service.dart   |   73 +-
 lib/features/sync/domain/entities/sync_data.dart   |   25 +
 .../sync/domain/services/sync_purge_service.dart   |   50 +
 .../presentation/providers/sync_provider.g.dart    |   50 +-
 .../presentation/screens/sync_conflict_screen.dart |    6 +-
 .../presentation/widgets/sync_settings_card.dart   |    4 +-
 .../data/datasources/task_local_datasource.dart    |   56 +-
 .../datasources/task_stats_local_datasource.dart   |   14 +-
 .../tasks/data/mappers/task_extensions.dart        |    6 +
 lib/features/tasks/data/models/task_model.dart     |    6 +
 .../tasks/domain/entities/daily_session_stats.dart |    4 +-
 .../tasks/domain/entities/global_stats.dart        |   13 +-
 lib/features/tasks/domain/entities/task.dart       |    6 +
 .../tasks/domain/entities/task_extensions.dart     |    4 +
 lib/features/tasks/domain/entities/task_stats.dart |    9 +-
 .../tasks/domain/services/task_service.dart        |    4 +-
 .../providers/all_tasks_provider.g.dart            |   12 +-
 .../providers/selected_task_selection.g.dart       |   22 +-
 .../presentation/providers/task_provider.g.dart    |  155 +-
 .../presentation/screens/all_tasks_screen.dart     |   31 +-
 .../presentation/screens/create_task_screen.dart   |   15 +-
 .../screens/create_task_with_project_screen.dart   |   15 +-
 .../presentation/screens/edit_task_screen.dart     |   13 +-
 .../presentation/screens/task_detail_screen.dart   |   12 +-
 .../presentation/widgets/add_subtask_chip.dart     |    4 +-
 .../presentation/widgets/all_tasks_content.dart    |   56 +-
 .../widgets/all_tasks_filter_panel.dart            |   62 +
 .../presentation/widgets/all_tasks_filters.dart    |  107 -
 .../tasks/presentation/widgets/all_tasks_list.dart |    2 +-
 .../widgets/create_task_new_project_hint.dart      |    2 +-
 .../widgets/create_task_project_autocomplete.dart  |    2 +-
 .../widgets/embedded_create_task_button.dart       |   25 -
 .../presentation/widgets/inline_add_subtask.dart   |    2 +-
 .../presentation/widgets/recent_session_tile.dart  |    8 +-
 .../presentation/widgets/subtask_count_chip.dart   |    7 +-
 .../presentation/widgets/subtasks_section.dart     |    4 +-
 .../tasks/presentation/widgets/task_date_row.dart  |    4 +-
 .../presentation/widgets/task_priority_badge.dart  |   10 +-
 .../presentation/widgets/task_quick_actions.dart   |   14 +-
 .../tasks/presentation/widgets/task_stats_row.dart |   18 +-
 .../presentation/widgets/task_summary_section.dart |   13 +-
 lib/main.dart                                      |    4 +
 linux/flutter/generated_plugin_registrant.cc       |    4 -
 linux/flutter/generated_plugins.cmake              |    2 +-
 macos/Flutter/GeneratedPluginRegistrant.swift      |    4 -
 macos/Podfile.lock                                 |   92 -
 macos/Runner.xcodeproj/project.pbxproj             |   42 +-
 .../xcshareddata/swiftpm/Package.resolved          |   77 +
 .../xcshareddata/xcschemes/Runner.xcscheme         |   18 +
 .../xcshareddata/swiftpm/Package.resolved          |   77 +
 pubspec.lock                                       |  446 +--
 pubspec.yaml                                       |   68 +-
 test/core/db/migration_harness_test.dart           |  274 ++
 test/domain/projects/project_service_test.dart     |   65 +
 .../session/focus_session_state_machine_test.dart  |  115 +
 test/domain/tasks/task_reminder_planner_test.dart  |   88 +
 test/domain/tasks/task_service_test.dart           |   90 +
 test/helpers/fixtures.dart                         |  100 +
 windows/flutter/generated_plugin_registrant.cc     |    3 -
 windows/flutter/generated_plugins.cmake            |    2 +-
 150 files changed, 3687 insertions(+), 3356 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
