### PR TITLE
feat(habits): Phase 3 recurrence and habit streaks

### DIFF
--- a/.agents/docs/architecture.md
+++ b/.agents/docs/architecture.md
@@ -158,7 +158,7 @@ Rules for schema changes:
 4. Regenerate code.
 5. Verify migration behavior with existing user data.
 
-Current sync-ready schema (v7) includes on `project_table`, `task_table`, and `focus_session_table`:
+Current sync-ready schema (v8) includes on `project_table`, `task_table`, and `focus_session_table`:
 - `uuid` (TEXT, unique) — stable sync identity, generated on create and backfilled on migration
 - `deleted_at` (nullable DateTime) — soft-delete tombstone; all reads filter `deletedAt IS NULL`
 
@@ -169,11 +169,18 @@ PM model (v7) adds:
 - Domain `Task.isCompleted` is a computed getter (`status == done`); DB still keeps `is_completed`
   synced from status for one compatibility cycle
 
+Recurrence / habits (v8) adds:
+- `task_table.recurrence_rule` (nullable JSON text), `recurrence_anchor_date`, `is_habit`
+- `task_completion_table` — occurrence log keyed by `(task_id, occurrence_date)` with soft-delete
+  and a partial unique index among live rows
+- Occurrences are expanded in pure domain code (`RecurrenceExpander`); habits are recurring tasks
+  with `isHabit = true` and streaks via `HabitStreakCalculator`
+
 Deletes are soft deletes. `ON DELETE CASCADE` no longer fires for app-level deletes, so project/task
-deletion must cascade soft-deletes to dependents inside a transaction (including milestones and
-clearing `task_tag` associations). `SyncPurgeService` hard-deletes tombstones older than the retention
-window (default 30 days). A stable `device_id` setting UUID is generated once on first launch for sync
-provenance.
+deletion must cascade soft-deletes to dependents inside a transaction (including milestones,
+completions, and clearing `task_tag` associations). `SyncPurgeService` hard-deletes tombstones older
+than the retention window (default 30 days), including completion rows before tasks. A stable
+`device_id` setting UUID is generated once on first launch for sync provenance.
 
 Current task schema also includes reminder configuration fields:
 - `reminder_mode` (enum-backed)

--- a/.agents/docs/patterns.md
+++ b/.agents/docs/patterns.md
@@ -280,6 +280,8 @@ Guidelines:
 - `smart` uses 1 week for long tasks and 1 day otherwise.
 - `custom` stores minutes-before as an integer.
 - Keep reminder computation in a pure planner utility so UI and services share logic.
+- For recurring tasks, use `computeReminderTimes` (rolling window of upcoming occurrences)
+  rather than a single `endDate`-based reminder.
 
 ## Soft Delete + UUID Sync Identity
 
@@ -296,12 +298,12 @@ await (_db.update(_db.projectTable)..where((t) => t.id.equals(id))).write(
 ```
 
 Gotchas:
-- Soft-deleting a project must transactionally soft-delete its tasks, milestones, and their sessions.
-- Soft-deleting a task must soft-delete descendants and their sessions, and remove `task_tag` rows.
+- Soft-deleting a project must transactionally soft-delete its tasks, milestones, completions, and their sessions.
+- Soft-deleting a task must soft-delete descendants, their completions, and their sessions, and remove `task_tag` rows.
 - Soft-deleting a tag removes its `task_tag` associations then tombstones the tag.
 - Soft-deleting a milestone clears `task.milestoneId` then tombstones the milestone.
 - Generate `uuid` on create via `generateUuid()`; migration backfills existing rows.
-- `SyncPurgeService` permanently removes tombstones past the retention window (including tags/milestones).
+- `SyncPurgeService` permanently removes tombstones past the retention window (including tags/milestones/completions).
 - Persist `SettingsKeys.deviceId` once via `SettingsService.ensureDeviceId()`.
 
 ## Task / Project Status + Tags / Milestones
@@ -324,6 +326,36 @@ Optional `statusFilter` mirrors the existing nullable `priorityFilter` on list f
 Gotchas:
 - Keep writing both `status` and `is_completed` until a later migration drops the bool column.
 - Filter completion chips (`TaskCompletionFilter`) should query `status`, not the legacy bool.
+
+## Recurrence Expansion + Habit Streaks
+
+Recurring tasks stay a **single row**. Occurrences are computed, never materialised as task rows.
+
+```dart
+// Pure expansion — no I/O
+final dates = RecurrenceExpander.expand(task, from, to);
+
+// Occurrence completion log (soft-delete aware upsert)
+await taskService.completeOccurrence(taskId, occurrenceDate);
+
+// Streaks skip days the rule did not schedule
+final streak = HabitStreakCalculator.calculate(
+  rule: task.recurrenceRule!,
+  anchor: task.recurrenceAnchorDate!,
+  completionDates: completions.map((c) => c.occurrenceDate),
+  from: windowStart,
+  to: windowEnd,
+);
+```
+
+Reminder scheduling uses a rolling window (`TaskReminderPlanner.computeReminderTimes`) so
+`flutter_local_notifications` only holds the next few occurrence reminders.
+
+Gotchas:
+- Store `RecurrenceRule` as JSON text via `dart_mappable`; parse with `RecurrenceRule.tryParseJson`.
+- Unique `(task_id, occurrence_date)` is a **partial** index (`WHERE deleted_at IS NULL`).
+- Habits are recurring tasks with `isHabit = true` — no separate habit table.
+- Reschedule reminders after `completeOccurrence` so the window advances.
 
 ## Mandatory Follow-Up
 

--- a/lib/core/constants/notification_constants.dart
+++ b/lib/core/constants/notification_constants.dart
@@ -13,6 +13,10 @@ abstract final class NotificationConstants {
   static const int alarmId = 1002;
   static const int taskReminderIdOffset = 20000;
 
+  /// Extra slots for rolling-window occurrence reminders (slot 0 uses the legacy id).
+  static const int taskReminderExtraSlotOffset = 300000;
+  static const int taskReminderSlotStride = 8;
+
   // Action IDs (notification buttons)
   static const String actionPause = 'focus_pause';
   static const String actionResume = 'focus_resume';
@@ -39,5 +43,13 @@ abstract final class NotificationConstants {
 
     final projectId = parts.length > 1 ? int.tryParse(parts[1]) : null;
     return (taskId: taskId, projectId: projectId);
+  }
+
+  /// Notification id for [taskId] reminder slot [slot] (0-based).
+  ///
+  /// Slot 0 preserves the pre-v8 id (`taskReminderIdOffset + taskId`).
+  static int taskReminderNotificationId(int taskId, [int slot = 0]) {
+    if (slot <= 0) return taskReminderIdOffset + taskId;
+    return taskReminderExtraSlotOffset + taskId * taskReminderSlotStride + slot;
   }
 }

--- a/lib/core/services/db_service.dart
+++ b/lib/core/services/db_service.dart
@@ -3,6 +3,7 @@ import 'package:drift_flutter/drift_flutter.dart';
 import 'package:focus/features/settings/data/models/settings_model.dart';
 import 'package:focus/features/notifications/data/models/notification_inbox_model.dart';
 import 'package:focus/features/tasks/data/models/daily_session_stats_model.dart';
+import 'package:focus/features/tasks/data/models/task_completion_model.dart';
 import 'package:focus/features/tasks/data/models/task_model.dart';
 import 'package:focus/features/tags/data/models/tag_model.dart';
 import 'package:focus/features/tags/data/models/task_tag_model.dart';
@@ -32,6 +33,7 @@ part 'db_service.g.dart';
     TagTable,
     TaskTagTable,
     MilestoneTable,
+    TaskCompletionTable,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -41,7 +43,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 7;
+  int get schemaVersion => 8;
 
   /// Recalculates the [dailySessionStatsTable] row for the given
   /// local calendar [dateKey] (format `YYYY-MM-DD`).
@@ -76,6 +78,11 @@ class AppDatabase extends _$AppDatabase {
   MigrationStrategy get migration => MigrationStrategy(
     onCreate: (m) async {
       await m.createAll();
+      // Partial unique index is not expressible via Drift annotations.
+      await customStatement(
+        'CREATE UNIQUE INDEX IF NOT EXISTS task_completion_task_occurrence_live_idx '
+        'ON task_completion_table(task_id, occurrence_date) WHERE deleted_at IS NULL',
+      );
     },
     onUpgrade: (m, from, to) async {
       if (from < 2) {
@@ -239,6 +246,37 @@ class AppDatabase extends _$AppDatabase {
         await customStatement('CREATE UNIQUE INDEX IF NOT EXISTS milestone_uuid_idx ON milestone_table(uuid)');
         await customStatement('CREATE INDEX IF NOT EXISTS milestone_project_id_idx ON milestone_table(project_id)');
         await customStatement('CREATE INDEX IF NOT EXISTS milestone_deleted_at_idx ON milestone_table(deleted_at)');
+      }
+
+      // v7 → v8: Recurrence / habits — rule JSON, anchor, isHabit, and
+      // per-occurrence completion log with soft-delete-aware uniqueness.
+      if (from < 8) {
+        await customStatement('ALTER TABLE task_table ADD COLUMN recurrence_rule TEXT');
+        await customStatement('ALTER TABLE task_table ADD COLUMN recurrence_anchor_date INTEGER');
+        await customStatement(
+          'ALTER TABLE task_table ADD COLUMN is_habit INTEGER NOT NULL DEFAULT 0',
+        );
+
+        await m.createTable(taskCompletionTable);
+
+        await customStatement(
+          'CREATE UNIQUE INDEX IF NOT EXISTS task_completion_uuid_idx ON task_completion_table(uuid)',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS task_completion_task_id_idx ON task_completion_table(task_id)',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS task_completion_occurrence_date_idx '
+          'ON task_completion_table(occurrence_date)',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS task_completion_deleted_at_idx ON task_completion_table(deleted_at)',
+        );
+        // Unique (taskId, occurrenceDate) among live rows only.
+        await customStatement(
+          'CREATE UNIQUE INDEX IF NOT EXISTS task_completion_task_occurrence_live_idx '
+          'ON task_completion_table(task_id, occurrence_date) WHERE deleted_at IS NULL',
+        );
       }
     },
     beforeOpen: (details) async {

--- a/lib/core/services/db_service.g.dart
+++ b/lib/core/services/db_service.g.dart
@@ -1354,6 +1354,43 @@ class $TaskTableTable extends TaskTable
       'REFERENCES milestone_table (id) ON DELETE SET NULL',
     ),
   );
+  static const VerificationMeta _recurrenceRuleMeta = const VerificationMeta(
+    'recurrenceRule',
+  );
+  @override
+  late final GeneratedColumn<String> recurrenceRule = GeneratedColumn<String>(
+    'recurrence_rule',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _recurrenceAnchorDateMeta =
+      const VerificationMeta('recurrenceAnchorDate');
+  @override
+  late final GeneratedColumn<DateTime> recurrenceAnchorDate =
+      GeneratedColumn<DateTime>(
+        'recurrence_anchor_date',
+        aliasedName,
+        true,
+        type: DriftSqlType.dateTime,
+        requiredDuringInsert: false,
+      );
+  static const VerificationMeta _isHabitMeta = const VerificationMeta(
+    'isHabit',
+  );
+  @override
+  late final GeneratedColumn<bool> isHabit = GeneratedColumn<bool>(
+    'is_habit',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'CHECK ("is_habit" IN (0, 1))',
+    ),
+    defaultValue: const Constant(false),
+  );
   static const VerificationMeta _isCompletedMeta = const VerificationMeta(
     'isCompleted',
   );
@@ -1420,6 +1457,9 @@ class $TaskTableTable extends TaskTable
     estimatedMinutes,
     sortOrder,
     milestoneId,
+    recurrenceRule,
+    recurrenceAnchorDate,
+    isHabit,
     isCompleted,
     createdAt,
     updatedAt,
@@ -1535,6 +1575,30 @@ class $TaskTableTable extends TaskTable
         ),
       );
     }
+    if (data.containsKey('recurrence_rule')) {
+      context.handle(
+        _recurrenceRuleMeta,
+        recurrenceRule.isAcceptableOrUnknown(
+          data['recurrence_rule']!,
+          _recurrenceRuleMeta,
+        ),
+      );
+    }
+    if (data.containsKey('recurrence_anchor_date')) {
+      context.handle(
+        _recurrenceAnchorDateMeta,
+        recurrenceAnchorDate.isAcceptableOrUnknown(
+          data['recurrence_anchor_date']!,
+          _recurrenceAnchorDateMeta,
+        ),
+      );
+    }
+    if (data.containsKey('is_habit')) {
+      context.handle(
+        _isHabitMeta,
+        isHabit.isAcceptableOrUnknown(data['is_habit']!, _isHabitMeta),
+      );
+    }
     if (data.containsKey('is_completed')) {
       context.handle(
         _isCompletedMeta,
@@ -1645,6 +1709,18 @@ class $TaskTableTable extends TaskTable
         DriftSqlType.int,
         data['${effectivePrefix}milestone_id'],
       ),
+      recurrenceRule: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}recurrence_rule'],
+      ),
+      recurrenceAnchorDate: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}recurrence_anchor_date'],
+      ),
+      isHabit: attachedDatabase.typeMapping.read(
+        DriftSqlType.bool,
+        data['${effectivePrefix}is_habit'],
+      )!,
       isCompleted: attachedDatabase.typeMapping.read(
         DriftSqlType.bool,
         data['${effectivePrefix}is_completed'],
@@ -1695,6 +1771,15 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
   final double sortOrder;
   final int? milestoneId;
 
+  /// JSON-encoded [RecurrenceRule], or null for one-shot tasks.
+  final String? recurrenceRule;
+
+  /// Series start used by [RecurrenceExpander]; defaults to start/created when null.
+  final DateTime? recurrenceAnchorDate;
+
+  /// When true, the recurring task is surfaced as a habit (streaks / agenda).
+  final bool isHabit;
+
   /// Kept in sync with [status] == done for one migration cycle (v7).
   final bool isCompleted;
   final DateTime createdAt;
@@ -1717,6 +1802,9 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     this.estimatedMinutes,
     required this.sortOrder,
     this.milestoneId,
+    this.recurrenceRule,
+    this.recurrenceAnchorDate,
+    required this.isHabit,
     required this.isCompleted,
     required this.createdAt,
     required this.updatedAt,
@@ -1769,6 +1857,13 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     if (!nullToAbsent || milestoneId != null) {
       map['milestone_id'] = Variable<int>(milestoneId);
     }
+    if (!nullToAbsent || recurrenceRule != null) {
+      map['recurrence_rule'] = Variable<String>(recurrenceRule);
+    }
+    if (!nullToAbsent || recurrenceAnchorDate != null) {
+      map['recurrence_anchor_date'] = Variable<DateTime>(recurrenceAnchorDate);
+    }
+    map['is_habit'] = Variable<bool>(isHabit);
     map['is_completed'] = Variable<bool>(isCompleted);
     map['created_at'] = Variable<DateTime>(createdAt);
     map['updated_at'] = Variable<DateTime>(updatedAt);
@@ -1811,6 +1906,13 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
       milestoneId: milestoneId == null && nullToAbsent
           ? const Value.absent()
           : Value(milestoneId),
+      recurrenceRule: recurrenceRule == null && nullToAbsent
+          ? const Value.absent()
+          : Value(recurrenceRule),
+      recurrenceAnchorDate: recurrenceAnchorDate == null && nullToAbsent
+          ? const Value.absent()
+          : Value(recurrenceAnchorDate),
+      isHabit: Value(isHabit),
       isCompleted: Value(isCompleted),
       createdAt: Value(createdAt),
       updatedAt: Value(updatedAt),
@@ -1850,6 +1952,11 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
       estimatedMinutes: serializer.fromJson<int?>(json['estimatedMinutes']),
       sortOrder: serializer.fromJson<double>(json['sortOrder']),
       milestoneId: serializer.fromJson<int?>(json['milestoneId']),
+      recurrenceRule: serializer.fromJson<String?>(json['recurrenceRule']),
+      recurrenceAnchorDate: serializer.fromJson<DateTime?>(
+        json['recurrenceAnchorDate'],
+      ),
+      isHabit: serializer.fromJson<bool>(json['isHabit']),
       isCompleted: serializer.fromJson<bool>(json['isCompleted']),
       createdAt: serializer.fromJson<DateTime>(json['createdAt']),
       updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
@@ -1884,6 +1991,11 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
       'estimatedMinutes': serializer.toJson<int?>(estimatedMinutes),
       'sortOrder': serializer.toJson<double>(sortOrder),
       'milestoneId': serializer.toJson<int?>(milestoneId),
+      'recurrenceRule': serializer.toJson<String?>(recurrenceRule),
+      'recurrenceAnchorDate': serializer.toJson<DateTime?>(
+        recurrenceAnchorDate,
+      ),
+      'isHabit': serializer.toJson<bool>(isHabit),
       'isCompleted': serializer.toJson<bool>(isCompleted),
       'createdAt': serializer.toJson<DateTime>(createdAt),
       'updatedAt': serializer.toJson<DateTime>(updatedAt),
@@ -1908,6 +2020,9 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     Value<int?> estimatedMinutes = const Value.absent(),
     double? sortOrder,
     Value<int?> milestoneId = const Value.absent(),
+    Value<String?> recurrenceRule = const Value.absent(),
+    Value<DateTime?> recurrenceAnchorDate = const Value.absent(),
+    bool? isHabit,
     bool? isCompleted,
     DateTime? createdAt,
     DateTime? updatedAt,
@@ -1933,6 +2048,13 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
         : this.estimatedMinutes,
     sortOrder: sortOrder ?? this.sortOrder,
     milestoneId: milestoneId.present ? milestoneId.value : this.milestoneId,
+    recurrenceRule: recurrenceRule.present
+        ? recurrenceRule.value
+        : this.recurrenceRule,
+    recurrenceAnchorDate: recurrenceAnchorDate.present
+        ? recurrenceAnchorDate.value
+        : this.recurrenceAnchorDate,
+    isHabit: isHabit ?? this.isHabit,
     isCompleted: isCompleted ?? this.isCompleted,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
@@ -1968,6 +2090,13 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
       milestoneId: data.milestoneId.present
           ? data.milestoneId.value
           : this.milestoneId,
+      recurrenceRule: data.recurrenceRule.present
+          ? data.recurrenceRule.value
+          : this.recurrenceRule,
+      recurrenceAnchorDate: data.recurrenceAnchorDate.present
+          ? data.recurrenceAnchorDate.value
+          : this.recurrenceAnchorDate,
+      isHabit: data.isHabit.present ? data.isHabit.value : this.isHabit,
       isCompleted: data.isCompleted.present
           ? data.isCompleted.value
           : this.isCompleted,
@@ -1996,6 +2125,9 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
           ..write('estimatedMinutes: $estimatedMinutes, ')
           ..write('sortOrder: $sortOrder, ')
           ..write('milestoneId: $milestoneId, ')
+          ..write('recurrenceRule: $recurrenceRule, ')
+          ..write('recurrenceAnchorDate: $recurrenceAnchorDate, ')
+          ..write('isHabit: $isHabit, ')
           ..write('isCompleted: $isCompleted, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
@@ -2005,7 +2137,7 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
   }
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     id,
     uuid,
     projectId,
@@ -2022,11 +2154,14 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
     estimatedMinutes,
     sortOrder,
     milestoneId,
+    recurrenceRule,
+    recurrenceAnchorDate,
+    isHabit,
     isCompleted,
     createdAt,
     updatedAt,
     deletedAt,
-  );
+  ]);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -2048,6 +2183,9 @@ class TaskTableData extends DataClass implements Insertable<TaskTableData> {
           other.estimatedMinutes == this.estimatedMinutes &&
           other.sortOrder == this.sortOrder &&
           other.milestoneId == this.milestoneId &&
+          other.recurrenceRule == this.recurrenceRule &&
+          other.recurrenceAnchorDate == this.recurrenceAnchorDate &&
+          other.isHabit == this.isHabit &&
           other.isCompleted == this.isCompleted &&
           other.createdAt == this.createdAt &&
           other.updatedAt == this.updatedAt &&
@@ -2071,6 +2209,9 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
   final Value<int?> estimatedMinutes;
   final Value<double> sortOrder;
   final Value<int?> milestoneId;
+  final Value<String?> recurrenceRule;
+  final Value<DateTime?> recurrenceAnchorDate;
+  final Value<bool> isHabit;
   final Value<bool> isCompleted;
   final Value<DateTime> createdAt;
   final Value<DateTime> updatedAt;
@@ -2092,6 +2233,9 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     this.estimatedMinutes = const Value.absent(),
     this.sortOrder = const Value.absent(),
     this.milestoneId = const Value.absent(),
+    this.recurrenceRule = const Value.absent(),
+    this.recurrenceAnchorDate = const Value.absent(),
+    this.isHabit = const Value.absent(),
     this.isCompleted = const Value.absent(),
     this.createdAt = const Value.absent(),
     this.updatedAt = const Value.absent(),
@@ -2114,6 +2258,9 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     this.estimatedMinutes = const Value.absent(),
     this.sortOrder = const Value.absent(),
     this.milestoneId = const Value.absent(),
+    this.recurrenceRule = const Value.absent(),
+    this.recurrenceAnchorDate = const Value.absent(),
+    this.isHabit = const Value.absent(),
     this.isCompleted = const Value.absent(),
     required DateTime createdAt,
     required DateTime updatedAt,
@@ -2142,6 +2289,9 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     Expression<int>? estimatedMinutes,
     Expression<double>? sortOrder,
     Expression<int>? milestoneId,
+    Expression<String>? recurrenceRule,
+    Expression<DateTime>? recurrenceAnchorDate,
+    Expression<bool>? isHabit,
     Expression<bool>? isCompleted,
     Expression<DateTime>? createdAt,
     Expression<DateTime>? updatedAt,
@@ -2165,6 +2315,10 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
       if (estimatedMinutes != null) 'estimated_minutes': estimatedMinutes,
       if (sortOrder != null) 'sort_order': sortOrder,
       if (milestoneId != null) 'milestone_id': milestoneId,
+      if (recurrenceRule != null) 'recurrence_rule': recurrenceRule,
+      if (recurrenceAnchorDate != null)
+        'recurrence_anchor_date': recurrenceAnchorDate,
+      if (isHabit != null) 'is_habit': isHabit,
       if (isCompleted != null) 'is_completed': isCompleted,
       if (createdAt != null) 'created_at': createdAt,
       if (updatedAt != null) 'updated_at': updatedAt,
@@ -2189,6 +2343,9 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     Value<int?>? estimatedMinutes,
     Value<double>? sortOrder,
     Value<int?>? milestoneId,
+    Value<String?>? recurrenceRule,
+    Value<DateTime?>? recurrenceAnchorDate,
+    Value<bool>? isHabit,
     Value<bool>? isCompleted,
     Value<DateTime>? createdAt,
     Value<DateTime>? updatedAt,
@@ -2212,6 +2369,9 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
       estimatedMinutes: estimatedMinutes ?? this.estimatedMinutes,
       sortOrder: sortOrder ?? this.sortOrder,
       milestoneId: milestoneId ?? this.milestoneId,
+      recurrenceRule: recurrenceRule ?? this.recurrenceRule,
+      recurrenceAnchorDate: recurrenceAnchorDate ?? this.recurrenceAnchorDate,
+      isHabit: isHabit ?? this.isHabit,
       isCompleted: isCompleted ?? this.isCompleted,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
@@ -2278,6 +2438,17 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
     if (milestoneId.present) {
       map['milestone_id'] = Variable<int>(milestoneId.value);
     }
+    if (recurrenceRule.present) {
+      map['recurrence_rule'] = Variable<String>(recurrenceRule.value);
+    }
+    if (recurrenceAnchorDate.present) {
+      map['recurrence_anchor_date'] = Variable<DateTime>(
+        recurrenceAnchorDate.value,
+      );
+    }
+    if (isHabit.present) {
+      map['is_habit'] = Variable<bool>(isHabit.value);
+    }
     if (isCompleted.present) {
       map['is_completed'] = Variable<bool>(isCompleted.value);
     }
@@ -2312,6 +2483,9 @@ class TaskTableCompanion extends UpdateCompanion<TaskTableData> {
           ..write('estimatedMinutes: $estimatedMinutes, ')
           ..write('sortOrder: $sortOrder, ')
           ..write('milestoneId: $milestoneId, ')
+          ..write('recurrenceRule: $recurrenceRule, ')
+          ..write('recurrenceAnchorDate: $recurrenceAnchorDate, ')
+          ..write('isHabit: $isHabit, ')
           ..write('isCompleted: $isCompleted, ')
           ..write('createdAt: $createdAt, ')
           ..write('updatedAt: $updatedAt, ')
@@ -4942,6 +5116,526 @@ class TaskTagTableCompanion extends UpdateCompanion<TaskTagTableData> {
   }
 }
 
+class $TaskCompletionTableTable extends TaskCompletionTable
+    with TableInfo<$TaskCompletionTableTable, TaskCompletionTableData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $TaskCompletionTableTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
+  @override
+  late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
+    'uuid',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
+  );
+  static const VerificationMeta _taskIdMeta = const VerificationMeta('taskId');
+  @override
+  late final GeneratedColumn<int> taskId = GeneratedColumn<int>(
+    'task_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES task_table (id) ON DELETE CASCADE',
+    ),
+  );
+  static const VerificationMeta _occurrenceDateMeta = const VerificationMeta(
+    'occurrenceDate',
+  );
+  @override
+  late final GeneratedColumn<String> occurrenceDate = GeneratedColumn<String>(
+    'occurrence_date',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _completedAtMeta = const VerificationMeta(
+    'completedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> completedAt = GeneratedColumn<DateTime>(
+    'completed_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta(
+    'createdAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _deletedAtMeta = const VerificationMeta(
+    'deletedAt',
+  );
+  @override
+  late final GeneratedColumn<DateTime> deletedAt = GeneratedColumn<DateTime>(
+    'deleted_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    uuid,
+    taskId,
+    occurrenceDate,
+    completedAt,
+    createdAt,
+    updatedAt,
+    deletedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'task_completion_table';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<TaskCompletionTableData> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('uuid')) {
+      context.handle(
+        _uuidMeta,
+        uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_uuidMeta);
+    }
+    if (data.containsKey('task_id')) {
+      context.handle(
+        _taskIdMeta,
+        taskId.isAcceptableOrUnknown(data['task_id']!, _taskIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_taskIdMeta);
+    }
+    if (data.containsKey('occurrence_date')) {
+      context.handle(
+        _occurrenceDateMeta,
+        occurrenceDate.isAcceptableOrUnknown(
+          data['occurrence_date']!,
+          _occurrenceDateMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_occurrenceDateMeta);
+    }
+    if (data.containsKey('completed_at')) {
+      context.handle(
+        _completedAtMeta,
+        completedAt.isAcceptableOrUnknown(
+          data['completed_at']!,
+          _completedAtMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_completedAtMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(
+        _createdAtMeta,
+        createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    if (data.containsKey('deleted_at')) {
+      context.handle(
+        _deletedAtMeta,
+        deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta),
+      );
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  TaskCompletionTableData map(
+    Map<String, dynamic> data, {
+    String? tablePrefix,
+  }) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return TaskCompletionTableData(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      uuid: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}uuid'],
+      )!,
+      taskId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}task_id'],
+      )!,
+      occurrenceDate: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}occurrence_date'],
+      )!,
+      completedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}completed_at'],
+      )!,
+      createdAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}created_at'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}updated_at'],
+      )!,
+      deletedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.dateTime,
+        data['${effectivePrefix}deleted_at'],
+      ),
+    );
+  }
+
+  @override
+  $TaskCompletionTableTable createAlias(String alias) {
+    return $TaskCompletionTableTable(attachedDatabase, alias);
+  }
+}
+
+class TaskCompletionTableData extends DataClass
+    implements Insertable<TaskCompletionTableData> {
+  final int id;
+  final String uuid;
+  final int taskId;
+
+  /// Local calendar date as `YYYY-MM-DD` (date-only, no time component).
+  final String occurrenceDate;
+  final DateTime completedAt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? deletedAt;
+  const TaskCompletionTableData({
+    required this.id,
+    required this.uuid,
+    required this.taskId,
+    required this.occurrenceDate,
+    required this.completedAt,
+    required this.createdAt,
+    required this.updatedAt,
+    this.deletedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['uuid'] = Variable<String>(uuid);
+    map['task_id'] = Variable<int>(taskId);
+    map['occurrence_date'] = Variable<String>(occurrenceDate);
+    map['completed_at'] = Variable<DateTime>(completedAt);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<DateTime>(deletedAt);
+    }
+    return map;
+  }
+
+  TaskCompletionTableCompanion toCompanion(bool nullToAbsent) {
+    return TaskCompletionTableCompanion(
+      id: Value(id),
+      uuid: Value(uuid),
+      taskId: Value(taskId),
+      occurrenceDate: Value(occurrenceDate),
+      completedAt: Value(completedAt),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent
+          ? const Value.absent()
+          : Value(deletedAt),
+    );
+  }
+
+  factory TaskCompletionTableData.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return TaskCompletionTableData(
+      id: serializer.fromJson<int>(json['id']),
+      uuid: serializer.fromJson<String>(json['uuid']),
+      taskId: serializer.fromJson<int>(json['taskId']),
+      occurrenceDate: serializer.fromJson<String>(json['occurrenceDate']),
+      completedAt: serializer.fromJson<DateTime>(json['completedAt']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+      deletedAt: serializer.fromJson<DateTime?>(json['deletedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'uuid': serializer.toJson<String>(uuid),
+      'taskId': serializer.toJson<int>(taskId),
+      'occurrenceDate': serializer.toJson<String>(occurrenceDate),
+      'completedAt': serializer.toJson<DateTime>(completedAt),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+      'deletedAt': serializer.toJson<DateTime?>(deletedAt),
+    };
+  }
+
+  TaskCompletionTableData copyWith({
+    int? id,
+    String? uuid,
+    int? taskId,
+    String? occurrenceDate,
+    DateTime? completedAt,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    Value<DateTime?> deletedAt = const Value.absent(),
+  }) => TaskCompletionTableData(
+    id: id ?? this.id,
+    uuid: uuid ?? this.uuid,
+    taskId: taskId ?? this.taskId,
+    occurrenceDate: occurrenceDate ?? this.occurrenceDate,
+    completedAt: completedAt ?? this.completedAt,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
+  );
+  TaskCompletionTableData copyWithCompanion(TaskCompletionTableCompanion data) {
+    return TaskCompletionTableData(
+      id: data.id.present ? data.id.value : this.id,
+      uuid: data.uuid.present ? data.uuid.value : this.uuid,
+      taskId: data.taskId.present ? data.taskId.value : this.taskId,
+      occurrenceDate: data.occurrenceDate.present
+          ? data.occurrenceDate.value
+          : this.occurrenceDate,
+      completedAt: data.completedAt.present
+          ? data.completedAt.value
+          : this.completedAt,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TaskCompletionTableData(')
+          ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
+          ..write('taskId: $taskId, ')
+          ..write('occurrenceDate: $occurrenceDate, ')
+          ..write('completedAt: $completedAt, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    uuid,
+    taskId,
+    occurrenceDate,
+    completedAt,
+    createdAt,
+    updatedAt,
+    deletedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is TaskCompletionTableData &&
+          other.id == this.id &&
+          other.uuid == this.uuid &&
+          other.taskId == this.taskId &&
+          other.occurrenceDate == this.occurrenceDate &&
+          other.completedAt == this.completedAt &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
+}
+
+class TaskCompletionTableCompanion
+    extends UpdateCompanion<TaskCompletionTableData> {
+  final Value<int> id;
+  final Value<String> uuid;
+  final Value<int> taskId;
+  final Value<String> occurrenceDate;
+  final Value<DateTime> completedAt;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<DateTime?> deletedAt;
+  const TaskCompletionTableCompanion({
+    this.id = const Value.absent(),
+    this.uuid = const Value.absent(),
+    this.taskId = const Value.absent(),
+    this.occurrenceDate = const Value.absent(),
+    this.completedAt = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
+  });
+  TaskCompletionTableCompanion.insert({
+    this.id = const Value.absent(),
+    required String uuid,
+    required int taskId,
+    required String occurrenceDate,
+    required DateTime completedAt,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    this.deletedAt = const Value.absent(),
+  }) : uuid = Value(uuid),
+       taskId = Value(taskId),
+       occurrenceDate = Value(occurrenceDate),
+       completedAt = Value(completedAt),
+       createdAt = Value(createdAt),
+       updatedAt = Value(updatedAt);
+  static Insertable<TaskCompletionTableData> custom({
+    Expression<int>? id,
+    Expression<String>? uuid,
+    Expression<int>? taskId,
+    Expression<String>? occurrenceDate,
+    Expression<DateTime>? completedAt,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<DateTime>? deletedAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (uuid != null) 'uuid': uuid,
+      if (taskId != null) 'task_id': taskId,
+      if (occurrenceDate != null) 'occurrence_date': occurrenceDate,
+      if (completedAt != null) 'completed_at': completedAt,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
+    });
+  }
+
+  TaskCompletionTableCompanion copyWith({
+    Value<int>? id,
+    Value<String>? uuid,
+    Value<int>? taskId,
+    Value<String>? occurrenceDate,
+    Value<DateTime>? completedAt,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+    Value<DateTime?>? deletedAt,
+  }) {
+    return TaskCompletionTableCompanion(
+      id: id ?? this.id,
+      uuid: uuid ?? this.uuid,
+      taskId: taskId ?? this.taskId,
+      occurrenceDate: occurrenceDate ?? this.occurrenceDate,
+      completedAt: completedAt ?? this.completedAt,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (uuid.present) {
+      map['uuid'] = Variable<String>(uuid.value);
+    }
+    if (taskId.present) {
+      map['task_id'] = Variable<int>(taskId.value);
+    }
+    if (occurrenceDate.present) {
+      map['occurrence_date'] = Variable<String>(occurrenceDate.value);
+    }
+    if (completedAt.present) {
+      map['completed_at'] = Variable<DateTime>(completedAt.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<DateTime>(deletedAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('TaskCompletionTableCompanion(')
+          ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
+          ..write('taskId: $taskId, ')
+          ..write('occurrenceDate: $occurrenceDate, ')
+          ..write('completedAt: $completedAt, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -4957,6 +5651,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
       $NotificationInboxTableTable(this);
   late final $TagTableTable tagTable = $TagTableTable(this);
   late final $TaskTagTableTable taskTagTable = $TaskTagTableTable(this);
+  late final $TaskCompletionTableTable taskCompletionTable =
+      $TaskCompletionTableTable(this);
   late final Index projectCreatedAtIdx = Index(
     'project_created_at_idx',
     'CREATE INDEX project_created_at_idx ON project_table (created_at)',
@@ -5077,6 +5773,22 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'milestone_deleted_at_idx',
     'CREATE INDEX milestone_deleted_at_idx ON milestone_table (deleted_at)',
   );
+  late final Index taskCompletionUuidIdx = Index(
+    'task_completion_uuid_idx',
+    'CREATE UNIQUE INDEX task_completion_uuid_idx ON task_completion_table (uuid)',
+  );
+  late final Index taskCompletionTaskIdIdx = Index(
+    'task_completion_task_id_idx',
+    'CREATE INDEX task_completion_task_id_idx ON task_completion_table (task_id)',
+  );
+  late final Index taskCompletionOccurrenceDateIdx = Index(
+    'task_completion_occurrence_date_idx',
+    'CREATE INDEX task_completion_occurrence_date_idx ON task_completion_table (occurrence_date)',
+  );
+  late final Index taskCompletionDeletedAtIdx = Index(
+    'task_completion_deleted_at_idx',
+    'CREATE INDEX task_completion_deleted_at_idx ON task_completion_table (deleted_at)',
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -5091,6 +5803,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     notificationInboxTable,
     tagTable,
     taskTagTable,
+    taskCompletionTable,
     projectCreatedAtIdx,
     projectUpdatedAtIdx,
     projectUuidIdx,
@@ -5121,6 +5834,10 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     milestoneUuidIdx,
     milestoneProjectIdIdx,
     milestoneDeletedAtIdx,
+    taskCompletionUuidIdx,
+    taskCompletionTaskIdIdx,
+    taskCompletionOccurrenceDateIdx,
+    taskCompletionDeletedAtIdx,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -5172,6 +5889,13 @@ abstract class _$AppDatabase extends GeneratedDatabase {
         limitUpdateKind: UpdateKind.delete,
       ),
       result: [TableUpdate('task_tag_table', kind: UpdateKind.delete)],
+    ),
+    WritePropagation(
+      on: TableUpdateQuery.onTableName(
+        'task_table',
+        limitUpdateKind: UpdateKind.delete,
+      ),
+      result: [TableUpdate('task_completion_table', kind: UpdateKind.delete)],
     ),
   ]);
 }
@@ -6174,6 +6898,9 @@ typedef $$TaskTableTableCreateCompanionBuilder =
       Value<int?> estimatedMinutes,
       Value<double> sortOrder,
       Value<int?> milestoneId,
+      Value<String?> recurrenceRule,
+      Value<DateTime?> recurrenceAnchorDate,
+      Value<bool> isHabit,
       Value<bool> isCompleted,
       required DateTime createdAt,
       required DateTime updatedAt,
@@ -6197,6 +6924,9 @@ typedef $$TaskTableTableUpdateCompanionBuilder =
       Value<int?> estimatedMinutes,
       Value<double> sortOrder,
       Value<int?> milestoneId,
+      Value<String?> recurrenceRule,
+      Value<DateTime?> recurrenceAnchorDate,
+      Value<bool> isHabit,
       Value<bool> isCompleted,
       Value<DateTime> createdAt,
       Value<DateTime> updatedAt,
@@ -6297,6 +7027,30 @@ final class $$TaskTableTableReferences
       manager.$state.copyWith(prefetchedData: cache),
     );
   }
+
+  static MultiTypedResultKey<
+    $TaskCompletionTableTable,
+    List<TaskCompletionTableData>
+  >
+  _taskCompletionTableRefsTable(_$AppDatabase db) =>
+      MultiTypedResultKey.fromTable(
+        db.taskCompletionTable,
+        aliasName: 'task_table__id__task_completion_table__task_id',
+      );
+
+  $$TaskCompletionTableTableProcessedTableManager get taskCompletionTableRefs {
+    final manager = $$TaskCompletionTableTableTableManager(
+      $_db,
+      $_db.taskCompletionTable,
+    ).filter((f) => f.taskId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(
+      _taskCompletionTableRefsTable($_db),
+    );
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
 }
 
 class $$TaskTableTableFilterComposer
@@ -6373,6 +7127,21 @@ class $$TaskTableTableFilterComposer
 
   ColumnFilters<double> get sortOrder => $composableBuilder(
     column: $table.sortOrder,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get recurrenceRule => $composableBuilder(
+    column: $table.recurrenceRule,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get recurrenceAnchorDate => $composableBuilder(
+    column: $table.recurrenceAnchorDate,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<bool> get isHabit => $composableBuilder(
+    column: $table.isHabit,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -6514,6 +7283,31 @@ class $$TaskTableTableFilterComposer
     );
     return f(composer);
   }
+
+  Expression<bool> taskCompletionTableRefs(
+    Expression<bool> Function($$TaskCompletionTableTableFilterComposer f) f,
+  ) {
+    final $$TaskCompletionTableTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.taskCompletionTable,
+      getReferencedColumn: (t) => t.taskId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TaskCompletionTableTableFilterComposer(
+            $db: $db,
+            $table: $db.taskCompletionTable,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$TaskTableTableOrderingComposer
@@ -6587,6 +7381,21 @@ class $$TaskTableTableOrderingComposer
 
   ColumnOrderings<double> get sortOrder => $composableBuilder(
     column: $table.sortOrder,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get recurrenceRule => $composableBuilder(
+    column: $table.recurrenceRule,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get recurrenceAnchorDate => $composableBuilder(
+    column: $table.recurrenceAnchorDate,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<bool> get isHabit => $composableBuilder(
+    column: $table.isHabit,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -6737,6 +7546,19 @@ class $$TaskTableTableAnnotationComposer
   GeneratedColumn<double> get sortOrder =>
       $composableBuilder(column: $table.sortOrder, builder: (column) => column);
 
+  GeneratedColumn<String> get recurrenceRule => $composableBuilder(
+    column: $table.recurrenceRule,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get recurrenceAnchorDate => $composableBuilder(
+    column: $table.recurrenceAnchorDate,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<bool> get isHabit =>
+      $composableBuilder(column: $table.isHabit, builder: (column) => column);
+
   GeneratedColumn<bool> get isCompleted => $composableBuilder(
     column: $table.isCompleted,
     builder: (column) => column,
@@ -6870,6 +7692,32 @@ class $$TaskTableTableAnnotationComposer
     );
     return f(composer);
   }
+
+  Expression<T> taskCompletionTableRefs<T extends Object>(
+    Expression<T> Function($$TaskCompletionTableTableAnnotationComposer a) f,
+  ) {
+    final $$TaskCompletionTableTableAnnotationComposer composer =
+        $composerBuilder(
+          composer: this,
+          getCurrentColumn: (t) => t.id,
+          referencedTable: $db.taskCompletionTable,
+          getReferencedColumn: (t) => t.taskId,
+          builder:
+              (
+                joinBuilder, {
+                $addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer,
+              }) => $$TaskCompletionTableTableAnnotationComposer(
+                $db: $db,
+                $table: $db.taskCompletionTable,
+                $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+                joinBuilder: joinBuilder,
+                $removeJoinBuilderFromRootComposer:
+                    $removeJoinBuilderFromRootComposer,
+              ),
+        );
+    return f(composer);
+  }
 }
 
 class $$TaskTableTableTableManager
@@ -6891,6 +7739,7 @@ class $$TaskTableTableTableManager
             bool milestoneId,
             bool focusSessionTableRefs,
             bool taskTagTableRefs,
+            bool taskCompletionTableRefs,
           })
         > {
   $$TaskTableTableTableManager(_$AppDatabase db, $TaskTableTable table)
@@ -6922,6 +7771,9 @@ class $$TaskTableTableTableManager
                 Value<int?> estimatedMinutes = const Value.absent(),
                 Value<double> sortOrder = const Value.absent(),
                 Value<int?> milestoneId = const Value.absent(),
+                Value<String?> recurrenceRule = const Value.absent(),
+                Value<DateTime?> recurrenceAnchorDate = const Value.absent(),
+                Value<bool> isHabit = const Value.absent(),
                 Value<bool> isCompleted = const Value.absent(),
                 Value<DateTime> createdAt = const Value.absent(),
                 Value<DateTime> updatedAt = const Value.absent(),
@@ -6943,6 +7795,9 @@ class $$TaskTableTableTableManager
                 estimatedMinutes: estimatedMinutes,
                 sortOrder: sortOrder,
                 milestoneId: milestoneId,
+                recurrenceRule: recurrenceRule,
+                recurrenceAnchorDate: recurrenceAnchorDate,
+                isHabit: isHabit,
                 isCompleted: isCompleted,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
@@ -6966,6 +7821,9 @@ class $$TaskTableTableTableManager
                 Value<int?> estimatedMinutes = const Value.absent(),
                 Value<double> sortOrder = const Value.absent(),
                 Value<int?> milestoneId = const Value.absent(),
+                Value<String?> recurrenceRule = const Value.absent(),
+                Value<DateTime?> recurrenceAnchorDate = const Value.absent(),
+                Value<bool> isHabit = const Value.absent(),
                 Value<bool> isCompleted = const Value.absent(),
                 required DateTime createdAt,
                 required DateTime updatedAt,
@@ -6987,6 +7845,9 @@ class $$TaskTableTableTableManager
                 estimatedMinutes: estimatedMinutes,
                 sortOrder: sortOrder,
                 milestoneId: milestoneId,
+                recurrenceRule: recurrenceRule,
+                recurrenceAnchorDate: recurrenceAnchorDate,
+                isHabit: isHabit,
                 isCompleted: isCompleted,
                 createdAt: createdAt,
                 updatedAt: updatedAt,
@@ -7007,12 +7868,14 @@ class $$TaskTableTableTableManager
                 milestoneId = false,
                 focusSessionTableRefs = false,
                 taskTagTableRefs = false,
+                taskCompletionTableRefs = false,
               }) {
                 return PrefetchHooks(
                   db: db,
                   explicitlyWatchedTables: [
                     if (focusSessionTableRefs) db.focusSessionTable,
                     if (taskTagTableRefs) db.taskTagTable,
+                    if (taskCompletionTableRefs) db.taskCompletionTable,
                   ],
                   addJoins:
                       <
@@ -7116,6 +7979,27 @@ class $$TaskTableTableTableManager
                               ),
                           typedResults: items,
                         ),
+                      if (taskCompletionTableRefs)
+                        await $_getPrefetchedData<
+                          TaskTableData,
+                          $TaskTableTable,
+                          TaskCompletionTableData
+                        >(
+                          currentTable: table,
+                          referencedTable: $$TaskTableTableReferences
+                              ._taskCompletionTableRefsTable(db),
+                          managerFromTypedResult: (p0) =>
+                              $$TaskTableTableReferences(
+                                db,
+                                table,
+                                p0,
+                              ).taskCompletionTableRefs,
+                          referencedItemsForCurrentItem:
+                              (item, referencedItems) => referencedItems.where(
+                                (e) => e.taskId == item.id,
+                              ),
+                          typedResults: items,
+                        ),
                     ];
                   },
                 );
@@ -7142,6 +8026,7 @@ typedef $$TaskTableTableProcessedTableManager =
         bool milestoneId,
         bool focusSessionTableRefs,
         bool taskTagTableRefs,
+        bool taskCompletionTableRefs,
       })
     >;
 typedef $$FocusSessionTableTableCreateCompanionBuilder =
@@ -8979,6 +9864,397 @@ typedef $$TaskTagTableTableProcessedTableManager =
       TaskTagTableData,
       PrefetchHooks Function({bool taskId, bool tagId})
     >;
+typedef $$TaskCompletionTableTableCreateCompanionBuilder =
+    TaskCompletionTableCompanion Function({
+      Value<int> id,
+      required String uuid,
+      required int taskId,
+      required String occurrenceDate,
+      required DateTime completedAt,
+      required DateTime createdAt,
+      required DateTime updatedAt,
+      Value<DateTime?> deletedAt,
+    });
+typedef $$TaskCompletionTableTableUpdateCompanionBuilder =
+    TaskCompletionTableCompanion Function({
+      Value<int> id,
+      Value<String> uuid,
+      Value<int> taskId,
+      Value<String> occurrenceDate,
+      Value<DateTime> completedAt,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<DateTime?> deletedAt,
+    });
+
+final class $$TaskCompletionTableTableReferences
+    extends
+        BaseReferences<
+          _$AppDatabase,
+          $TaskCompletionTableTable,
+          TaskCompletionTableData
+        > {
+  $$TaskCompletionTableTableReferences(
+    super.$_db,
+    super.$_table,
+    super.$_typedResult,
+  );
+
+  static $TaskTableTable _taskIdTable(_$AppDatabase db) => db.taskTable
+      .createAlias('task_completion_table__task_id__task_table__id');
+
+  $$TaskTableTableProcessedTableManager get taskId {
+    final $_column = $_itemColumn<int>('task_id')!;
+
+    final manager = $$TaskTableTableTableManager(
+      $_db,
+      $_db.taskTable,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_taskIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$TaskCompletionTableTableFilterComposer
+    extends Composer<_$AppDatabase, $TaskCompletionTableTable> {
+  $$TaskCompletionTableTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get uuid => $composableBuilder(
+    column: $table.uuid,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get occurrenceDate => $composableBuilder(
+    column: $table.occurrenceDate,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<DateTime> get deletedAt => $composableBuilder(
+    column: $table.deletedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  $$TaskTableTableFilterComposer get taskId {
+    final $$TaskTableTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.taskId,
+      referencedTable: $db.taskTable,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TaskTableTableFilterComposer(
+            $db: $db,
+            $table: $db.taskTable,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$TaskCompletionTableTableOrderingComposer
+    extends Composer<_$AppDatabase, $TaskCompletionTableTable> {
+  $$TaskCompletionTableTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get uuid => $composableBuilder(
+    column: $table.uuid,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get occurrenceDate => $composableBuilder(
+    column: $table.occurrenceDate,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+    column: $table.createdAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<DateTime> get deletedAt => $composableBuilder(
+    column: $table.deletedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  $$TaskTableTableOrderingComposer get taskId {
+    final $$TaskTableTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.taskId,
+      referencedTable: $db.taskTable,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TaskTableTableOrderingComposer(
+            $db: $db,
+            $table: $db.taskTable,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$TaskCompletionTableTableAnnotationComposer
+    extends Composer<_$AppDatabase, $TaskCompletionTableTable> {
+  $$TaskCompletionTableTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get uuid =>
+      $composableBuilder(column: $table.uuid, builder: (column) => column);
+
+  GeneratedColumn<String> get occurrenceDate => $composableBuilder(
+    column: $table.occurrenceDate,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get completedAt => $composableBuilder(
+    column: $table.completedAt,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => column);
+
+  $$TaskTableTableAnnotationComposer get taskId {
+    final $$TaskTableTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.taskId,
+      referencedTable: $db.taskTable,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$TaskTableTableAnnotationComposer(
+            $db: $db,
+            $table: $db.taskTable,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$TaskCompletionTableTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $TaskCompletionTableTable,
+          TaskCompletionTableData,
+          $$TaskCompletionTableTableFilterComposer,
+          $$TaskCompletionTableTableOrderingComposer,
+          $$TaskCompletionTableTableAnnotationComposer,
+          $$TaskCompletionTableTableCreateCompanionBuilder,
+          $$TaskCompletionTableTableUpdateCompanionBuilder,
+          (TaskCompletionTableData, $$TaskCompletionTableTableReferences),
+          TaskCompletionTableData,
+          PrefetchHooks Function({bool taskId})
+        > {
+  $$TaskCompletionTableTableTableManager(
+    _$AppDatabase db,
+    $TaskCompletionTableTable table,
+  ) : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$TaskCompletionTableTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$TaskCompletionTableTableOrderingComposer(
+                $db: db,
+                $table: table,
+              ),
+          createComputedFieldComposer: () =>
+              $$TaskCompletionTableTableAnnotationComposer(
+                $db: db,
+                $table: table,
+              ),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> uuid = const Value.absent(),
+                Value<int> taskId = const Value.absent(),
+                Value<String> occurrenceDate = const Value.absent(),
+                Value<DateTime> completedAt = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<DateTime?> deletedAt = const Value.absent(),
+              }) => TaskCompletionTableCompanion(
+                id: id,
+                uuid: uuid,
+                taskId: taskId,
+                occurrenceDate: occurrenceDate,
+                completedAt: completedAt,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                deletedAt: deletedAt,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String uuid,
+                required int taskId,
+                required String occurrenceDate,
+                required DateTime completedAt,
+                required DateTime createdAt,
+                required DateTime updatedAt,
+                Value<DateTime?> deletedAt = const Value.absent(),
+              }) => TaskCompletionTableCompanion.insert(
+                id: id,
+                uuid: uuid,
+                taskId: taskId,
+                occurrenceDate: occurrenceDate,
+                completedAt: completedAt,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                deletedAt: deletedAt,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$TaskCompletionTableTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({taskId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (taskId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.taskId,
+                                referencedTable:
+                                    $$TaskCompletionTableTableReferences
+                                        ._taskIdTable(db),
+                                referencedColumn:
+                                    $$TaskCompletionTableTableReferences
+                                        ._taskIdTable(db)
+                                        .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$TaskCompletionTableTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $TaskCompletionTableTable,
+      TaskCompletionTableData,
+      $$TaskCompletionTableTableFilterComposer,
+      $$TaskCompletionTableTableOrderingComposer,
+      $$TaskCompletionTableTableAnnotationComposer,
+      $$TaskCompletionTableTableCreateCompanionBuilder,
+      $$TaskCompletionTableTableUpdateCompanionBuilder,
+      (TaskCompletionTableData, $$TaskCompletionTableTableReferences),
+      TaskCompletionTableData,
+      PrefetchHooks Function({bool taskId})
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -9007,4 +10283,6 @@ class $AppDatabaseManager {
       $$TagTableTableTableManager(_db, _db.tagTable);
   $$TaskTagTableTableTableManager get taskTagTable =>
       $$TaskTagTableTableTableManager(_db, _db.taskTagTable);
+  $$TaskCompletionTableTableTableManager get taskCompletionTable =>
+      $$TaskCompletionTableTableTableManager(_db, _db.taskCompletionTable);
 }

--- a/lib/features/projects/data/datasources/project_local_datasource.dart
+++ b/lib/features/projects/data/datasources/project_local_datasource.dart
@@ -84,6 +84,13 @@ class ProjectLocalDataSourceImpl implements IProjectLocalDataSource {
             FocusSessionTableCompanion(deletedAt: Value(now)),
           );
 
+          await (_db
+                  .update(_db.taskCompletionTable)
+                ..where((t) => t.taskId.isIn(taskIds) & t.deletedAt.isNull()))
+              .write(
+                TaskCompletionTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
+              );
+
           await (_db.delete(_db.taskTagTable)..where((t) => t.taskId.isIn(taskIds))).go();
 
           await (_db.update(_db.taskTable)..where((t) => t.projectId.equals(id) & t.deletedAt.isNull())).write(

--- a/lib/features/sync/domain/entities/sync_data.dart
+++ b/lib/features/sync/domain/entities/sync_data.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import '../../../../core/utils/id_utils.dart';
+import '../../../tasks/domain/entities/recurrence_rule.dart';
 import '../../../tasks/domain/entities/task.dart';
 import '../../../tasks/domain/entities/task_priority.dart';
 import '../../../tasks/domain/entities/task_reminder_mode.dart';
@@ -153,6 +154,9 @@ class SyncTaskData {
   final int? estimatedMinutes;
   final double sortOrder;
   final int? milestoneId;
+  final String? recurrenceRuleJson;
+  final DateTime? recurrenceAnchorDate;
+  final bool isHabit;
   final bool isCompleted;
   final DateTime createdAt;
   final DateTime updatedAt;
@@ -175,6 +179,9 @@ class SyncTaskData {
     this.estimatedMinutes,
     this.sortOrder = 0,
     this.milestoneId,
+    this.recurrenceRuleJson,
+    this.recurrenceAnchorDate,
+    this.isHabit = false,
     required this.isCompleted,
     required this.createdAt,
     required this.updatedAt,
@@ -201,6 +208,11 @@ class SyncTaskData {
       estimatedMinutes: json['estimatedMinutes'] as int?,
       sortOrder: (json['sortOrder'] as num?)?.toDouble() ?? 0,
       milestoneId: json['milestoneId'] as int?,
+      recurrenceRuleJson: json['recurrenceRuleJson'] as String?,
+      recurrenceAnchorDate: json['recurrenceAnchorDate'] != null
+          ? DateTime.parse(json['recurrenceAnchorDate'] as String)
+          : null,
+      isHabit: json['isHabit'] as bool? ?? false,
       isCompleted: isCompleted,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
@@ -225,6 +237,9 @@ class SyncTaskData {
     'estimatedMinutes': estimatedMinutes,
     'sortOrder': sortOrder,
     'milestoneId': milestoneId,
+    'recurrenceRuleJson': recurrenceRuleJson,
+    'recurrenceAnchorDate': recurrenceAnchorDate?.toIso8601String(),
+    'isHabit': isHabit,
     'isCompleted': isCompleted,
     'createdAt': createdAt.toIso8601String(),
     'updatedAt': updatedAt.toIso8601String(),
@@ -249,6 +264,9 @@ class SyncTaskData {
       estimatedMinutes: task.estimatedMinutes,
       sortOrder: task.sortOrder,
       milestoneId: task.milestoneId,
+      recurrenceRuleJson: task.recurrenceRule?.toJson(),
+      recurrenceAnchorDate: task.recurrenceAnchorDate,
+      isHabit: task.isHabit,
       isCompleted: task.isCompleted,
       createdAt: task.createdAt,
       updatedAt: task.updatedAt,
@@ -279,6 +297,9 @@ class SyncTaskData {
       estimatedMinutes: estimatedMinutes,
       sortOrder: sortOrder,
       milestoneId: milestoneId,
+      recurrenceRule: RecurrenceRule.tryParseJson(recurrenceRuleJson),
+      recurrenceAnchorDate: recurrenceAnchorDate,
+      isHabit: isHabit,
       createdAt: createdAt,
       updatedAt: updatedAt,
       deletedAt: deletedAt,

--- a/lib/features/sync/domain/services/sync_purge_service.dart
+++ b/lib/features/sync/domain/services/sync_purge_service.dart
@@ -21,12 +21,16 @@ class SyncPurgeService {
 
   /// Hard-deletes soft-deleted rows whose [deletedAt] is older than [retention].
   ///
-  /// Order respects FK dependents: task_tag → sessions → tasks → milestones →
-  /// tags → projects.
+  /// Order respects FK dependents: completions → task_tag → sessions → tasks →
+  /// milestones → tags → projects.
   Future<Result<int>> purgeExpiredTombstones({DateTime? now}) async {
     try {
       final cutoff = (now ?? DateTime.now()).subtract(retention);
       return await _db.transaction(() async {
+        final completions = await (_db.delete(
+          _db.taskCompletionTable,
+        )..where((t) => t.deletedAt.isNotNull() & t.deletedAt.isSmallerThanValue(cutoff))).go();
+
         // Remove junction rows for tasks about to be purged.
         final expiredTaskIds =
             await (_db.selectOnly(_db.taskTable)
@@ -36,6 +40,8 @@ class SyncPurgeService {
                 .get();
         var taskTags = 0;
         if (expiredTaskIds.isNotEmpty) {
+          // Also hard-delete any remaining completions for purged tasks.
+          await (_db.delete(_db.taskCompletionTable)..where((t) => t.taskId.isIn(expiredTaskIds))).go();
           taskTags = await (_db.delete(_db.taskTagTable)..where((t) => t.taskId.isIn(expiredTaskIds))).go();
         }
 
@@ -64,10 +70,10 @@ class SyncPurgeService {
         final projects = await (_db.delete(
           _db.projectTable,
         )..where((t) => t.deletedAt.isNotNull() & t.deletedAt.isSmallerThanValue(cutoff))).go();
-        final total = taskTags + sessions + tasks + milestones + tags + projects;
+        final total = completions + taskTags + sessions + tasks + milestones + tags + projects;
         _log.info(
           'Purged $total expired tombstones '
-          '(taskTags=$taskTags, sessions=$sessions, tasks=$tasks, '
+          '(completions=$completions, taskTags=$taskTags, sessions=$sessions, tasks=$tasks, '
           'milestones=$milestones, tags=$tags, projects=$projects)',
           tag: 'SyncPurgeService',
         );

--- a/lib/features/tasks/data/datasources/task_local_datasource.dart
+++ b/lib/features/tasks/data/datasources/task_local_datasource.dart
@@ -35,6 +35,17 @@ abstract class ITaskLocalDataSource {
     TaskStatus? statusFilter,
     TaskCompletionFilter completionFilter,
   });
+
+  Future<List<TaskCompletionTableData>> getCompletionsForTask(int taskId);
+
+  Future<TaskCompletionTableData?> getCompletion(int taskId, String occurrenceDateKey);
+
+  /// Inserts or undeletes a completion for `(taskId, occurrenceDate)`.
+  Future<TaskCompletionTableData> upsertCompletion(TaskCompletionTableCompanion companion);
+
+  Future<void> softDeleteCompletion(int id);
+
+  Stream<List<TaskCompletionTableData>> watchCompletionsForTask(int taskId);
 }
 
 class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
@@ -80,9 +91,13 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
   @override
   Future<List<TaskTableData>> getTasksWithDeadlines() async {
     try {
-      return await (_db.select(
-        _db.taskTable,
-      )..where((t) => t.endDate.isNotNull() & t.status.equalsValue(TaskStatus.done).not() & t.deletedAt.isNull())).get();
+      return await (_db.select(_db.taskTable)..where(
+            (t) =>
+                (t.endDate.isNotNull() | t.recurrenceRule.isNotNull()) &
+                t.status.equalsValue(TaskStatus.done).not() &
+                t.deletedAt.isNull(),
+          ))
+          .get();
     } catch (e, st) {
       _log.error('getTasksWithDeadlines failed', tag: 'TaskLocalDS', error: e, stackTrace: st);
       rethrow;
@@ -111,7 +126,7 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
 
   @override
   Future<void> deleteTask(int id) async {
-    // Soft-delete the task, all descendants, and their focus sessions.
+    // Soft-delete the task, all descendants, their completions, and sessions.
     try {
       await _db.transaction(() async {
         final now = DateTime.now();
@@ -120,6 +135,13 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
 
         await (_db.update(_db.focusSessionTable)..where((t) => t.taskId.isIn(idsToDelete) & t.deletedAt.isNull()))
             .write(FocusSessionTableCompanion(deletedAt: Value(now)));
+
+        await (_db
+                .update(_db.taskCompletionTable)
+              ..where((t) => t.taskId.isIn(idsToDelete) & t.deletedAt.isNull()))
+            .write(
+              TaskCompletionTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
+            );
 
         await (_db.delete(_db.taskTagTable)..where((t) => t.taskId.isIn(idsToDelete))).go();
 
@@ -158,7 +180,12 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
   @override
   Stream<List<TaskTableData>> watchTasksWithDeadlines() {
     return (_db.select(_db.taskTable)
-          ..where((t) => t.endDate.isNotNull() & t.status.equalsValue(TaskStatus.done).not() & t.deletedAt.isNull())
+          ..where(
+            (t) =>
+                (t.endDate.isNotNull() | t.recurrenceRule.isNotNull()) &
+                t.status.equalsValue(TaskStatus.done).not() &
+                t.deletedAt.isNull(),
+          )
           ..orderBy([(t) => OrderingTerm.asc(t.endDate)]))
         .watch();
   }
@@ -269,5 +296,95 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
     }
 
     return query.watch();
+  }
+
+  @override
+  Future<List<TaskCompletionTableData>> getCompletionsForTask(int taskId) async {
+    try {
+      return await (_db.select(_db.taskCompletionTable)
+            ..where((t) => t.taskId.equals(taskId) & t.deletedAt.isNull())
+            ..orderBy([(t) => OrderingTerm.asc(t.occurrenceDate)]))
+          .get();
+    } catch (e, st) {
+      _log.error('getCompletionsForTask failed', tag: 'TaskLocalDS', error: e, stackTrace: st);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<TaskCompletionTableData?> getCompletion(int taskId, String occurrenceDateKey) async {
+    try {
+      return await (_db.select(_db.taskCompletionTable)..where(
+            (t) =>
+                t.taskId.equals(taskId) & t.occurrenceDate.equals(occurrenceDateKey) & t.deletedAt.isNull(),
+          ))
+          .getSingleOrNull();
+    } catch (e, st) {
+      _log.error('getCompletion failed', tag: 'TaskLocalDS', error: e, stackTrace: st);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<TaskCompletionTableData> upsertCompletion(TaskCompletionTableCompanion companion) async {
+    try {
+      return await _db.transaction(() async {
+        final taskId = companion.taskId.value;
+        final dateKey = companion.occurrenceDate.value;
+
+        // Prefer an existing live row (idempotent complete).
+        final live = await (_db.select(_db.taskCompletionTable)..where(
+              (t) => t.taskId.equals(taskId) & t.occurrenceDate.equals(dateKey) & t.deletedAt.isNull(),
+            ))
+            .getSingleOrNull();
+        if (live != null) return live;
+
+        // Revive a soft-deleted row for the same occurrence if present.
+        final tombstoned = await (_db.select(_db.taskCompletionTable)..where(
+              (t) => t.taskId.equals(taskId) & t.occurrenceDate.equals(dateKey) & t.deletedAt.isNotNull(),
+            ))
+            .getSingleOrNull();
+        if (tombstoned != null) {
+          final now = DateTime.now();
+          await (_db.update(_db.taskCompletionTable)..where((t) => t.id.equals(tombstoned.id))).write(
+            TaskCompletionTableCompanion(
+              completedAt: companion.completedAt.present ? companion.completedAt : Value(now),
+              updatedAt: companion.updatedAt.present ? companion.updatedAt : Value(now),
+              deletedAt: const Value(null),
+            ),
+          );
+          return (await (_db.select(
+            _db.taskCompletionTable,
+          )..where((t) => t.id.equals(tombstoned.id))).getSingle());
+        }
+
+        final id = await _db.into(_db.taskCompletionTable).insert(companion);
+        return (await (_db.select(_db.taskCompletionTable)..where((t) => t.id.equals(id))).getSingle());
+      });
+    } catch (e, st) {
+      _log.error('upsertCompletion failed', tag: 'TaskLocalDS', error: e, stackTrace: st);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> softDeleteCompletion(int id) async {
+    try {
+      final now = DateTime.now();
+      await (_db.update(_db.taskCompletionTable)..where((t) => t.id.equals(id) & t.deletedAt.isNull())).write(
+        TaskCompletionTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
+      );
+    } catch (e, st) {
+      _log.error('softDeleteCompletion failed', tag: 'TaskLocalDS', error: e, stackTrace: st);
+      rethrow;
+    }
+  }
+
+  @override
+  Stream<List<TaskCompletionTableData>> watchCompletionsForTask(int taskId) {
+    return (_db.select(_db.taskCompletionTable)
+          ..where((t) => t.taskId.equals(taskId) & t.deletedAt.isNull())
+          ..orderBy([(t) => OrderingTerm.asc(t.occurrenceDate)]))
+        .watch();
   }
 }

--- a/lib/features/tasks/data/mappers/task_completion_extensions.dart
+++ b/lib/features/tasks/data/mappers/task_completion_extensions.dart
@@ -1,0 +1,45 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:focus/core/services/db_service.dart';
+
+import '../../domain/entities/task_completion.dart';
+import 'task_extensions.dart';
+
+extension DbTaskCompletionToDomain on TaskCompletionTableData {
+  TaskCompletion toDomain() => TaskCompletion(
+    id: id,
+    uuid: uuid,
+    taskId: taskId,
+    occurrenceDate: parseOccurrenceDateKey(occurrenceDate),
+    completedAt: completedAt,
+    createdAt: createdAt,
+    updatedAt: updatedAt,
+    deletedAt: deletedAt,
+  );
+}
+
+extension DomainTaskCompletionToCompanion on TaskCompletion {
+  TaskCompletionTableCompanion toCompanion() {
+    final dateKey = occurrenceDateKey(occurrenceDate);
+    if (id != null) {
+      return TaskCompletionTableCompanion(
+        id: Value(id!),
+        uuid: Value(uuid),
+        taskId: Value(taskId),
+        occurrenceDate: Value(dateKey),
+        completedAt: Value(completedAt),
+        createdAt: Value(createdAt),
+        updatedAt: Value(updatedAt),
+        deletedAt: Value(deletedAt),
+      );
+    }
+    return TaskCompletionTableCompanion.insert(
+      uuid: uuid,
+      taskId: taskId,
+      occurrenceDate: dateKey,
+      completedAt: completedAt,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      deletedAt: Value(deletedAt),
+    );
+  }
+}

--- a/lib/features/tasks/data/mappers/task_extensions.dart
+++ b/lib/features/tasks/data/mappers/task_extensions.dart
@@ -1,5 +1,7 @@
 import 'package:drift/drift.dart' show Value;
 import 'package:focus/core/services/db_service.dart';
+import 'package:focus/core/utils/datetime_formatter.dart';
+import 'package:focus/features/tasks/domain/entities/recurrence_rule.dart';
 import 'package:focus/features/tasks/domain/entities/task_status.dart';
 
 import '../../domain/entities/task.dart';
@@ -22,6 +24,9 @@ extension DbTaskToDomain on TaskTableData {
     estimatedMinutes: estimatedMinutes,
     sortOrder: sortOrder,
     milestoneId: milestoneId,
+    recurrenceRule: RecurrenceRule.tryParseJson(recurrenceRule),
+    recurrenceAnchorDate: recurrenceAnchorDate,
+    isHabit: isHabit,
     createdAt: createdAt,
     updatedAt: updatedAt,
     deletedAt: deletedAt,
@@ -33,9 +38,10 @@ extension DomainTaskToCompanion on Task {
   /// or a full companion (with id) for updates.
   ///
   /// Writes both [status] and legacy [isCompleted] so they stay in sync
-  /// during the v7 compatibility window.
+  /// during the v7 compatibility cycle.
   TaskTableCompanion toCompanion() {
     final completed = status == TaskStatus.done;
+    final ruleJson = recurrenceRule?.toJson();
     if (id != null) {
       return TaskTableCompanion(
         id: Value(id!),
@@ -54,6 +60,9 @@ extension DomainTaskToCompanion on Task {
         estimatedMinutes: Value(estimatedMinutes),
         sortOrder: Value(sortOrder),
         milestoneId: Value(milestoneId),
+        recurrenceRule: Value(ruleJson),
+        recurrenceAnchorDate: Value(recurrenceAnchorDate),
+        isHabit: Value(isHabit),
         isCompleted: Value(completed),
         createdAt: Value(createdAt),
         updatedAt: Value(updatedAt),
@@ -76,10 +85,25 @@ extension DomainTaskToCompanion on Task {
       estimatedMinutes: Value(estimatedMinutes),
       sortOrder: Value(sortOrder),
       milestoneId: Value(milestoneId),
+      recurrenceRule: Value(ruleJson),
+      recurrenceAnchorDate: Value(recurrenceAnchorDate),
+      isHabit: Value(isHabit),
       isCompleted: Value(completed),
       createdAt: createdAt,
       updatedAt: updatedAt,
       deletedAt: Value(deletedAt),
     );
   }
+}
+
+/// Formats a date-only key for [TaskCompletionTable.occurrenceDate].
+String occurrenceDateKey(DateTime date) => date.toLocal().toShortDateKey();
+
+/// Parses a `YYYY-MM-DD` occurrence key into a local midnight [DateTime].
+DateTime parseOccurrenceDateKey(String key) {
+  final parts = key.split('-');
+  if (parts.length != 3) {
+    throw FormatException('Invalid occurrence date key: $key');
+  }
+  return DateTime(int.parse(parts[0]), int.parse(parts[1]), int.parse(parts[2]));
 }

--- a/lib/features/tasks/data/models/task_completion_model.dart
+++ b/lib/features/tasks/data/models/task_completion_model.dart
@@ -1,0 +1,26 @@
+import 'package:drift/drift.dart';
+
+import 'task_model.dart';
+
+@TableIndex(name: 'task_completion_uuid_idx', columns: {#uuid}, unique: true)
+@TableIndex(name: 'task_completion_task_id_idx', columns: {#taskId})
+@TableIndex(name: 'task_completion_occurrence_date_idx', columns: {#occurrenceDate})
+@TableIndex(name: 'task_completion_deleted_at_idx', columns: {#deletedAt})
+class TaskCompletionTable extends Table {
+  IntColumn get id => integer().autoIncrement()();
+
+  TextColumn get uuid => text().unique()();
+
+  IntColumn get taskId => integer().references(TaskTable, #id, onDelete: KeyAction.cascade)();
+
+  /// Local calendar date as `YYYY-MM-DD` (date-only, no time component).
+  TextColumn get occurrenceDate => text()();
+
+  DateTimeColumn get completedAt => dateTime()();
+
+  DateTimeColumn get createdAt => dateTime()();
+
+  DateTimeColumn get updatedAt => dateTime()();
+
+  DateTimeColumn get deletedAt => dateTime().nullable()();
+}

--- a/lib/features/tasks/data/models/task_model.dart
+++ b/lib/features/tasks/data/models/task_model.dart
@@ -50,6 +50,15 @@ class TaskTable extends Table {
 
   IntColumn get milestoneId => integer().nullable().references(MilestoneTable, #id, onDelete: KeyAction.setNull)();
 
+  /// JSON-encoded [RecurrenceRule], or null for one-shot tasks.
+  TextColumn get recurrenceRule => text().nullable()();
+
+  /// Series start used by [RecurrenceExpander]; defaults to start/created when null.
+  DateTimeColumn get recurrenceAnchorDate => dateTime().nullable()();
+
+  /// When true, the recurring task is surfaced as a habit (streaks / agenda).
+  BoolColumn get isHabit => boolean().withDefault(const Constant(false))();
+
   /// Kept in sync with [status] == done for one migration cycle (v7).
   BoolColumn get isCompleted => boolean().withDefault(const Constant(false))();
 

--- a/lib/features/tasks/data/repositories/task_repository_impl.dart
+++ b/lib/features/tasks/data/repositories/task_repository_impl.dart
@@ -1,11 +1,13 @@
 import '../../domain/entities/all_tasks_filter_state.dart';
 import '../../domain/entities/task.dart';
+import '../../domain/entities/task_completion.dart';
 import '../../domain/entities/task_extensions.dart';
 import '../../domain/entities/task_filter_state.dart';
 import '../../domain/entities/task_priority.dart';
 import '../../domain/entities/task_status.dart';
 import '../../domain/repositories/i_task_repository.dart';
 import '../datasources/task_local_datasource.dart';
+import '../mappers/task_completion_extensions.dart';
 import '../mappers/task_extensions.dart';
 import '../../../../core/services/log_service.dart';
 
@@ -124,5 +126,33 @@ class TaskRepositoryImpl implements ITaskRepository {
           completionFilter: completionFilter,
         )
         .map((rows) => rows.map((r) => r.toDomain()).toList());
+  }
+
+  @override
+  Future<List<TaskCompletion>> getCompletionsForTask(int taskId) async {
+    final rows = await _local.getCompletionsForTask(taskId);
+    return rows.map((r) => r.toDomain()).toList();
+  }
+
+  @override
+  Future<TaskCompletion?> getCompletion(int taskId, DateTime occurrenceDate) async {
+    final row = await _local.getCompletion(taskId, occurrenceDateKey(occurrenceDate));
+    return row?.toDomain();
+  }
+
+  @override
+  Future<TaskCompletion> upsertCompletion(TaskCompletion completion) async {
+    final row = await _local.upsertCompletion(completion.toCompanion());
+    return row.toDomain();
+  }
+
+  @override
+  Future<void> softDeleteCompletion(int id) async {
+    await _local.softDeleteCompletion(id);
+  }
+
+  @override
+  Stream<List<TaskCompletion>> watchCompletionsForTask(int taskId) {
+    return _local.watchCompletionsForTask(taskId).map((rows) => rows.map((r) => r.toDomain()).toList());
   }
 }

--- a/lib/features/tasks/domain/entities/recurrence_rule.dart
+++ b/lib/features/tasks/domain/entities/recurrence_rule.dart
@@ -1,0 +1,64 @@
+import 'package:dart_mappable/dart_mappable.dart';
+import 'package:meta/meta.dart';
+
+part 'recurrence_rule.mapper.dart';
+
+/// How often a recurring task / habit repeats.
+@MappableEnum()
+enum RecurrenceFrequency { daily, weekly, monthly }
+
+/// Practical recurrence definition stored as JSON on [Task.recurrenceRule].
+///
+/// Weekdays use Dart's [DateTime.weekday] convention (Mon=1 … Sun=7).
+@immutable
+@MappableClass()
+class RecurrenceRule with RecurrenceRuleMappable {
+  /// Base cadence.
+  final RecurrenceFrequency frequency;
+
+  /// Repeat every N periods (minimum 1).
+  final int interval;
+
+  /// For [RecurrenceFrequency.weekly]: which weekdays fire.
+  /// When null/empty, the weekday of the anchor date is used.
+  final List<int>? byWeekday;
+
+  /// For [RecurrenceFrequency.monthly]: day of month (1–31).
+  /// When null, the day-of-month of the anchor is used. Clamped to month length.
+  final int? byMonthDay;
+
+  /// Optional density hint (e.g. "3 times per week"). Expansion still uses
+  /// [byWeekday] / interval; this is reserved for UI / future schedulers.
+  final int? timesPerPeriod;
+
+  /// Inclusive end of the series (date-level).
+  final DateTime? until;
+
+  /// Maximum number of occurrences from the series start (inclusive).
+  final int? count;
+
+  const RecurrenceRule({
+    required this.frequency,
+    this.interval = 1,
+    this.byWeekday,
+    this.byMonthDay,
+    this.timesPerPeriod,
+    this.until,
+    this.count,
+  });
+
+  /// Normalized interval, always ≥ 1.
+  int get effectiveInterval => interval < 1 ? 1 : interval;
+
+  /// Parse from JSON map, or `null` if [json] is null/empty.
+  static RecurrenceRule? tryParse(Map<String, dynamic>? json) {
+    if (json == null || json.isEmpty) return null;
+    return RecurrenceRuleMapper.fromMap(json);
+  }
+
+  /// Parse from a JSON string stored in Drift.
+  static RecurrenceRule? tryParseJson(String? raw) {
+    if (raw == null || raw.trim().isEmpty) return null;
+    return RecurrenceRuleMapper.fromJson(raw);
+  }
+}

--- a/lib/features/tasks/domain/entities/recurrence_rule.mapper.dart
+++ b/lib/features/tasks/domain/entities/recurrence_rule.mapper.dart
@@ -1,0 +1,272 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// dart format off
+// ignore_for_file: type=lint
+// ignore_for_file: invalid_use_of_protected_member
+// ignore_for_file: unused_element, unnecessary_cast, override_on_non_overriding_member
+// ignore_for_file: strict_raw_type, inference_failure_on_untyped_parameter
+
+part of 'recurrence_rule.dart';
+
+class RecurrenceFrequencyMapper extends EnumMapper<RecurrenceFrequency> {
+  RecurrenceFrequencyMapper._();
+
+  static RecurrenceFrequencyMapper? _instance;
+  static RecurrenceFrequencyMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = RecurrenceFrequencyMapper._());
+    }
+    return _instance!;
+  }
+
+  static RecurrenceFrequency fromValue(dynamic value) {
+    ensureInitialized();
+    return MapperContainer.globals.fromValue(value);
+  }
+
+  @override
+  RecurrenceFrequency decode(dynamic value) {
+    switch (value) {
+      case r'daily':
+        return RecurrenceFrequency.daily;
+      case r'weekly':
+        return RecurrenceFrequency.weekly;
+      case r'monthly':
+        return RecurrenceFrequency.monthly;
+      default:
+        throw MapperException.unknownEnumValue(value);
+    }
+  }
+
+  @override
+  dynamic encode(RecurrenceFrequency self) {
+    switch (self) {
+      case RecurrenceFrequency.daily:
+        return r'daily';
+      case RecurrenceFrequency.weekly:
+        return r'weekly';
+      case RecurrenceFrequency.monthly:
+        return r'monthly';
+    }
+  }
+}
+
+extension RecurrenceFrequencyMapperExtension on RecurrenceFrequency {
+  String toValue() {
+    RecurrenceFrequencyMapper.ensureInitialized();
+    return MapperContainer.globals.toValue<RecurrenceFrequency>(this) as String;
+  }
+}
+
+class RecurrenceRuleMapper extends ClassMapperBase<RecurrenceRule> {
+  RecurrenceRuleMapper._();
+
+  static RecurrenceRuleMapper? _instance;
+  static RecurrenceRuleMapper ensureInitialized() {
+    if (_instance == null) {
+      MapperContainer.globals.use(_instance = RecurrenceRuleMapper._());
+      RecurrenceFrequencyMapper.ensureInitialized();
+    }
+    return _instance!;
+  }
+
+  @override
+  final String id = 'RecurrenceRule';
+
+  static RecurrenceFrequency _$frequency(RecurrenceRule v) => v.frequency;
+  static const Field<RecurrenceRule, RecurrenceFrequency> _f$frequency = Field(
+    'frequency',
+    _$frequency,
+  );
+  static int _$interval(RecurrenceRule v) => v.interval;
+  static const Field<RecurrenceRule, int> _f$interval = Field(
+    'interval',
+    _$interval,
+    opt: true,
+    def: 1,
+  );
+  static List<int>? _$byWeekday(RecurrenceRule v) => v.byWeekday;
+  static const Field<RecurrenceRule, List<int>> _f$byWeekday = Field(
+    'byWeekday',
+    _$byWeekday,
+    opt: true,
+  );
+  static int? _$byMonthDay(RecurrenceRule v) => v.byMonthDay;
+  static const Field<RecurrenceRule, int> _f$byMonthDay = Field(
+    'byMonthDay',
+    _$byMonthDay,
+    opt: true,
+  );
+  static int? _$timesPerPeriod(RecurrenceRule v) => v.timesPerPeriod;
+  static const Field<RecurrenceRule, int> _f$timesPerPeriod = Field(
+    'timesPerPeriod',
+    _$timesPerPeriod,
+    opt: true,
+  );
+  static DateTime? _$until(RecurrenceRule v) => v.until;
+  static const Field<RecurrenceRule, DateTime> _f$until = Field(
+    'until',
+    _$until,
+    opt: true,
+  );
+  static int? _$count(RecurrenceRule v) => v.count;
+  static const Field<RecurrenceRule, int> _f$count = Field(
+    'count',
+    _$count,
+    opt: true,
+  );
+
+  @override
+  final MappableFields<RecurrenceRule> fields = const {
+    #frequency: _f$frequency,
+    #interval: _f$interval,
+    #byWeekday: _f$byWeekday,
+    #byMonthDay: _f$byMonthDay,
+    #timesPerPeriod: _f$timesPerPeriod,
+    #until: _f$until,
+    #count: _f$count,
+  };
+
+  static RecurrenceRule _instantiate(DecodingData data) {
+    return RecurrenceRule(
+      frequency: data.dec(_f$frequency),
+      interval: data.dec(_f$interval),
+      byWeekday: data.dec(_f$byWeekday),
+      byMonthDay: data.dec(_f$byMonthDay),
+      timesPerPeriod: data.dec(_f$timesPerPeriod),
+      until: data.dec(_f$until),
+      count: data.dec(_f$count),
+    );
+  }
+
+  @override
+  final Function instantiate = _instantiate;
+
+  static RecurrenceRule fromMap(Map<String, dynamic> map) {
+    return ensureInitialized().decodeMap<RecurrenceRule>(map);
+  }
+
+  static RecurrenceRule fromJson(String json) {
+    return ensureInitialized().decodeJson<RecurrenceRule>(json);
+  }
+}
+
+mixin RecurrenceRuleMappable {
+  String toJson() {
+    return RecurrenceRuleMapper.ensureInitialized().encodeJson<RecurrenceRule>(
+      this as RecurrenceRule,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return RecurrenceRuleMapper.ensureInitialized().encodeMap<RecurrenceRule>(
+      this as RecurrenceRule,
+    );
+  }
+
+  RecurrenceRuleCopyWith<RecurrenceRule, RecurrenceRule, RecurrenceRule>
+  get copyWith => _RecurrenceRuleCopyWithImpl<RecurrenceRule, RecurrenceRule>(
+    this as RecurrenceRule,
+    $identity,
+    $identity,
+  );
+  @override
+  String toString() {
+    return RecurrenceRuleMapper.ensureInitialized().stringifyValue(
+      this as RecurrenceRule,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return RecurrenceRuleMapper.ensureInitialized().equalsValue(
+      this as RecurrenceRule,
+      other,
+    );
+  }
+
+  @override
+  int get hashCode {
+    return RecurrenceRuleMapper.ensureInitialized().hashValue(
+      this as RecurrenceRule,
+    );
+  }
+}
+
+extension RecurrenceRuleValueCopy<$R, $Out>
+    on ObjectCopyWith<$R, RecurrenceRule, $Out> {
+  RecurrenceRuleCopyWith<$R, RecurrenceRule, $Out> get $asRecurrenceRule =>
+      $base.as((v, t, t2) => _RecurrenceRuleCopyWithImpl<$R, $Out>(v, t, t2));
+}
+
+abstract class RecurrenceRuleCopyWith<$R, $In extends RecurrenceRule, $Out>
+    implements ClassCopyWith<$R, $In, $Out> {
+  ListCopyWith<$R, int, ObjectCopyWith<$R, int, int>>? get byWeekday;
+  $R call({
+    RecurrenceFrequency? frequency,
+    int? interval,
+    List<int>? byWeekday,
+    int? byMonthDay,
+    int? timesPerPeriod,
+    DateTime? until,
+    int? count,
+  });
+  RecurrenceRuleCopyWith<$R2, $In, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  );
+}
+
+class _RecurrenceRuleCopyWithImpl<$R, $Out>
+    extends ClassCopyWithBase<$R, RecurrenceRule, $Out>
+    implements RecurrenceRuleCopyWith<$R, RecurrenceRule, $Out> {
+  _RecurrenceRuleCopyWithImpl(super.value, super.then, super.then2);
+
+  @override
+  late final ClassMapperBase<RecurrenceRule> $mapper =
+      RecurrenceRuleMapper.ensureInitialized();
+  @override
+  ListCopyWith<$R, int, ObjectCopyWith<$R, int, int>>? get byWeekday =>
+      $value.byWeekday != null
+      ? ListCopyWith(
+          $value.byWeekday!,
+          (v, t) => ObjectCopyWith(v, $identity, t),
+          (v) => call(byWeekday: v),
+        )
+      : null;
+  @override
+  $R call({
+    RecurrenceFrequency? frequency,
+    int? interval,
+    Object? byWeekday = $none,
+    Object? byMonthDay = $none,
+    Object? timesPerPeriod = $none,
+    Object? until = $none,
+    Object? count = $none,
+  }) => $apply(
+    FieldCopyWithData({
+      if (frequency != null) #frequency: frequency,
+      if (interval != null) #interval: interval,
+      if (byWeekday != $none) #byWeekday: byWeekday,
+      if (byMonthDay != $none) #byMonthDay: byMonthDay,
+      if (timesPerPeriod != $none) #timesPerPeriod: timesPerPeriod,
+      if (until != $none) #until: until,
+      if (count != $none) #count: count,
+    }),
+  );
+  @override
+  RecurrenceRule $make(CopyWithData data) => RecurrenceRule(
+    frequency: data.get(#frequency, or: $value.frequency),
+    interval: data.get(#interval, or: $value.interval),
+    byWeekday: data.get(#byWeekday, or: $value.byWeekday),
+    byMonthDay: data.get(#byMonthDay, or: $value.byMonthDay),
+    timesPerPeriod: data.get(#timesPerPeriod, or: $value.timesPerPeriod),
+    until: data.get(#until, or: $value.until),
+    count: data.get(#count, or: $value.count),
+  );
+
+  @override
+  RecurrenceRuleCopyWith<$R2, RecurrenceRule, $Out2> $chain<$R2, $Out2>(
+    Then<$Out2, $R2> t,
+  ) => _RecurrenceRuleCopyWithImpl<$R2, $Out2>($value, $cast, t);
+}
+

--- a/lib/features/tasks/domain/entities/task.dart
+++ b/lib/features/tasks/domain/entities/task.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:meta/meta.dart';
 
+import 'recurrence_rule.dart';
 import 'task_priority.dart';
 import 'task_reminder_mode.dart';
 import 'task_status.dart';
@@ -9,6 +10,9 @@ import 'task_status.dart';
 ///
 /// [depth] encodes nesting: 0 = root task, 1 = subtask, 2 = sub-subtask, etc.
 /// [isCompleted] is derived from [status] == [TaskStatus.done].
+///
+/// Recurring tasks keep a single row; occurrences are expanded via
+/// [RecurrenceExpander] and completions are logged separately.
 @immutable
 class Task extends Equatable {
   final int? id;
@@ -27,6 +31,9 @@ class Task extends Equatable {
   final int? estimatedMinutes;
   final double sortOrder;
   final int? milestoneId;
+  final RecurrenceRule? recurrenceRule;
+  final DateTime? recurrenceAnchorDate;
+  final bool isHabit;
   final DateTime createdAt;
   final DateTime updatedAt;
   final DateTime? deletedAt;
@@ -48,6 +55,9 @@ class Task extends Equatable {
     this.estimatedMinutes,
     this.sortOrder = 0,
     this.milestoneId,
+    this.recurrenceRule,
+    this.recurrenceAnchorDate,
+    this.isHabit = false,
     required this.createdAt,
     required this.updatedAt,
     this.deletedAt,
@@ -55,6 +65,9 @@ class Task extends Equatable {
 
   /// Compatibility getter — true when [status] is [TaskStatus.done].
   bool get isCompleted => status == TaskStatus.done;
+
+  /// Whether this task expands into multiple occurrences.
+  bool get isRecurring => recurrenceRule != null;
 
   @override
   List<Object?> get props => [
@@ -74,6 +87,9 @@ class Task extends Equatable {
     estimatedMinutes,
     sortOrder,
     milestoneId,
+    recurrenceRule,
+    recurrenceAnchorDate,
+    isHabit,
     createdAt,
     updatedAt,
     deletedAt,

--- a/lib/features/tasks/domain/entities/task_completion.dart
+++ b/lib/features/tasks/domain/entities/task_completion.dart
@@ -1,0 +1,41 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// Log entry for a single completed occurrence of a (recurring) task.
+///
+/// [occurrenceDate] is date-only (local midnight). Unique with [taskId]
+/// among non-deleted rows.
+@immutable
+class TaskCompletion extends Equatable {
+  final int? id;
+  final String uuid;
+  final int taskId;
+  final DateTime occurrenceDate;
+  final DateTime completedAt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? deletedAt;
+
+  const TaskCompletion({
+    this.id,
+    required this.uuid,
+    required this.taskId,
+    required this.occurrenceDate,
+    required this.completedAt,
+    required this.createdAt,
+    required this.updatedAt,
+    this.deletedAt,
+  });
+
+  @override
+  List<Object?> get props => [
+    id,
+    uuid,
+    taskId,
+    occurrenceDate,
+    completedAt,
+    createdAt,
+    updatedAt,
+    deletedAt,
+  ];
+}

--- a/lib/features/tasks/domain/entities/task_completion_extensions.dart
+++ b/lib/features/tasks/domain/entities/task_completion_extensions.dart
@@ -1,0 +1,29 @@
+import 'task_completion.dart';
+
+const _TaskCompletionCopyWithUnset _unset = _TaskCompletionCopyWithUnset();
+
+class _TaskCompletionCopyWithUnset {
+  const _TaskCompletionCopyWithUnset();
+}
+
+extension TaskCompletionCopyWith on TaskCompletion {
+  TaskCompletion copyWith({
+    int? id,
+    String? uuid,
+    int? taskId,
+    DateTime? occurrenceDate,
+    DateTime? completedAt,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    Object? deletedAt = _unset,
+  }) => TaskCompletion(
+    id: id ?? this.id,
+    uuid: uuid ?? this.uuid,
+    taskId: taskId ?? this.taskId,
+    occurrenceDate: occurrenceDate ?? this.occurrenceDate,
+    completedAt: completedAt ?? this.completedAt,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    deletedAt: deletedAt == _unset ? this.deletedAt : deletedAt as DateTime?,
+  );
+}

--- a/lib/features/tasks/domain/entities/task_extensions.dart
+++ b/lib/features/tasks/domain/entities/task_extensions.dart
@@ -2,6 +2,7 @@ import 'package:focus/features/tasks/domain/entities/task_priority.dart';
 import 'package:focus/features/tasks/domain/entities/task_reminder_mode.dart';
 import 'package:focus/features/tasks/domain/entities/task_status.dart';
 
+import 'recurrence_rule.dart';
 import 'task.dart';
 
 /// Sentinel object used in [TaskCopyWith.copyWith] to distinguish
@@ -32,6 +33,9 @@ extension TaskCopyWith on Task {
     Object? estimatedMinutes = _taskCopyWithUnset,
     double? sortOrder,
     Object? milestoneId = _taskCopyWithUnset,
+    Object? recurrenceRule = _taskCopyWithUnset,
+    Object? recurrenceAnchorDate = _taskCopyWithUnset,
+    bool? isHabit,
     DateTime? createdAt,
     DateTime? updatedAt,
     Object? deletedAt = _taskCopyWithUnset,
@@ -56,6 +60,13 @@ extension TaskCopyWith on Task {
         : estimatedMinutes as int?,
     sortOrder: sortOrder ?? this.sortOrder,
     milestoneId: milestoneId == _taskCopyWithUnset ? this.milestoneId : milestoneId as int?,
+    recurrenceRule: recurrenceRule == _taskCopyWithUnset
+        ? this.recurrenceRule
+        : recurrenceRule as RecurrenceRule?,
+    recurrenceAnchorDate: recurrenceAnchorDate == _taskCopyWithUnset
+        ? this.recurrenceAnchorDate
+        : recurrenceAnchorDate as DateTime?,
+    isHabit: isHabit ?? this.isHabit,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
     deletedAt: deletedAt == _taskCopyWithUnset ? this.deletedAt : deletedAt as DateTime?,

--- a/lib/features/tasks/domain/repositories/i_task_repository.dart
+++ b/lib/features/tasks/domain/repositories/i_task_repository.dart
@@ -1,5 +1,6 @@
 import '../entities/all_tasks_filter_state.dart';
 import '../entities/task.dart';
+import '../entities/task_completion.dart';
 import '../entities/task_filter_state.dart';
 import '../entities/task_priority.dart';
 import '../entities/task_status.dart';
@@ -41,4 +42,14 @@ abstract class ITaskRepository {
     TaskStatus? statusFilter,
     TaskCompletionFilter completionFilter,
   });
+
+  Future<List<TaskCompletion>> getCompletionsForTask(int taskId);
+
+  Future<TaskCompletion?> getCompletion(int taskId, DateTime occurrenceDate);
+
+  Future<TaskCompletion> upsertCompletion(TaskCompletion completion);
+
+  Future<void> softDeleteCompletion(int id);
+
+  Stream<List<TaskCompletion>> watchCompletionsForTask(int taskId);
 }

--- a/lib/features/tasks/domain/services/habit_streak_calculator.dart
+++ b/lib/features/tasks/domain/services/habit_streak_calculator.dart
@@ -1,0 +1,130 @@
+import '../entities/recurrence_rule.dart';
+import 'recurrence_expander.dart';
+
+/// Result of evaluating habit consistency against a scheduled series.
+class HabitStreakResult {
+  /// Consecutive completed scheduled occurrences ending at the most recent
+  /// due occurrence (skips "today" when it is still open and incomplete).
+  final int currentStreak;
+
+  /// Longest run of consecutive completed scheduled occurrences in the window.
+  final int longestStreak;
+
+  /// `completed / scheduled` for occurrences in `[from, to]` (0 when none).
+  final double completionRate;
+
+  /// Scheduled occurrence count in the evaluated window.
+  final int scheduledCount;
+
+  /// Completed occurrence count overlapping the scheduled set.
+  final int completedCount;
+
+  const HabitStreakResult({
+    required this.currentStreak,
+    required this.longestStreak,
+    required this.completionRate,
+    required this.scheduledCount,
+    required this.completedCount,
+  });
+}
+
+/// Pure streak / consistency calculator for habit-style recurring tasks.
+class HabitStreakCalculator {
+  const HabitStreakCalculator._();
+
+  /// Computes streak metrics from [completionDates] and the expanded schedule.
+  ///
+  /// Only days the habit was scheduled count — gaps where the rule did not
+  /// fire do not break the streak.
+  static HabitStreakResult calculate({
+    required RecurrenceRule rule,
+    required DateTime anchor,
+    required Iterable<DateTime> completionDates,
+    required DateTime from,
+    required DateTime to,
+    DateTime? now,
+  }) {
+    final effectiveNow = _dateOnly(now ?? DateTime.now());
+    final windowFrom = _dateOnly(from);
+    final windowTo = _dateOnly(to);
+
+    final scheduled = RecurrenceExpander.expandRule(
+      rule: rule,
+      anchor: anchor,
+      from: windowFrom,
+      to: windowTo,
+    );
+
+    final completedKeys = {
+      for (final c in completionDates) _dateKey(_dateOnly(c)),
+    };
+
+    final scheduledKeys = scheduled.map(_dateKey).toList();
+    final completedScheduled = scheduledKeys.where(completedKeys.contains).length;
+    final rate = scheduledKeys.isEmpty ? 0.0 : completedScheduled / scheduledKeys.length;
+
+    final longest = _longestStreak(scheduledKeys, completedKeys);
+    final current = _currentStreak(
+      scheduledKeys: scheduledKeys,
+      completedKeys: completedKeys,
+      today: effectiveNow,
+    );
+
+    return HabitStreakResult(
+      currentStreak: current,
+      longestStreak: longest,
+      completionRate: rate,
+      scheduledCount: scheduledKeys.length,
+      completedCount: completedScheduled,
+    );
+  }
+
+  static int _longestStreak(List<String> scheduledKeys, Set<String> completedKeys) {
+    var best = 0;
+    var run = 0;
+    for (final key in scheduledKeys) {
+      if (completedKeys.contains(key)) {
+        run++;
+        if (run > best) best = run;
+      } else {
+        run = 0;
+      }
+    }
+    return best;
+  }
+
+  static int _currentStreak({
+    required List<String> scheduledKeys,
+    required Set<String> completedKeys,
+    required DateTime today,
+  }) {
+    if (scheduledKeys.isEmpty) return 0;
+
+    final todayKey = _dateKey(today);
+    var endIndex = scheduledKeys.lastIndexWhere((k) => k.compareTo(todayKey) <= 0);
+    if (endIndex < 0) return 0;
+
+    // If today is scheduled but not yet completed, start from the prior occurrence.
+    if (scheduledKeys[endIndex] == todayKey && !completedKeys.contains(todayKey)) {
+      endIndex--;
+    }
+    if (endIndex < 0) return 0;
+
+    var streak = 0;
+    for (var i = endIndex; i >= 0; i--) {
+      if (completedKeys.contains(scheduledKeys[i])) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
+
+  static String _dateKey(DateTime dt) =>
+      '${dt.year.toString().padLeft(4, '0')}-'
+      '${dt.month.toString().padLeft(2, '0')}-'
+      '${dt.day.toString().padLeft(2, '0')}';
+}

--- a/lib/features/tasks/domain/services/recurrence_expander.dart
+++ b/lib/features/tasks/domain/services/recurrence_expander.dart
@@ -1,0 +1,165 @@
+import '../entities/recurrence_rule.dart';
+import '../entities/task.dart';
+
+/// Pure expander: materialises occurrence datetimes for a recurring [Task]
+/// inside an inclusive `[from, to]` window without writing to the database.
+class RecurrenceExpander {
+  const RecurrenceExpander._();
+
+  /// Expands [task] occurrences whose calendar date falls in `[from, to]`
+  /// (inclusive, compared at local date granularity).
+  ///
+  /// Returns an empty list when the task has no [Task.recurrenceRule].
+  /// Each occurrence keeps the wall-clock time of [Task.recurrenceAnchorDate]
+  /// (falling back to [Task.startDate], then midnight).
+  static List<DateTime> expand(Task task, DateTime from, DateTime to) {
+    final rule = task.recurrenceRule;
+    if (rule == null) return const [];
+
+    final anchor = _dateOnly(task.recurrenceAnchorDate ?? task.startDate ?? task.createdAt);
+    final windowStart = _dateOnly(from);
+    final windowEnd = _dateOnly(to);
+    if (windowEnd.isBefore(windowStart)) return const [];
+
+    final timeSource = task.recurrenceAnchorDate ?? task.startDate;
+    final hour = timeSource?.hour ?? 0;
+    final minute = timeSource?.minute ?? 0;
+    final second = timeSource?.second ?? 0;
+
+    final dates = expandRule(rule: rule, anchor: anchor, from: windowStart, to: windowEnd);
+    return [
+      for (final d in dates) DateTime(d.year, d.month, d.day, hour, minute, second),
+    ];
+  }
+
+  /// Expands a bare [rule] + [anchor] into date-only occurrence datetimes.
+  static List<DateTime> expandRule({
+    required RecurrenceRule rule,
+    required DateTime anchor,
+    required DateTime from,
+    required DateTime to,
+  }) {
+    final seriesAnchor = _dateOnly(anchor);
+    final windowStart = _dateOnly(from);
+    final windowEnd = _dateOnly(to);
+    if (windowEnd.isBefore(windowStart)) return const [];
+
+    final until = rule.until != null ? _dateOnly(rule.until!) : null;
+    final maxCount = rule.count;
+    final interval = rule.effectiveInterval;
+
+    final all = <DateTime>[];
+
+    switch (rule.frequency) {
+      case RecurrenceFrequency.daily:
+        all.addAll(_dailySeries(seriesAnchor, until, interval, maxCount, windowEnd));
+      case RecurrenceFrequency.weekly:
+        all.addAll(_weeklySeries(rule, seriesAnchor, until, interval, maxCount, windowEnd));
+      case RecurrenceFrequency.monthly:
+        all.addAll(_monthlySeries(rule, seriesAnchor, until, interval, maxCount, windowEnd));
+    }
+
+    return [
+      for (final d in all)
+        if (!d.isBefore(windowStart) && !d.isAfter(windowEnd)) d,
+    ];
+  }
+
+  static List<DateTime> _dailySeries(
+    DateTime anchor,
+    DateTime? until,
+    int interval,
+    int? maxCount,
+    DateTime windowEnd,
+  ) {
+    final out = <DateTime>[];
+    var cursor = anchor;
+    final hardEnd = until != null && until.isBefore(windowEnd) ? until : windowEnd;
+    // Bound iteration even when until/count are open-ended.
+    final maxSteps = maxCount ?? ((hardEnd.difference(anchor).inDays ~/ interval) + 2).clamp(1, 40000);
+
+    for (var i = 0; i < maxSteps; i++) {
+      if (until != null && cursor.isAfter(until)) break;
+      out.add(cursor);
+      if (maxCount != null && out.length >= maxCount) break;
+      cursor = cursor.add(Duration(days: interval));
+      if (cursor.isAfter(hardEnd) && (maxCount == null || out.length >= maxCount)) {
+        // Still continue if we need more for count but hardEnd passed — count wins.
+        if (maxCount == null) break;
+      }
+      if (maxCount == null && cursor.isAfter(hardEnd)) break;
+    }
+    return out;
+  }
+
+  static List<DateTime> _weeklySeries(
+    RecurrenceRule rule,
+    DateTime anchor,
+    DateTime? until,
+    int interval,
+    int? maxCount,
+    DateTime windowEnd,
+  ) {
+    final weekdays = (rule.byWeekday == null || rule.byWeekday!.isEmpty)
+        ? <int>[anchor.weekday]
+        : (List<int>.from(rule.byWeekday!)..sort());
+
+    final anchorWeekStart = anchor.subtract(Duration(days: anchor.weekday - DateTime.monday));
+    final hardEnd = until != null && until.isBefore(windowEnd) ? until : windowEnd;
+    final weeksSpan = (hardEnd.difference(anchorWeekStart).inDays ~/ 7) + 2;
+    final maxWeeks = maxCount != null ? (maxCount * interval + weekdays.length) : weeksSpan.clamp(1, 6000);
+
+    final out = <DateTime>[];
+    for (var weekOffset = 0; weekOffset < maxWeeks; weekOffset++) {
+      if (weekOffset % interval != 0) continue;
+      final weekStart = anchorWeekStart.add(Duration(days: weekOffset * 7));
+      for (final weekday in weekdays) {
+        final day = weekStart.add(Duration(days: weekday - DateTime.monday));
+        if (day.isBefore(anchor)) continue;
+        if (until != null && day.isAfter(until)) return out;
+        out.add(day);
+        if (maxCount != null && out.length >= maxCount) return out;
+      }
+      if (maxCount == null && weekStart.isAfter(hardEnd)) break;
+    }
+    return out;
+  }
+
+  static List<DateTime> _monthlySeries(
+    RecurrenceRule rule,
+    DateTime anchor,
+    DateTime? until,
+    int interval,
+    int? maxCount,
+    DateTime windowEnd,
+  ) {
+    final targetDay = rule.byMonthDay ?? anchor.day;
+    final hardEnd = until != null && until.isBefore(windowEnd) ? until : windowEnd;
+    final monthsSpan = (hardEnd.year - anchor.year) * 12 + (hardEnd.month - anchor.month) + 2;
+    final maxMonths = maxCount != null ? maxCount * interval : monthsSpan.clamp(1, 2400);
+
+    final out = <DateTime>[];
+    for (var monthOffset = 0; monthOffset < maxMonths; monthOffset++) {
+      if (monthOffset % interval != 0) continue;
+      final candidate = _addMonthsClamped(anchor, monthOffset, targetDay);
+      if (candidate.isBefore(anchor)) continue;
+      if (until != null && candidate.isAfter(until)) break;
+      out.add(candidate);
+      if (maxCount != null && out.length >= maxCount) break;
+      if (maxCount == null && candidate.isAfter(hardEnd)) break;
+    }
+    return out;
+  }
+
+  /// Adds [months] to [anchor]'s year/month, clamping day to [targetDay] or last day.
+  static DateTime _addMonthsClamped(DateTime anchor, int months, int targetDay) {
+    final totalMonths = anchor.year * 12 + (anchor.month - 1) + months;
+    final year = totalMonths ~/ 12;
+    final month = totalMonths % 12 + 1;
+    final lastDay = DateTime(year, month + 1, 0).day;
+    final day = targetDay.clamp(1, lastDay);
+    return DateTime(year, month, day);
+  }
+
+  static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
+}

--- a/lib/features/tasks/domain/services/task_notification_service.dart
+++ b/lib/features/tasks/domain/services/task_notification_service.dart
@@ -17,30 +17,32 @@ class TaskNotificationService {
   Future<Result<void>> scheduleTaskReminder(Task task) async {
     try {
       if (task.id == null) return const Success(null);
-      if (task.endDate == null || task.isCompleted) {
-        await cancelTaskReminder(task.id!);
+
+      await cancelTaskReminder(task.id!);
+
+      if (!task.isRecurring && (task.endDate == null || task.isCompleted)) {
         return const Success(null);
       }
 
       final now = DateTime.now();
-      if (!task.endDate!.isAfter(now)) {
-        await cancelTaskReminder(task.id!);
+      if (!task.isRecurring && task.endDate != null && !task.endDate!.isAfter(now)) {
         return const Success(null);
       }
 
-      final scheduledTime = TaskReminderPlanner.computeReminderTime(task, now: now);
-      if (scheduledTime == null) {
-        await cancelTaskReminder(task.id!);
+      final scheduledTimes = TaskReminderPlanner.computeReminderTimes(task, now: now);
+      if (scheduledTimes.isEmpty) {
         return const Success(null);
       }
 
-      await _notificationService.scheduleNotification(
-        id: _taskNotificationId(task.id!),
-        title: 'Task Reminder',
-        body: task.title,
-        scheduledTime: scheduledTime,
-        payload: NotificationConstants.taskPayload(taskId: task.id!, projectId: task.projectId),
-      );
+      for (var i = 0; i < scheduledTimes.length; i++) {
+        await _notificationService.scheduleNotification(
+          id: NotificationConstants.taskReminderNotificationId(task.id!, i),
+          title: 'Task Reminder',
+          body: task.title,
+          scheduledTime: scheduledTimes[i],
+          payload: NotificationConstants.taskPayload(taskId: task.id!, projectId: task.projectId),
+        );
+      }
 
       return const Success(null);
     } catch (e, st) {
@@ -56,7 +58,11 @@ class TaskNotificationService {
 
   Future<Result<void>> cancelTaskReminder(int taskId) async {
     try {
-      await _notificationService.cancelNotification(_taskNotificationId(taskId));
+      for (var slot = 0; slot < NotificationConstants.taskReminderSlotStride; slot++) {
+        await _notificationService.cancelNotification(
+          NotificationConstants.taskReminderNotificationId(taskId, slot),
+        );
+      }
       return const Success(null);
     } catch (e, st) {
       _log.warning(
@@ -81,6 +87,4 @@ class TaskNotificationService {
       return Failure(NotificationFailure('Failed to reschedule task reminders', error: e, stackTrace: st));
     }
   }
-
-  int _taskNotificationId(int taskId) => NotificationConstants.taskReminderIdOffset + taskId;
 }

--- a/lib/features/tasks/domain/services/task_reminder_planner.dart
+++ b/lib/features/tasks/domain/services/task_reminder_planner.dart
@@ -1,26 +1,79 @@
 import '../entities/task.dart';
 import '../entities/task_reminder_mode.dart';
+import 'recurrence_expander.dart';
 
+/// Pure reminder-time planner for one-shot and recurring tasks.
 class TaskReminderPlanner {
   const TaskReminderPlanner._();
 
+  /// How many upcoming occurrences to schedule reminders for.
+  static const int rollingWindowSize = 5;
+
+  /// Horizon used when expanding recurring occurrences for reminders.
+  static const Duration rollingHorizon = Duration(days: 90);
+
+  /// Single reminder for a non-recurring task (or the next one for recurring).
   static DateTime? computeReminderTime(Task task, {DateTime? now}) {
-    final deadline = task.endDate;
-    if (task.id == null || deadline == null || task.isCompleted || task.reminderMode == TaskReminderMode.none) {
-      return null;
-    }
-
-    final lead = _leadDuration(task, now: now);
-    if (lead == null) return null;
-
-    final effectiveNow = now ?? DateTime.now();
-    final reminderTime = deadline.subtract(lead);
-
-    // If the planned reminder is already in the past, schedule immediately.
-    return reminderTime.isAfter(effectiveNow) ? reminderTime : effectiveNow.add(const Duration(seconds: 2));
+    final times = computeReminderTimes(task, now: now, windowSize: 1);
+    return times.isEmpty ? null : times.first;
   }
 
-  static Duration? _leadDuration(Task task, {DateTime? now}) {
+  /// Rolling window of reminder times for [task].
+  ///
+  /// Non-recurring tasks yield 0–1 entries based on [Task.endDate].
+  /// Recurring tasks expand the next [windowSize] occurrences and apply the
+  /// same lead logic relative to each occurrence datetime.
+  static List<DateTime> computeReminderTimes(
+    Task task, {
+    DateTime? now,
+    int windowSize = rollingWindowSize,
+  }) {
+    if (task.id == null || task.reminderMode == TaskReminderMode.none) {
+      return const [];
+    }
+
+    final effectiveNow = now ?? DateTime.now();
+
+    if (task.isRecurring) {
+      return _recurringReminders(task, effectiveNow, windowSize);
+    }
+
+    if (task.isCompleted) return const [];
+    final deadline = task.endDate;
+    if (deadline == null) return const [];
+
+    final reminder = _reminderForDeadline(task, deadline, effectiveNow);
+    return reminder == null ? const [] : [reminder];
+  }
+
+  static List<DateTime> _recurringReminders(Task task, DateTime now, int windowSize) {
+    if (windowSize <= 0) return const [];
+
+    final from = DateTime(now.year, now.month, now.day);
+    final to = from.add(rollingHorizon);
+    final occurrences = RecurrenceExpander.expand(task, from, to)
+        .where((o) => !o.isBefore(now))
+        .take(windowSize)
+        .toList();
+
+    final reminders = <DateTime>[];
+    for (final occurrence in occurrences) {
+      final reminder = _reminderForDeadline(task, occurrence, now);
+      if (reminder != null) reminders.add(reminder);
+    }
+    return reminders;
+  }
+
+  static DateTime? _reminderForDeadline(Task task, DateTime deadline, DateTime now) {
+    final lead = _leadDuration(task, deadline: deadline, now: now);
+    if (lead == null) return null;
+
+    final reminderTime = deadline.subtract(lead);
+    // If the planned reminder is already in the past, schedule immediately.
+    return reminderTime.isAfter(now) ? reminderTime : now.add(const Duration(seconds: 2));
+  }
+
+  static Duration? _leadDuration(Task task, {required DateTime deadline, DateTime? now}) {
     switch (task.reminderMode) {
       case TaskReminderMode.weekBefore:
         return const Duration(days: 7);
@@ -33,13 +86,12 @@ class TaskReminderPlanner {
       case TaskReminderMode.none:
         return null;
       case TaskReminderMode.smart:
-        return _smartLead(task, now: now);
+        return _smartLead(task, deadline: deadline, now: now);
     }
   }
 
-  static Duration _smartLead(Task task, {DateTime? now}) {
-    final deadline = task.endDate!;
-    final referenceStart = task.startDate ?? task.createdAt;
+  static Duration _smartLead(Task task, {required DateTime deadline, DateTime? now}) {
+    final referenceStart = task.recurrenceAnchorDate ?? task.startDate ?? task.createdAt;
     final span = deadline.difference(referenceStart);
 
     if (span >= const Duration(days: 7)) {

--- a/lib/features/tasks/domain/services/task_service.dart
+++ b/lib/features/tasks/domain/services/task_service.dart
@@ -1,7 +1,9 @@
 import '../../../../core/services/log_service.dart';
 import '../../../../core/utils/id_utils.dart';
 import '../../../../core/utils/result.dart';
+import '../entities/recurrence_rule.dart';
 import '../entities/task.dart';
+import '../entities/task_completion.dart';
 import '../entities/task_extensions.dart';
 import '../entities/task_priority.dart';
 import '../entities/task_reminder_mode.dart';
@@ -15,7 +17,7 @@ final _log = LogService.instance;
 ///
 /// Sits between the presentation layer (providers/commands) and the
 /// repository. Encapsulates business logic such as timestamping,
-/// completion toggling, and depth management.
+/// completion toggling, occurrence logging, and depth management.
 class TaskService {
   final ITaskRepository _repository;
   final TaskNotificationService _taskNotificationService;
@@ -29,6 +31,11 @@ class TaskService {
   Future<Task?> getTaskById(int id) => _repository.getTaskById(id);
 
   Stream<List<Task>> watchTasksByProjectId(int projectId) => _repository.watchTasksByProjectId(projectId);
+
+  Future<List<TaskCompletion>> getCompletionsForTask(int taskId) => _repository.getCompletionsForTask(taskId);
+
+  Stream<List<TaskCompletion>> watchCompletionsForTask(int taskId) =>
+      _repository.watchCompletionsForTask(taskId);
 
   //  Write
 
@@ -46,6 +53,9 @@ class TaskService {
     int? estimatedMinutes,
     double sortOrder = 0,
     int? milestoneId,
+    RecurrenceRule? recurrenceRule,
+    DateTime? recurrenceAnchorDate,
+    bool isHabit = false,
     required int depth,
   }) async {
     try {
@@ -65,6 +75,9 @@ class TaskService {
         estimatedMinutes: estimatedMinutes,
         sortOrder: sortOrder,
         milestoneId: milestoneId,
+        recurrenceRule: recurrenceRule,
+        recurrenceAnchorDate: recurrenceAnchorDate ?? (recurrenceRule != null ? (startDate ?? now) : null),
+        isHabit: isHabit,
         depth: depth,
         createdAt: now,
         updatedAt: now,
@@ -120,6 +133,54 @@ class TaskService {
     } catch (e, st) {
       _log.error('Failed to toggle task ${task.id}', tag: 'TaskService', error: e, stackTrace: st);
       return Failure(DatabaseFailure('Failed to toggle task', error: e, stackTrace: st));
+    }
+  }
+
+  /// Records completion of a single occurrence for a recurring task.
+  ///
+  /// For non-recurring tasks, marks the task [TaskStatus.done] (same as
+  /// completing via [toggleTaskCompletion]) and returns `null` completion.
+  Future<Result<TaskCompletion?>> completeOccurrence(int taskId, DateTime occurrenceDate) async {
+    try {
+      final task = await _repository.getTaskById(taskId);
+      if (task == null) {
+        return const Failure(NotFoundFailure('Task not found'));
+      }
+
+      if (!task.isRecurring) {
+        if (!task.isCompleted) {
+          final updated = task.copyWith(status: TaskStatus.done, updatedAt: DateTime.now());
+          await _repository.updateTask(updated);
+          await _taskNotificationService.cancelTaskReminder(taskId);
+        }
+        return const Success(null);
+      }
+
+      final now = DateTime.now();
+      final dateOnly = DateTime(occurrenceDate.year, occurrenceDate.month, occurrenceDate.day);
+      final completion = TaskCompletion(
+        uuid: generateUuid(),
+        taskId: taskId,
+        occurrenceDate: dateOnly,
+        completedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      );
+      final saved = await _repository.upsertCompletion(completion);
+      await _taskNotificationService.scheduleTaskReminder(task);
+      _log.info(
+        'Occurrence completed for task $taskId on ${dateOnly.toIso8601String()}',
+        tag: 'TaskService',
+      );
+      return Success(saved);
+    } catch (e, st) {
+      _log.error(
+        'Failed to complete occurrence for task $taskId',
+        tag: 'TaskService',
+        error: e,
+        stackTrace: st,
+      );
+      return Failure(DatabaseFailure('Failed to complete occurrence', error: e, stackTrace: st));
     }
   }
 }

--- a/test/core/db/migration_harness_test.dart
+++ b/test/core/db/migration_harness_test.dart
@@ -5,18 +5,18 @@ import 'package:focus/features/tasks/domain/entities/task_status.dart';
 import 'package:focus/features/projects/domain/entities/project_status.dart';
 import 'package:sqlite3/sqlite3.dart';
 
-/// Phase 2 migration harness.
+/// Phase 3 migration harness.
 ///
-/// Captures the current (v7) schema via [AppDatabase.forTesting] and verifies
-/// that upgrading from a hand-built v1 schema reaches v7 without nested
-/// transaction statements, without losing rows, and with PM-model columns.
+/// Captures the current (v8) schema via [AppDatabase.forTesting] and verifies
+/// that upgrading from a hand-built v1 schema reaches v8 without nested
+/// transaction statements, without losing rows, and with PM + recurrence columns.
 void main() {
-  test('onCreate produces schema version 7 with expected tables', () async {
+  test('onCreate produces schema version 8 with expected tables', () async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 7);
+    expect(version.read<int>('user_version'), 8);
 
     final tables = await db.customSelect("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").get();
     final names = tables.map((row) => row.read<String>('name')).toSet();
@@ -32,6 +32,7 @@ void main() {
         'tag_table',
         'task_tag_table',
         'milestone_table',
+        'task_completion_table',
       }),
     );
 
@@ -43,7 +44,18 @@ void main() {
     final taskColNames = taskCols.map((r) => r.read<String>('name')).toSet();
     expect(
       taskColNames,
-      containsAll({'uuid', 'deleted_at', 'status', 'estimated_minutes', 'sort_order', 'milestone_id', 'is_completed'}),
+      containsAll({
+        'uuid',
+        'deleted_at',
+        'status',
+        'estimated_minutes',
+        'sort_order',
+        'milestone_id',
+        'is_completed',
+        'recurrence_rule',
+        'recurrence_anchor_date',
+        'is_habit',
+      }),
     );
 
     final tagCols = await db.customSelect('PRAGMA table_info(tag_table)').get();
@@ -53,9 +65,31 @@ void main() {
     final milestoneCols = await db.customSelect('PRAGMA table_info(milestone_table)').get();
     final milestoneColNames = milestoneCols.map((r) => r.read<String>('name')).toSet();
     expect(milestoneColNames, containsAll({'uuid', 'project_id', 'title', 'target_date', 'deleted_at'}));
+
+    final completionCols = await db.customSelect('PRAGMA table_info(task_completion_table)').get();
+    final completionColNames = completionCols.map((r) => r.read<String>('name')).toSet();
+    expect(
+      completionColNames,
+      containsAll({
+        'uuid',
+        'task_id',
+        'occurrence_date',
+        'completed_at',
+        'created_at',
+        'updated_at',
+        'deleted_at',
+      }),
+    );
+
+    final indexes = await db
+        .customSelect(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'task_completion_task_occurrence_live_idx'",
+        )
+        .get();
+    expect(indexes, hasLength(1));
   });
 
-  test('migrates v1 schema to v7, preserves rows, and backfills uuids/status', () async {
+  test('migrates v1 schema to v8, preserves rows, and backfills uuids/status', () async {
     final raw = sqlite3.openInMemory();
     _createV1Schema(raw);
     raw.execute('INSERT INTO project_table (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)', [
@@ -83,7 +117,7 @@ void main() {
     });
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 7);
+    expect(version.read<int>('user_version'), 8);
 
     final tasks = await db.select(db.taskTable).get();
     expect(tasks, hasLength(1));
@@ -94,6 +128,8 @@ void main() {
     expect(tasks.single.status, TaskStatus.done);
     expect(tasks.single.isCompleted, isTrue);
     expect(tasks.single.sortOrder, 0.0);
+    expect(tasks.single.recurrenceRule, isNull);
+    expect(tasks.single.isHabit, isFalse);
 
     // reminder columns added in v4
     expect(tasks.single.reminderMode.index, 0);
@@ -115,10 +151,20 @@ void main() {
         .customSelect("SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE '%uuid%'")
         .get();
     final indexNames = indexes.map((r) => r.read<String>('name')).toSet();
-    expect(indexNames, containsAll({'project_uuid_idx', 'task_uuid_idx', 'focus_session_uuid_idx', 'tag_uuid_idx', 'milestone_uuid_idx'}));
+    expect(
+      indexNames,
+      containsAll({
+        'project_uuid_idx',
+        'task_uuid_idx',
+        'focus_session_uuid_idx',
+        'tag_uuid_idx',
+        'milestone_uuid_idx',
+        'task_completion_uuid_idx',
+      }),
+    );
   });
 
-  test('migrates v5 schema to v7 adding soft-delete and PM columns', () async {
+  test('migrates v5 schema to v8 adding soft-delete and PM columns', () async {
     final raw = sqlite3.openInMemory();
     _createV5Schema(raw);
     raw.execute('INSERT INTO project_table (id, title, created_at, updated_at) VALUES (?, ?, ?, ?)', [
@@ -139,7 +185,7 @@ void main() {
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 7);
+    expect(version.read<int>('user_version'), 8);
 
     final project = (await db.select(db.projectTable).get()).single;
     expect(project.uuid, isNotEmpty);
@@ -151,9 +197,14 @@ void main() {
     expect(task.deletedAt, isNull);
     expect(task.status, TaskStatus.todo);
     expect(task.isCompleted, isFalse);
+    expect(task.isHabit, isFalse);
+    expect(task.recurrenceRule, isNull);
+
+    final completions = await db.select(db.taskCompletionTable).get();
+    expect(completions, isEmpty);
   });
 
-  test('migrates v6 schema to v7 backfilling status from is_completed', () async {
+  test('migrates v6 schema to v8 backfilling status from is_completed', () async {
     final raw = sqlite3.openInMemory();
     _createV6Schema(raw);
     raw.execute(
@@ -178,7 +229,7 @@ void main() {
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 7);
+    expect(version.read<int>('user_version'), 8);
 
     final tasks = await db.select(db.taskTable).get();
     expect(tasks, hasLength(2));
@@ -188,11 +239,14 @@ void main() {
     expect(done.isCompleted, isTrue);
     expect(open.status, TaskStatus.todo);
     expect(open.isCompleted, isFalse);
+    expect(open.isHabit, isFalse);
 
     final tags = await db.select(db.tagTable).get();
     expect(tags, isEmpty);
     final milestones = await db.select(db.milestoneTable).get();
     expect(milestones, isEmpty);
+    final completions = await db.select(db.taskCompletionTable).get();
+    expect(completions, isEmpty);
   });
 }
 

--- a/test/domain/tasks/habit_streak_calculator_test.dart
+++ b/test/domain/tasks/habit_streak_calculator_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/features/tasks/domain/entities/recurrence_rule.dart';
+import 'package:focus/features/tasks/domain/services/habit_streak_calculator.dart';
+
+void main() {
+  group('HabitStreakCalculator', () {
+    const daily = RecurrenceRule(frequency: RecurrenceFrequency.daily);
+    final anchor = DateTime(2026, 8, 1);
+
+    test('returns zeros when nothing is scheduled in the window', () {
+      final result = HabitStreakCalculator.calculate(
+        rule: daily,
+        anchor: DateTime(2027, 1, 1),
+        completionDates: const [],
+        from: DateTime(2026, 8, 1),
+        to: DateTime(2026, 8, 7),
+        now: DateTime(2026, 8, 7),
+      );
+      expect(result.scheduledCount, 0);
+      expect(result.currentStreak, 0);
+      expect(result.longestStreak, 0);
+      expect(result.completionRate, 0);
+    });
+
+    test('computes completion rate from scheduled days only', () {
+      final result = HabitStreakCalculator.calculate(
+        rule: daily,
+        anchor: anchor,
+        completionDates: [
+          DateTime(2026, 8, 1),
+          DateTime(2026, 8, 2),
+          DateTime(2026, 8, 4),
+        ],
+        from: DateTime(2026, 8, 1),
+        to: DateTime(2026, 8, 4),
+        now: DateTime(2026, 8, 4),
+      );
+      expect(result.scheduledCount, 4);
+      expect(result.completedCount, 3);
+      expect(result.completionRate, 0.75);
+    });
+
+    test('longest streak counts consecutive scheduled completions', () {
+      final result = HabitStreakCalculator.calculate(
+        rule: daily,
+        anchor: anchor,
+        completionDates: [
+          DateTime(2026, 8, 1),
+          DateTime(2026, 8, 2),
+          DateTime(2026, 8, 3),
+          // miss 4
+          DateTime(2026, 8, 5),
+          DateTime(2026, 8, 6),
+        ],
+        from: DateTime(2026, 8, 1),
+        to: DateTime(2026, 8, 6),
+        now: DateTime(2026, 8, 6),
+      );
+      expect(result.longestStreak, 3);
+      expect(result.currentStreak, 2);
+    });
+
+    test('current streak ignores incomplete today', () {
+      final result = HabitStreakCalculator.calculate(
+        rule: daily,
+        anchor: anchor,
+        completionDates: [
+          DateTime(2026, 8, 1),
+          DateTime(2026, 8, 2),
+          DateTime(2026, 8, 3),
+        ],
+        from: DateTime(2026, 8, 1),
+        to: DateTime(2026, 8, 4),
+        now: DateTime(2026, 8, 4),
+      );
+      expect(result.currentStreak, 3);
+    });
+
+    test('weekly habit skips non-scheduled days without breaking streak', () {
+      const weekly = RecurrenceRule(
+        frequency: RecurrenceFrequency.weekly,
+        byWeekday: [DateTime.monday, DateTime.wednesday, DateTime.friday],
+      );
+      // Aug 2026: Mon3, Wed5, Fri7, Mon10, Wed12, Fri14
+      final result = HabitStreakCalculator.calculate(
+        rule: weekly,
+        anchor: DateTime(2026, 8, 3),
+        completionDates: [
+          DateTime(2026, 8, 3),
+          DateTime(2026, 8, 5),
+          DateTime(2026, 8, 7),
+          DateTime(2026, 8, 10),
+        ],
+        from: DateTime(2026, 8, 1),
+        to: DateTime(2026, 8, 14),
+        now: DateTime(2026, 8, 11),
+      );
+      expect(result.currentStreak, 4);
+      expect(result.longestStreak, 4);
+      // Tue/Thu gaps do not appear in scheduled set.
+      expect(result.scheduledCount, 6);
+    });
+
+    test('broken streak resets current but keeps longest', () {
+      final result = HabitStreakCalculator.calculate(
+        rule: daily,
+        anchor: anchor,
+        completionDates: [
+          DateTime(2026, 8, 1),
+          DateTime(2026, 8, 2),
+          DateTime(2026, 8, 3),
+          DateTime(2026, 8, 5),
+        ],
+        from: DateTime(2026, 8, 1),
+        to: DateTime(2026, 8, 5),
+        now: DateTime(2026, 8, 5),
+      );
+      expect(result.longestStreak, 3);
+      expect(result.currentStreak, 1);
+    });
+  });
+}

--- a/test/domain/tasks/recurrence_expander_test.dart
+++ b/test/domain/tasks/recurrence_expander_test.dart
@@ -1,0 +1,160 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/features/tasks/domain/entities/recurrence_rule.dart';
+import 'package:focus/features/tasks/domain/services/recurrence_expander.dart';
+
+import '../../helpers/fixtures.dart';
+
+void main() {
+  group('RecurrenceExpander.expand', () {
+    test('returns empty list when task has no recurrence rule', () {
+      final task = buildTask(recurrenceRule: null);
+      final result = RecurrenceExpander.expand(
+        task,
+        DateTime(2026, 8, 1),
+        DateTime(2026, 8, 31),
+      );
+      expect(result, isEmpty);
+    });
+
+    test('expands daily occurrences within the window', () {
+      final task = buildTask(
+        recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.daily),
+        recurrenceAnchorDate: DateTime(2026, 8, 1, 9),
+        startDate: DateTime(2026, 8, 1, 9),
+        endDate: null,
+      );
+      final result = RecurrenceExpander.expand(
+        task,
+        DateTime(2026, 8, 2),
+        DateTime(2026, 8, 4),
+      );
+      expect(result, [
+        DateTime(2026, 8, 2, 9),
+        DateTime(2026, 8, 3, 9),
+        DateTime(2026, 8, 4, 9),
+      ]);
+    });
+
+    test('respects daily interval', () {
+      final task = buildTask(
+        recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.daily, interval: 2),
+        recurrenceAnchorDate: DateTime(2026, 8, 1),
+        endDate: null,
+      );
+      final result = RecurrenceExpander.expand(
+        task,
+        DateTime(2026, 8, 1),
+        DateTime(2026, 8, 7),
+      );
+      expect(result.map((d) => d.day).toList(), [1, 3, 5, 7]);
+    });
+
+    test('respects count limit', () {
+      final task = buildTask(
+        recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.daily, count: 3),
+        recurrenceAnchorDate: DateTime(2026, 8, 1),
+        endDate: null,
+      );
+      final result = RecurrenceExpander.expand(
+        task,
+        DateTime(2026, 8, 1),
+        DateTime(2026, 8, 31),
+      );
+      expect(result, hasLength(3));
+      expect(result.last.day, 3);
+    });
+
+    test('respects until date', () {
+      final task = buildTask(
+        recurrenceRule: RecurrenceRule(
+          frequency: RecurrenceFrequency.daily,
+          until: DateTime(2026, 8, 3),
+        ),
+        recurrenceAnchorDate: DateTime(2026, 8, 1),
+        endDate: null,
+      );
+      final result = RecurrenceExpander.expand(
+        task,
+        DateTime(2026, 8, 1),
+        DateTime(2026, 8, 31),
+      );
+      expect(result.map((d) => d.day).toList(), [1, 2, 3]);
+    });
+
+    test('expands weekly on selected weekdays', () {
+      final task = buildTask(
+        recurrenceRule: const RecurrenceRule(
+          frequency: RecurrenceFrequency.weekly,
+          byWeekday: [DateTime.monday, DateTime.wednesday, DateTime.friday],
+        ),
+        // Saturday Aug 1 2026
+        recurrenceAnchorDate: DateTime(2026, 8, 1),
+        endDate: null,
+      );
+      final result = RecurrenceExpander.expand(
+        task,
+        DateTime(2026, 8, 1),
+        DateTime(2026, 8, 14),
+      );
+      expect(
+        result.map((d) => d.weekday).toSet(),
+        {DateTime.monday, DateTime.wednesday, DateTime.friday},
+      );
+      expect(result.first, DateTime(2026, 8, 3)); // first Mon after anchor
+    });
+
+    test('expands weekly with interval of 2 weeks', () {
+      final task = buildTask(
+        recurrenceRule: const RecurrenceRule(
+          frequency: RecurrenceFrequency.weekly,
+          interval: 2,
+          byWeekday: [DateTime.monday],
+        ),
+        recurrenceAnchorDate: DateTime(2026, 8, 3), // Mon
+        endDate: null,
+      );
+      final result = RecurrenceExpander.expand(
+        task,
+        DateTime(2026, 8, 3),
+        DateTime(2026, 8, 31),
+      );
+      expect(result.map((d) => d.day).toList(), [3, 17, 31]);
+    });
+
+    test('expands monthly clamping to last day of short months', () {
+      final task = buildTask(
+        recurrenceRule: const RecurrenceRule(
+          frequency: RecurrenceFrequency.monthly,
+          byMonthDay: 31,
+        ),
+        recurrenceAnchorDate: DateTime(2026, 1, 31),
+        endDate: null,
+      );
+      final result = RecurrenceExpander.expand(
+        task,
+        DateTime(2026, 1, 1),
+        DateTime(2026, 4, 30),
+      );
+      expect(result, [
+        DateTime(2026, 1, 31),
+        DateTime(2026, 2, 28),
+        DateTime(2026, 3, 31),
+        DateTime(2026, 4, 30),
+      ]);
+    });
+
+    test('excludes occurrences before the window', () {
+      final task = buildTask(
+        recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.daily),
+        recurrenceAnchorDate: DateTime(2026, 7, 1),
+        endDate: null,
+      );
+      final result = RecurrenceExpander.expand(
+        task,
+        DateTime(2026, 8, 1),
+        DateTime(2026, 8, 2),
+      );
+      expect(result, [DateTime(2026, 8, 1), DateTime(2026, 8, 2)]);
+    });
+  });
+}

--- a/test/domain/tasks/task_reminder_planner_test.dart
+++ b/test/domain/tasks/task_reminder_planner_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/features/tasks/domain/entities/recurrence_rule.dart';
 import 'package:focus/features/tasks/domain/entities/task_reminder_mode.dart';
 import 'package:focus/features/tasks/domain/services/task_reminder_planner.dart';
 
@@ -83,6 +84,30 @@ void main() {
       );
       final reminder = TaskReminderPlanner.computeReminderTime(task, now: testNow);
       expect(reminder, deadline.subtract(const Duration(days: 1)));
+    });
+  });
+
+  group('TaskReminderPlanner.computeReminderTimes (rolling window)', () {
+    test('returns multiple reminders for recurring tasks', () {
+      final task = buildTask(
+        reminderMode: TaskReminderMode.dayBefore,
+        recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.daily),
+        recurrenceAnchorDate: DateTime(2026, 8, 1, 10),
+        endDate: null,
+      );
+      final reminders = TaskReminderPlanner.computeReminderTimes(
+        task,
+        now: DateTime(2026, 8, 2, 8),
+        windowSize: 3,
+      );
+      expect(reminders, hasLength(3));
+      // Each reminder is 1 day before the occurrence (or now+2s if past).
+      expect(reminders[0].isBefore(reminders[1]), isTrue);
+    });
+
+    test('returns empty for completed one-shot tasks', () {
+      final task = buildTask(isCompleted: true);
+      expect(TaskReminderPlanner.computeReminderTimes(task, now: testNow), isEmpty);
     });
   });
 }

--- a/test/domain/tasks/task_service_test.dart
+++ b/test/domain/tasks/task_service_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:focus/core/utils/result.dart';
+import 'package:focus/features/tasks/domain/entities/recurrence_rule.dart';
 import 'package:focus/features/tasks/domain/entities/task.dart';
+import 'package:focus/features/tasks/domain/entities/task_completion.dart';
+import 'package:focus/features/tasks/domain/entities/task_completion_extensions.dart';
 import 'package:focus/features/tasks/domain/entities/task_extensions.dart';
 import 'package:focus/features/tasks/domain/entities/task_status.dart';
 import 'package:focus/features/tasks/domain/repositories/i_task_repository.dart';
@@ -21,6 +24,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(buildTask());
+    registerFallbackValue(buildCompletion());
   });
 
   setUp(() {
@@ -82,6 +86,48 @@ void main() {
     final result = await service.toggleTaskCompletion(task);
     expect(result, isA<Success<void>>());
     verify(() => notifications.scheduleTaskReminder(any())).called(1);
+  });
+
+  test('completeOccurrence marks non-recurring task done', () async {
+    when(() => repository.getTaskById(4)).thenAnswer((_) async => buildTask(id: 4, isCompleted: false));
+    when(() => repository.updateTask(any())).thenAnswer((_) async {});
+
+    final result = await service.completeOccurrence(4, DateTime(2026, 8, 2));
+    expect(result, isA<Success<TaskCompletion?>>());
+    expect((result as Success<TaskCompletion?>).value, isNull);
+    final captured = verify(() => repository.updateTask(captureAny())).captured.single as Task;
+    expect(captured.status, TaskStatus.done);
+    verify(() => notifications.cancelTaskReminder(4)).called(1);
+    verifyNever(() => repository.upsertCompletion(any()));
+  });
+
+  test('completeOccurrence upserts completion for recurring tasks', () async {
+    final task = buildTask(
+      id: 9,
+      recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.daily),
+      recurrenceAnchorDate: DateTime(2026, 8, 1),
+      isHabit: true,
+      endDate: null,
+    );
+    when(() => repository.getTaskById(9)).thenAnswer((_) async => task);
+    when(() => repository.upsertCompletion(any())).thenAnswer((invocation) async {
+      final c = invocation.positionalArguments.first as TaskCompletion;
+      return c.copyWith(id: 42);
+    });
+
+    final result = await service.completeOccurrence(9, DateTime(2026, 8, 2, 15));
+    expect(result, isA<Success<TaskCompletion?>>());
+    final saved = (result as Success<TaskCompletion?>).value!;
+    expect(saved.id, 42);
+    expect(saved.occurrenceDate, DateTime(2026, 8, 2));
+    verify(() => notifications.scheduleTaskReminder(task)).called(1);
+    verifyNever(() => repository.updateTask(any()));
+  });
+
+  test('completeOccurrence returns NotFound when task missing', () async {
+    when(() => repository.getTaskById(99)).thenAnswer((_) async => null);
+    final result = await service.completeOccurrence(99, DateTime(2026, 8, 2));
+    expect(result, isA<Failure<TaskCompletion?>>());
   });
 
   test('createTask returns Failure when repository throws', () async {

--- a/test/helpers/fixtures.dart
+++ b/test/helpers/fixtures.dart
@@ -5,7 +5,9 @@ import 'package:focus/features/projects/domain/entities/project_status.dart';
 import 'package:focus/features/session/domain/entities/focus_session.dart';
 import 'package:focus/features/session/domain/entities/session_state.dart';
 import 'package:focus/features/tags/domain/entities/tag.dart';
+import 'package:focus/features/tasks/domain/entities/recurrence_rule.dart';
 import 'package:focus/features/tasks/domain/entities/task.dart';
+import 'package:focus/features/tasks/domain/entities/task_completion.dart';
 import 'package:focus/features/tasks/domain/entities/task_priority.dart';
 import 'package:focus/features/tasks/domain/entities/task_reminder_mode.dart';
 import 'package:focus/features/tasks/domain/entities/task_status.dart';
@@ -28,6 +30,9 @@ Task buildTask({
   int? estimatedMinutes,
   double sortOrder = 0,
   int? milestoneId,
+  RecurrenceRule? recurrenceRule,
+  DateTime? recurrenceAnchorDate,
+  bool isHabit = false,
   bool isCompleted = false,
   DateTime? createdAt,
   DateTime? updatedAt,
@@ -50,6 +55,9 @@ Task buildTask({
     estimatedMinutes: estimatedMinutes,
     sortOrder: sortOrder,
     milestoneId: milestoneId,
+    recurrenceRule: recurrenceRule,
+    recurrenceAnchorDate: recurrenceAnchorDate,
+    isHabit: isHabit,
     createdAt: created,
     updatedAt: updatedAt ?? created,
     deletedAt: deletedAt,
@@ -57,6 +65,29 @@ Task buildTask({
 }
 
 const _sentinel = Object();
+
+TaskCompletion buildCompletion({
+  int? id = 1,
+  String? uuid,
+  int taskId = 1,
+  DateTime? occurrenceDate,
+  DateTime? completedAt,
+  DateTime? createdAt,
+  DateTime? updatedAt,
+  DateTime? deletedAt,
+}) {
+  final created = createdAt ?? testNow;
+  return TaskCompletion(
+    id: id,
+    uuid: uuid ?? 'completion-uuid-${id ?? 0}',
+    taskId: taskId,
+    occurrenceDate: occurrenceDate ?? DateTime(testNow.year, testNow.month, testNow.day),
+    completedAt: completedAt ?? created,
+    createdAt: created,
+    updatedAt: updatedAt ?? created,
+    deletedAt: deletedAt,
+  );
+}
 
 Project buildProject({
   int? id = 1,


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch feat/phase-3-recurrence-habits into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
6c52123 feat(habits): add recurrence rules and habit streak tracking
66561f0 feat(projects): add task/project status, tags, and milestones
b8c42ab feat(sync): add uuid identity and soft-delete tombstones
da236d4 feat(ui): collapse list filters and adopt ForUI desktop chrome
dfc058e fix(deps): pin sqlite3 to analyzer-compatible major
ffb349f chore(deps): declare sqlite3 for migration harness tests
a973c42 test(foundation): add domain tests and Drift migration harness
a360273 chore(deps): upgrade Flutter, ForUI, and related packages to current majors
66dfbd0 docs(agents): add Dart/Flutter style rules for shorthands and opacity

### Files
- .agents/docs/architecture.md
- .agents/docs/coding_style.md
- .agents/docs/commands.md
- .agents/docs/patterns.md
- .fvmrc
- AGENTS.md
- lib/core/app.dart
- lib/core/config/theme/app_theme.dart
- lib/core/config/theme/card_style.dart
- lib/core/config/theme/theme_builder.dart
- lib/core/config/theme/typography/typography.dart
- lib/core/constants/notification_constants.dart
- lib/core/di/injection.dart
- lib/core/providers/expansion_provider.g.dart
- lib/core/services/db_service.dart
- lib/core/services/db_service.g.dart
- lib/core/services/log_service.dart
- lib/core/utils/date_time_utils.dart
- lib/core/utils/id_utils.dart
- lib/core/widgets/action_menu_button.dart
- lib/core/widgets/adaptive_shell.dart
- lib/core/widgets/adaptive_shell_desktop_layout.dart
- lib/core/widgets/app_card.dart
- lib/core/widgets/app_search_bar.dart
- lib/core/widgets/base_form_screen.dart
- lib/core/widgets/confirmation_dialog.dart
- lib/core/widgets/list_toolbar.dart
- lib/core/widgets/master_detail_layout.dart
- lib/core/widgets/sort_filter_chips.dart
- lib/core/widgets/time_field.dart
- lib/features/home/presentation/pages/home_screen.dart
- lib/features/home/presentation/providers/activity_graph_providers.g.dart
- lib/features/home/presentation/providers/upcoming_calendar_state_provider.g.dart
- lib/features/home/presentation/providers/upcoming_calendar_view_provider.g.dart
- lib/features/home/presentation/widgets/calendar_content.dart
- lib/features/home/presentation/widgets/calendar_view_toggle.dart
- lib/features/home/presentation/widgets/global_stats_row.dart
- lib/features/home/presentation/widgets/overlay_task_tile.dart
- lib/features/home/presentation/widgets/quick_session_button.dart
- lib/features/home/presentation/widgets/recent_project_tile.dart
- lib/features/home/presentation/widgets/recent_task_tile.dart
- lib/features/home/presentation/widgets/section_header.dart
- lib/features/home/presentation/widgets/streak_badge.dart
- lib/features/home/presentation/widgets/task_popup_content.dart
- lib/features/home/presentation/widgets/today_summary_card.dart
- lib/features/milestones/data/datasources/milestone_local_datasource.dart
- lib/features/milestones/data/mappers/milestone_extensions.dart
- lib/features/milestones/data/models/milestone_model.dart
- lib/features/milestones/data/repositories/milestone_repository_impl.dart
- lib/features/milestones/domain/entities/milestone.dart
- lib/features/milestones/domain/entities/milestone_extensions.dart
- lib/features/milestones/domain/repositories/i_milestone_repository.dart
- lib/features/milestones/domain/services/milestone_service.dart
- lib/features/projects/data/datasources/project_local_datasource.dart
- lib/features/projects/data/mappers/project_extensions.dart
- lib/features/projects/data/models/project_model.dart
- lib/features/projects/data/repositories/project_repository_impl.dart
- lib/features/projects/domain/entities/project.dart
- lib/features/projects/domain/entities/project_extensions.dart
- lib/features/projects/domain/entities/project_list_filter_state.dart
- lib/features/projects/domain/entities/project_status.dart
- lib/features/projects/domain/repositories/i_project_repository.dart
- lib/features/projects/domain/services/project_service.dart
- lib/features/projects/presentation/providers/filtered_project_list_provider.part.dart
- lib/features/projects/presentation/providers/project_list_filter_provider.part.dart
- lib/features/projects/presentation/providers/project_provider.dart
- lib/features/projects/presentation/providers/project_provider.g.dart
- lib/features/projects/presentation/screens/create_project_screen.dart
- lib/features/projects/presentation/screens/edit_project_screen.dart
- lib/features/projects/presentation/screens/project_detail_screen.dart
- lib/features/projects/presentation/screens/project_list_screen.dart
- lib/features/projects/presentation/screens/projects_screen.g.dart
- lib/features/projects/presentation/widgets/project_card.dart
- lib/features/projects/presentation/widgets/project_detail_header.dart
- lib/features/projects/presentation/widgets/project_filter_panel.dart
- lib/features/projects/presentation/widgets/project_meta_section.dart
- lib/features/reports/presentation/providers/reports_insights_window_provider.g.dart
- lib/features/reports/presentation/widgets/focus_ratio_chart.dart
- lib/features/reports/presentation/widgets/insights_window_toggle.dart
- lib/features/reports/presentation/widgets/productivity_insights_section.dart
- lib/features/session/data/datasources/focus_local_datasource.dart
- lib/features/session/data/mappers/focus_session_mappers.dart
- lib/features/session/data/models/focus_session_model.dart
- lib/features/session/data/repositories/focus_session_repository_impl.dart
- lib/features/session/domain/entities/focus_session.dart
- lib/features/session/domain/entities/focus_session_extensions.dart
- lib/features/session/domain/services/focus_session_service.dart
- lib/features/session/domain/services/focus_session_state_machine.dart
- lib/features/session/presentation/commands/focus_commands.dart
- lib/features/session/presentation/providers/ambience_mute_provider.g.dart
- lib/features/session/presentation/providers/focus_screen_provider.g.dart
- lib/features/session/presentation/providers/focus_session_provider.dart
- lib/features/session/presentation/providers/focus_session_provider.g.dart
- lib/features/session/presentation/screens/focus_session_screen.dart
- lib/features/session/presentation/widgets/ambience_marquee_row.dart
- lib/features/session/presentation/widgets/circular_timer.dart
- lib/features/session/presentation/widgets/focus_controls_with_callback.dart
- lib/features/session/presentation/widgets/focus_task_info.dart
- lib/features/session/presentation/widgets/mini_player_overlay.dart
- lib/features/settings/domain/entities/setting.dart
- lib/features/settings/domain/services/settings_service.dart
- lib/features/settings/presentation/providers/settings_provider.g.dart
- lib/features/settings/presentation/widgets/expandable_section.dart
- lib/features/settings/presentation/widgets/sound_item_tile.dart
- lib/features/settings/presentation/widgets/timer_settings_card.dart
- lib/features/sync/data/services/google_drive_service.dart
- lib/features/sync/domain/entities/sync_data.dart
- lib/features/sync/domain/services/sync_purge_service.dart
- lib/features/sync/presentation/providers/sync_provider.g.dart
- lib/features/sync/presentation/screens/sync_conflict_screen.dart
- lib/features/sync/presentation/widgets/sync_settings_card.dart
- lib/features/tags/data/datasources/tag_local_datasource.dart
- lib/features/tags/data/mappers/tag_extensions.dart
- lib/features/tags/data/models/tag_model.dart
- lib/features/tags/data/models/task_tag_model.dart
- lib/features/tags/data/repositories/tag_repository_impl.dart
- lib/features/tags/domain/entities/tag.dart
- lib/features/tags/domain/entities/tag_extensions.dart
- lib/features/tags/domain/repositories/i_tag_repository.dart
- lib/features/tags/domain/services/tag_service.dart
- lib/features/tasks/data/datasources/task_local_datasource.dart
- lib/features/tasks/data/datasources/task_stats_local_datasource.dart
- lib/features/tasks/data/mappers/task_completion_extensions.dart
- lib/features/tasks/data/mappers/task_extensions.dart
- lib/features/tasks/data/models/task_completion_model.dart
- lib/features/tasks/data/models/task_model.dart
- lib/features/tasks/data/repositories/task_repository_impl.dart
- lib/features/tasks/domain/entities/all_tasks_filter_state.dart
- lib/features/tasks/domain/entities/daily_session_stats.dart
- lib/features/tasks/domain/entities/global_stats.dart
- lib/features/tasks/domain/entities/recurrence_rule.dart
- lib/features/tasks/domain/entities/recurrence_rule.mapper.dart
- lib/features/tasks/domain/entities/task.dart
- lib/features/tasks/domain/entities/task_completion.dart
- lib/features/tasks/domain/entities/task_completion_extensions.dart
- lib/features/tasks/domain/entities/task_extensions.dart
- lib/features/tasks/domain/entities/task_stats.dart
- lib/features/tasks/domain/entities/task_status.dart
- lib/features/tasks/domain/repositories/i_task_repository.dart
- lib/features/tasks/domain/services/habit_streak_calculator.dart
- lib/features/tasks/domain/services/recurrence_expander.dart
- lib/features/tasks/domain/services/task_notification_service.dart
- lib/features/tasks/domain/services/task_reminder_planner.dart
- lib/features/tasks/domain/services/task_service.dart
- lib/features/tasks/presentation/providers/all_tasks_provider.dart
- lib/features/tasks/presentation/providers/all_tasks_provider.g.dart
- lib/features/tasks/presentation/providers/filtered_all_tasks_provider.part.dart
- lib/features/tasks/presentation/providers/filtered_tasks_provider.part.dart
- lib/features/tasks/presentation/providers/selected_task_selection.g.dart
- lib/features/tasks/presentation/providers/task_filter_state.dart
- lib/features/tasks/presentation/providers/task_list_filter_provider.part.dart
- lib/features/tasks/presentation/providers/task_provider.dart
- lib/features/tasks/presentation/providers/task_provider.g.dart
- lib/features/tasks/presentation/screens/all_tasks_screen.dart
- lib/features/tasks/presentation/screens/create_task_screen.dart
- lib/features/tasks/presentation/screens/create_task_with_project_screen.dart
- lib/features/tasks/presentation/screens/edit_task_screen.dart
- lib/features/tasks/presentation/screens/task_detail_screen.dart
- lib/features/tasks/presentation/widgets/add_subtask_chip.dart
- lib/features/tasks/presentation/widgets/all_tasks_content.dart
- lib/features/tasks/presentation/widgets/all_tasks_filter_panel.dart
- lib/features/tasks/presentation/widgets/all_tasks_filters.dart
- lib/features/tasks/presentation/widgets/all_tasks_list.dart
- lib/features/tasks/presentation/widgets/create_task_new_project_hint.dart
- lib/features/tasks/presentation/widgets/create_task_project_autocomplete.dart
- lib/features/tasks/presentation/widgets/embedded_create_task_button.dart
- lib/features/tasks/presentation/widgets/inline_add_subtask.dart
- lib/features/tasks/presentation/widgets/recent_session_tile.dart
- lib/features/tasks/presentation/widgets/subtask_count_chip.dart
- lib/features/tasks/presentation/widgets/subtasks_section.dart
- lib/features/tasks/presentation/widgets/task_date_row.dart
- lib/features/tasks/presentation/widgets/task_priority_badge.dart
- lib/features/tasks/presentation/widgets/task_quick_actions.dart
- lib/features/tasks/presentation/widgets/task_stats_row.dart
- lib/features/tasks/presentation/widgets/task_summary_section.dart
- lib/main.dart
- linux/flutter/generated_plugin_registrant.cc
- linux/flutter/generated_plugins.cmake
- macos/Flutter/GeneratedPluginRegistrant.swift
- macos/Podfile.lock
- macos/Runner.xcodeproj/project.pbxproj
- macos/Runner.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
- macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
- macos/Runner.xcworkspace/xcshareddata/swiftpm/Package.resolved
- pubspec.lock
- pubspec.yaml
- test/core/db/migration_harness_test.dart
- test/domain/projects/project_service_test.dart
- test/domain/session/focus_session_state_machine_test.dart
- test/domain/tasks/habit_streak_calculator_test.dart
- test/domain/tasks/recurrence_expander_test.dart
- test/domain/tasks/task_reminder_planner_test.dart
- test/domain/tasks/task_service_test.dart
- test/helpers/fixtures.dart
- windows/flutter/generated_plugin_registrant.cc
- windows/flutter/generated_plugins.cmake

### Diffstat
 .agents/docs/architecture.md                       |    26 +-
 .agents/docs/coding_style.md                       |     5 +
 .agents/docs/commands.md                           |    12 +
 .agents/docs/patterns.md                           |    76 +
 .fvmrc                                             |     2 +-
 AGENTS.md                                          |     2 +-
 lib/core/app.dart                                  |     5 +-
 lib/core/config/theme/app_theme.dart               |     4 +-
 lib/core/config/theme/card_style.dart              |     8 +-
 lib/core/config/theme/theme_builder.dart           |    25 +-
 lib/core/config/theme/typography/typography.dart   |    13 +-
 lib/core/constants/notification_constants.dart     |    12 +
 lib/core/di/injection.dart                         |    26 +
 lib/core/providers/expansion_provider.g.dart       |    12 +-
 lib/core/services/db_service.dart                  |   140 +-
 lib/core/services/db_service.g.dart                | 11309 +++++++++++++------
 lib/core/services/log_service.dart                 |     8 +-
 lib/core/utils/date_time_utils.dart                |     2 +-
 lib/core/utils/id_utils.dart                       |     6 +
 lib/core/widgets/action_menu_button.dart           |    16 +-
 lib/core/widgets/adaptive_shell.dart               |    26 +-
 .../widgets/adaptive_shell_desktop_layout.dart     |    50 +-
 lib/core/widgets/app_card.dart                     |     4 +-
 lib/core/widgets/app_search_bar.dart               |     2 +-
 lib/core/widgets/base_form_screen.dart             |    86 +-
 lib/core/widgets/confirmation_dialog.dart          |    47 +-
 lib/core/widgets/list_toolbar.dart                 |   133 +
 lib/core/widgets/master_detail_layout.dart         |    22 +-
 lib/core/widgets/sort_filter_chips.dart            |     2 +-
 lib/core/widgets/time_field.dart                   |     6 +-
 .../home/presentation/pages/home_screen.dart       |     8 +-
 .../providers/activity_graph_providers.g.dart      |    48 +-
 .../upcoming_calendar_state_provider.g.dart        |     4 +-
 .../upcoming_calendar_view_provider.g.dart         |     4 +-
 .../presentation/widgets/calendar_content.dart     |     9 +-
 .../presentation/widgets/calendar_view_toggle.dart |     4 +-
 .../presentation/widgets/global_stats_row.dart     |     6 +-
 .../presentation/widgets/overlay_task_tile.dart    |     2 +-
 .../presentation/widgets/quick_session_button.dart |    24 +-
 .../presentation/widgets/recent_project_tile.dart  |     8 +-
 .../presentation/widgets/recent_task_tile.dart     |     4 +-
 .../home/presentation/widgets/section_header.dart  |     2 +-
 .../home/presentation/widgets/streak_badge.dart    |     2 +-
 .../presentation/widgets/task_popup_content.dart   |     6 +-
 .../presentation/widgets/today_summary_card.dart   |     2 +-
 .../datasources/milestone_local_datasource.dart    |    87 +
 .../data/mappers/milestone_extensions.dart         |    43 +
 .../milestones/data/models/milestone_model.dart    |    24 +
 .../repositories/milestone_repository_impl.dart    |    70 +
 .../milestones/domain/entities/milestone.dart      |    29 +
 .../domain/entities/milestone_extensions.dart      |    31 +
 .../repositories/i_milestone_repository.dart       |    15 +
 .../domain/services/milestone_service.dart         |    68 +
 .../data/datasources/project_local_datasource.dart |    58 +-
 .../projects/data/mappers/project_extensions.dart  |    12 +
 .../projects/data/models/project_model.dart        |    14 +
 .../data/repositories/project_repository_impl.dart |     9 +-
 lib/features/projects/domain/entities/project.dart |    22 +-
 .../domain/entities/project_extensions.dart        |     9 +
 .../domain/entities/project_list_filter_state.dart |     7 +
 .../projects/domain/entities/project_status.dart   |    16 +
 .../domain/repositories/i_project_repository.dart  |     2 +
 .../projects/domain/services/project_service.dart  |    13 +-
 .../filtered_project_list_provider.part.dart       |     1 +
 .../project_list_filter_provider.part.dart         |    18 +-
 .../presentation/providers/project_provider.dart   |     1 +
 .../presentation/providers/project_provider.g.dart |    10 +-
 .../screens/create_project_screen.dart             |    15 +-
 .../presentation/screens/edit_project_screen.dart  |    13 +-
 .../screens/project_detail_screen.dart             |    10 +-
 .../presentation/screens/project_list_screen.dart  |   105 +-
 .../presentation/screens/projects_screen.g.dart    |     4 +-
 .../presentation/widgets/project_card.dart         |     6 +-
 .../widgets/project_detail_header.dart             |     2 +-
 .../presentation/widgets/project_filter_panel.dart |    37 +
 .../presentation/widgets/project_meta_section.dart |    12 +-
 .../reports_insights_window_provider.g.dart        |     4 +-
 .../presentation/widgets/focus_ratio_chart.dart    |     7 +-
 .../widgets/insights_window_toggle.dart            |     4 +-
 .../widgets/productivity_insights_section.dart     |     2 +-
 .../data/datasources/focus_local_datasource.dart   |    24 +-
 .../data/mappers/focus_session_mappers.dart        |     6 +
 .../session/data/models/focus_session_model.dart   |     5 +
 .../focus_session_repository_impl.dart             |     7 +-
 .../session/domain/entities/focus_session.dart     |     7 +
 .../domain/entities/focus_session_extensions.dart  |     8 +-
 .../domain/services/focus_session_service.dart     |     3 +-
 .../services/focus_session_state_machine.dart      |    18 +-
 .../presentation/commands/focus_commands.dart      |     2 +-
 .../providers/ambience_mute_provider.g.dart        |     4 +-
 .../providers/focus_screen_provider.g.dart         |     4 +-
 .../providers/focus_session_provider.dart          |     3 +
 .../providers/focus_session_provider.g.dart        |     6 +-
 .../presentation/screens/focus_session_screen.dart |     2 +-
 .../presentation/widgets/ambience_marquee_row.dart |     4 +-
 .../presentation/widgets/circular_timer.dart       |     4 +-
 .../widgets/focus_controls_with_callback.dart      |    62 +-
 .../presentation/widgets/focus_task_info.dart      |     2 +-
 .../presentation/widgets/mini_player_overlay.dart  |     2 +-
 lib/features/settings/domain/entities/setting.dart |     3 +
 .../settings/domain/services/settings_service.dart |    12 +
 .../providers/settings_provider.g.dart             |     8 +-
 .../presentation/widgets/expandable_section.dart   |     2 +-
 .../presentation/widgets/sound_item_tile.dart      |     4 +-
 .../presentation/widgets/timer_settings_card.dart  |     6 +-
 .../sync/data/services/google_drive_service.dart   |    73 +-
 lib/features/sync/domain/entities/sync_data.dart   |   130 +-
 .../sync/domain/services/sync_purge_service.dart   |    87 +
 .../presentation/providers/sync_provider.g.dart    |     4 +-
 .../presentation/screens/sync_conflict_screen.dart |     6 +-
 .../presentation/widgets/sync_settings_card.dart   |     4 +-
 .../data/datasources/tag_local_datasource.dart     |   110 +
 lib/features/tags/data/mappers/tag_extensions.dart |    40 +
 lib/features/tags/data/models/tag_model.dart       |    21 +
 lib/features/tags/data/models/task_tag_model.dart  |    14 +
 .../data/repositories/tag_repository_impl.dart     |    79 +
 lib/features/tags/domain/entities/tag.dart         |    27 +
 .../tags/domain/entities/tag_extensions.dart       |    29 +
 .../tags/domain/repositories/i_tag_repository.dart |    19 +
 lib/features/tags/domain/services/tag_service.dart |    67 +
 .../data/datasources/task_local_datasource.dart    |   192 +-
 .../datasources/task_stats_local_datasource.dart   |    14 +-
 .../data/mappers/task_completion_extensions.dart   |    45 +
 .../tasks/data/mappers/task_extensions.dart        |    52 +-
 .../tasks/data/models/task_completion_model.dart   |    26 +
 lib/features/tasks/data/models/task_model.dart     |    29 +
 .../data/repositories/task_repository_impl.dart    |    35 +
 .../domain/entities/all_tasks_filter_state.dart    |     5 +
 .../tasks/domain/entities/daily_session_stats.dart |     4 +-
 .../tasks/domain/entities/global_stats.dart        |    13 +-
 .../tasks/domain/entities/recurrence_rule.dart     |    64 +
 .../domain/entities/recurrence_rule.mapper.dart    |   272 +
 lib/features/tasks/domain/entities/task.dart       |    42 +-
 .../tasks/domain/entities/task_completion.dart     |    41 +
 .../entities/task_completion_extensions.dart       |    29 +
 .../tasks/domain/entities/task_extensions.dart     |    28 +-
 lib/features/tasks/domain/entities/task_stats.dart |     9 +-
 .../tasks/domain/entities/task_status.dart         |    16 +
 .../domain/repositories/i_task_repository.dart     |    14 +
 .../domain/services/habit_streak_calculator.dart   |   130 +
 .../tasks/domain/services/recurrence_expander.dart |   165 +
 .../domain/services/task_notification_service.dart |    38 +-
 .../domain/services/task_reminder_planner.dart     |    74 +-
 .../tasks/domain/services/task_service.dart        |    80 +-
 .../presentation/providers/all_tasks_provider.dart |     7 +
 .../providers/all_tasks_provider.g.dart            |     6 +-
 .../filtered_all_tasks_provider.part.dart          |     1 +
 .../providers/filtered_tasks_provider.part.dart    |     1 +
 .../providers/selected_task_selection.g.dart       |    22 +-
 .../presentation/providers/task_filter_state.dart  |     5 +
 .../providers/task_list_filter_provider.part.dart  |     6 +
 .../presentation/providers/task_provider.dart      |     1 +
 .../presentation/providers/task_provider.g.dart    |    10 +-
 .../presentation/screens/all_tasks_screen.dart     |    31 +-
 .../presentation/screens/create_task_screen.dart   |    15 +-
 .../screens/create_task_with_project_screen.dart   |    15 +-
 .../presentation/screens/edit_task_screen.dart     |    13 +-
 .../presentation/screens/task_detail_screen.dart   |    12 +-
 .../presentation/widgets/add_subtask_chip.dart     |     4 +-
 .../presentation/widgets/all_tasks_content.dart    |    56 +-
 .../widgets/all_tasks_filter_panel.dart            |    62 +
 .../presentation/widgets/all_tasks_filters.dart    |   107 -
 .../tasks/presentation/widgets/all_tasks_list.dart |     2 +-
 .../widgets/create_task_new_project_hint.dart      |     2 +-
 .../widgets/create_task_project_autocomplete.dart  |     2 +-
 .../widgets/embedded_create_task_button.dart       |    25 -
 .../presentation/widgets/inline_add_subtask.dart   |     2 +-
 .../presentation/widgets/recent_session_tile.dart  |     8 +-
 .../presentation/widgets/subtask_count_chip.dart   |     7 +-
 .../presentation/widgets/subtasks_section.dart     |     4 +-
 .../tasks/presentation/widgets/task_date_row.dart  |     4 +-
 .../presentation/widgets/task_priority_badge.dart  |    10 +-
 .../presentation/widgets/task_quick_actions.dart   |    14 +-
 .../tasks/presentation/widgets/task_stats_row.dart |    18 +-
 .../presentation/widgets/task_summary_section.dart |    13 +-
 lib/main.dart                                      |     4 +
 linux/flutter/generated_plugin_registrant.cc       |     4 -
 linux/flutter/generated_plugins.cmake              |     2 +-
 macos/Flutter/GeneratedPluginRegistrant.swift      |     4 -
 macos/Podfile.lock                                 |    92 -
 macos/Runner.xcodeproj/project.pbxproj             |    42 +-
 .../xcshareddata/swiftpm/Package.resolved          |    77 +
 .../xcshareddata/xcschemes/Runner.xcscheme         |    18 +
 .../xcshareddata/swiftpm/Package.resolved          |    77 +
 pubspec.lock                                       |   446 +-
 pubspec.yaml                                       |    68 +-
 test/core/db/migration_harness_test.dart           |   474 +
 test/domain/projects/project_service_test.dart     |    65 +
 .../session/focus_session_state_machine_test.dart  |   115 +
 .../domain/tasks/habit_streak_calculator_test.dart |   122 +
 test/domain/tasks/recurrence_expander_test.dart    |   160 +
 test/domain/tasks/task_reminder_planner_test.dart  |   113 +
 test/domain/tasks/task_service_test.dart           |   138 +
 test/helpers/fixtures.dart                         |   190 +
 windows/flutter/generated_plugin_registrant.cc     |     3 -
 windows/flutter/generated_plugins.cmake            |     2 +-
 196 files changed, 13664 insertions(+), 4372 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
