### PR TITLE
feat(home): Phase 5 dashboard agenda and habits strip

### DIFF
--- a/.agents/docs/patterns.md
+++ b/.agents/docs/patterns.md
@@ -346,16 +346,27 @@ final streak = HabitStreakCalculator.calculate(
   from: windowStart,
   to: windowEnd,
 );
+
+// Home dashboard agenda + habits strip (pure)
+final agenda = TodayAgendaBuilder.buildAgenda(
+  tasks: deadlineTasks,
+  completionsByTaskId: completionsByTaskId,
+  today: DateTimeUtils.now(),
+);
 ```
 
 Reminder scheduling uses a rolling window (`TaskReminderPlanner.computeReminderTimes`) so
 `flutter_local_notifications` only holds the next few occurrence reminders.
+
+Home `todayAgendaProvider` / `habitsStripProvider` combine `watchTasksWithDeadlines()` with
+`watchAllCompletions()` via `asyncExpand` so habit checkboxes refresh without touching the task row.
 
 Gotchas:
 - Store `RecurrenceRule` as JSON text via `dart_mappable`; parse with `RecurrenceRule.tryParseJson`.
 - Unique `(task_id, occurrence_date)` is a **partial** index (`WHERE deleted_at IS NULL`).
 - Habits are recurring tasks with `isHabit = true` — no separate habit table.
 - Reschedule reminders after `completeOccurrence` so the window advances.
+- Home shows week strip only; month grid lives on Tasks / Calendar.
 
 ## Tasks View Modes + Sparse Board Ordering
 

--- a/lib/features/home/presentation/pages/home_screen.dart
+++ b/lib/features/home/presentation/pages/home_screen.dart
@@ -13,11 +13,12 @@ import '../../../../core/routing/routes.dart';
 import '../../../projects/presentation/providers/project_provider.dart';
 import '../../../tasks/domain/entities/global_stats.dart';
 import '../../../tasks/presentation/providers/task_stats_provider.dart';
-import '../widgets/empty_section.dart';
+import '../providers/habits_strip_provider.dart';
+import '../providers/today_agenda_provider.dart';
+import '../widgets/habits_strip_section.dart';
+import '../widgets/home_onboarding_card.dart';
 import '../widgets/quick_session_button.dart';
-import '../widgets/recent_project_tile.dart';
-import '../widgets/recent_task_tile.dart';
-import '../widgets/section_header.dart';
+import '../widgets/today_agenda_section.dart';
 import '../widgets/upcoming_calendar_card.dart';
 
 class HomeScreen extends ConsumerWidget {
@@ -27,14 +28,30 @@ class HomeScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final projectsAsync = ref.watch(projectListProvider);
     final globalStatsAsync = ref.watch(globalStatsProvider);
-    final recentTasksAsync = ref.watch(recentTasksProvider);
+    final agendaAsync = ref.watch(todayAgendaProvider);
+    final habitsAsync = ref.watch(habitsStripProvider);
 
     final stats = globalStatsAsync.value ?? GlobalStats.empty;
+    final projects = projectsAsync.value ?? const [];
+    final agenda = agendaAsync.value ?? const [];
+    final habits = habitsAsync.value ?? const [];
+
+    final showOnboarding =
+        projectsAsync.hasValue &&
+        agendaAsync.hasValue &&
+        habitsAsync.hasValue &&
+        projects.isEmpty &&
+        agenda.isEmpty &&
+        habits.isEmpty;
 
     return fu.FScaffold(
       header: fu.FHeader(
         suffixes: [
           if (stats.currentStreak > 0) StreakBadge(streak: stats.currentStreak),
+          fu.FHeaderAction(
+            icon: Icon(fu.FLucideIcons.chartBar, size: AppConstants.size.icon.regular),
+            onPress: () => context.push(AppRoutes.reports.path),
+          ),
           fu.FHeaderAction(
             icon: Icon(fu.FLucideIcons.settings, size: AppConstants.size.icon.regular),
             onPress: () => context.push(AppRoutes.settings.path),
@@ -62,53 +79,15 @@ class HomeScreen extends ConsumerWidget {
           spacing: AppConstants.spacing.regular,
           children: [
             const QuickSessionButton(),
-            fu.FButton(
-              variant: .outline,
-              onPress: () => context.push(AppRoutes.reports.path),
-              child: const Text('Open Reports'),
-            ),
-            SizedBox(height: AppConstants.spacing.regular),
-            SectionHeader(title: 'Upcoming Deadlines'),
-            const UpcomingCalendarCard(),
-            SectionHeader(
-              title: 'Recent Tasks',
-              onViewAll: () {
-                final projects = projectsAsync.value;
-                if (projects != null && projects.isNotEmpty) {
-                  context.push(AppRoutes.tasks.path);
-                }
-              },
-            ),
-            recentTasksAsync.when(
-              loading: () => const Center(child: fu.FCircularProgress()),
-              error: (err, _) => Padding(
-                padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.extraLarge2),
-                child: Text('Error: $err'),
-              ),
-              data: (tasks) {
-                if (tasks.isEmpty) {
-                  return const EmptySection(icon: fu.FLucideIcons.squareCheck, message: 'No tasks yet');
-                }
-                return Column(children: tasks.map((task) => RecentTaskTile(task: task)).toList());
-              },
-            ),
-            SizedBox(height: AppConstants.spacing.regular),
-            SectionHeader(title: 'Projects', onViewAll: () => context.push(AppRoutes.projects.path)),
-            projectsAsync.when(
-              loading: () => const Center(child: fu.FCircularProgress()),
-              error: (err, _) => Padding(
-                padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.extraLarge2),
-                child: Text('Error: $err'),
-              ),
-              data: (projects) {
-                if (projects.isEmpty) {
-                  return const EmptySection(icon: fu.FLucideIcons.folderOpen, message: 'No projects yet');
-                }
-                return Column(
-                  children: projects.take(3).map((project) => RecentProjectTile(project: project)).toList(),
-                );
-              },
-            ),
+            if (showOnboarding)
+              const HomeOnboardingCard()
+            else ...[
+              const TodayAgendaSection(),
+              SizedBox(height: AppConstants.spacing.small),
+              const HabitsStripSection(),
+              SizedBox(height: AppConstants.spacing.small),
+              const UpcomingCalendarCard(),
+            ],
           ],
         ),
       ),

--- a/lib/features/home/presentation/providers/habits_strip_provider.dart
+++ b/lib/features/home/presentation/providers/habits_strip_provider.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/utils/date_time_utils.dart';
+import '../../../tasks/domain/entities/habit_strip_item.dart';
+import '../../../tasks/domain/entities/task_completion.dart';
+import '../../../tasks/domain/services/today_agenda_builder.dart';
+import '../../../tasks/presentation/providers/task_provider.dart';
+
+Map<int, List<TaskCompletion>> _groupCompletions(List<TaskCompletion> completions) {
+  final map = <int, List<TaskCompletion>>{};
+  for (final c in completions) {
+    map.putIfAbsent(c.taskId, () => []).add(c);
+  }
+  return map;
+}
+
+/// Horizontally scrolling habits strip: today's completion + current streak.
+final habitsStripProvider = StreamProvider<List<HabitStripItem>>((ref) {
+  final repository = ref.watch(taskRepositoryProvider);
+  return repository.watchTasksWithDeadlines().asyncExpand((tasks) {
+    return repository.watchAllCompletions().map((completions) {
+      return TodayAgendaBuilder.buildHabitStrip(
+        tasks: tasks,
+        completionsByTaskId: _groupCompletions(completions),
+        today: DateTimeUtils.now(),
+      );
+    });
+  });
+});

--- a/lib/features/home/presentation/providers/today_agenda_provider.dart
+++ b/lib/features/home/presentation/providers/today_agenda_provider.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/utils/date_time_utils.dart';
+import '../../../tasks/domain/entities/task_completion.dart';
+import '../../../tasks/domain/entities/today_agenda_item.dart';
+import '../../../tasks/domain/services/today_agenda_builder.dart';
+import '../../../tasks/presentation/providers/task_provider.dart';
+
+Map<int, List<TaskCompletion>> _groupCompletions(List<TaskCompletion> completions) {
+  final map = <int, List<TaskCompletion>>{};
+  for (final c in completions) {
+    map.putIfAbsent(c.taskId, () => []).add(c);
+  }
+  return map;
+}
+
+/// Merged Today's Agenda: overdue, due today, and today's habit occurrences.
+///
+/// Combines [ITaskRepository.watchTasksWithDeadlines] with all completions so
+/// habit checkbox updates refresh without mutating the parent task row.
+final todayAgendaProvider = StreamProvider<List<TodayAgendaItem>>((ref) {
+  final repository = ref.watch(taskRepositoryProvider);
+  return repository.watchTasksWithDeadlines().asyncExpand((tasks) {
+    return repository.watchAllCompletions().map((completions) {
+      return TodayAgendaBuilder.buildAgenda(
+        tasks: tasks,
+        completionsByTaskId: _groupCompletions(completions),
+        today: DateTimeUtils.now(),
+      );
+    });
+  });
+});

--- a/lib/features/home/presentation/widgets/agenda_task_tile.dart
+++ b/lib/features/home/presentation/widgets/agenda_task_tile.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart' as fu;
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/config/theme/app_theme.dart';
+import '../../../../core/constants/app_constants.dart';
+import '../../../../core/routing/routes.dart';
+import '../../../../core/utils/datetime_formatter.dart';
+import '../../../session/presentation/commands/focus_commands.dart';
+import '../../../tasks/domain/entities/today_agenda_item.dart';
+import '../../../tasks/presentation/commands/task_commands.dart';
+import '../../../tasks/presentation/widgets/task_priority_badge.dart';
+
+class AgendaTaskTile extends ConsumerWidget {
+  final TodayAgendaItem item;
+
+  const AgendaTaskTile({super.key, required this.item});
+
+  String get _subtitle {
+    return switch (item.kind) {
+      TodayAgendaKind.overdue => item.occurrenceDate.toRelativeDueString(),
+      TodayAgendaKind.dueToday => 'Due today',
+      TodayAgendaKind.habitOccurrence => 'Habit',
+    };
+  }
+
+  Color _subtitleColor(BuildContext context) {
+    if (item.kind == TodayAgendaKind.overdue) return context.colors.destructive;
+    return context.colors.mutedForeground;
+  }
+
+  Future<void> _onToggle() async {
+    if (item.isCompleted) return;
+    await TaskCommands.completeAgendaItem(item);
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final task = item.task;
+
+    return GestureDetector(
+      onTap: () {
+        if (task.id == null) return;
+        context.push(AppRoutes.taskDetailPath(task.id!), extra: {'projectId': task.projectId});
+      },
+      child: fu.FCard(
+        child: Padding(
+          padding: EdgeInsets.all(AppConstants.spacing.regular),
+          child: Row(
+            children: [
+              fu.FCheckbox(value: item.isCompleted, onChange: item.isCompleted ? null : (_) => _onToggle()),
+              SizedBox(width: AppConstants.spacing.regular),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      task.title,
+                      style: context.typography.sm.copyWith(
+                        fontWeight: FontWeight.w500,
+                        color: item.isCompleted ? context.colors.mutedForeground : context.colors.foreground,
+                        decoration: item.isCompleted ? TextDecoration.lineThrough : null,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    SizedBox(height: AppConstants.spacing.extraSmall),
+                    Text(_subtitle, style: context.typography.xs.copyWith(color: _subtitleColor(context))),
+                  ],
+                ),
+              ),
+              TaskPriorityBadge(priority: task.priority),
+              if (!item.isCompleted && task.id != null) ...[
+                SizedBox(width: AppConstants.spacing.small),
+                fu.FButton(
+                  variant: .ghost,
+                  onPress: () => FocusCommands.start(context, ref, taskId: task.id!),
+                  child: Icon(fu.FLucideIcons.play, size: AppConstants.size.icon.extraSmall),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/calendar_content.dart
+++ b/lib/features/home/presentation/widgets/calendar_content.dart
@@ -6,17 +6,19 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/config/theme/app_theme.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/routing/routes.dart';
+import '../../../../core/utils/date_time_utils.dart';
 import '../../../../core/widgets/calendar/calendar_day_info.dart';
-import '../../../../core/widgets/calendar/calendar_month_grid.dart';
 import '../../../../core/widgets/calendar/calendar_week_strip.dart';
 import '../../../tasks/domain/entities/task.dart';
-import '../models/upcoming_calendar_ui_state.dart';
+import '../../../tasks/domain/services/calendar_event_grouping.dart';
 import '../providers/upcoming_calendar_state_provider.dart';
 import '../providers/upcoming_calendar_view_provider.dart';
 import '../utils/upcoming_calendar_utils.dart';
-import 'calendar_view_toggle.dart';
 import 'task_popup_content.dart';
 
+/// Compact "Next 7 Days" week strip for the home dashboard.
+///
+/// Month grid lives on the Tasks calendar tab.
 class CalendarContent extends ConsumerStatefulWidget {
   final List<Task> tasks;
 
@@ -36,46 +38,29 @@ class _CalendarContentState extends ConsumerState<CalendarContent> {
     super.dispose();
   }
 
-  Map<DateTime, List<Task>> get _tasksByDate {
-    return UpcomingCalendarUtils.groupTasksByDate(widget.tasks);
+  Map<DateTime, List<Task>> _tasksByDateForWeek(DateTime weekStart) {
+    final weekEnd = DateTimeUtils.addDays(weekStart, 6);
+    return CalendarEventGrouping.groupTasksByDate(tasks: widget.tasks, from: weekStart, to: weekEnd);
   }
 
-  Map<DateTime, CalendarDayInfo> get _dayInfo {
-    return {for (final entry in _tasksByDate.entries) entry.key: CalendarDayInfo(taskCount: entry.value.length)};
+  Map<DateTime, CalendarDayInfo> _dayInfo(Map<DateTime, List<Task>> tasksByDate) {
+    return {for (final entry in tasksByDate.entries) entry.key: CalendarDayInfo(taskCount: entry.value.length)};
   }
 
-  void _switchView({
-    required CalendarViewMode currentView,
-    required CalendarViewMode nextView,
-    required UpcomingCalendarUiState uiState,
-    required DateTime? selectedDay,
-  }) {
-    if (currentView == nextView) return;
-
-    final anchor = UpcomingCalendarUtils.resolveViewAnchor(
-      selectedDay: selectedDay,
-      uiSelectedDay: uiState.selectedDay,
-    );
+  void _previousWeek() {
     _removeOverlay();
-
-    ref.read(upcomingCalendarUiStateProvider.notifier).switchView(nextView, anchor: anchor);
-    ref.read(upcomingCalendarViewModeProvider.notifier).setMode(nextView);
+    ref.read(upcomingCalendarUiStateProvider.notifier).previousPeriod(CalendarViewMode.week);
   }
 
-  void _previousPeriod(CalendarViewMode viewMode) {
+  void _nextWeek() {
     _removeOverlay();
-    ref.read(upcomingCalendarUiStateProvider.notifier).previousPeriod(viewMode);
+    ref.read(upcomingCalendarUiStateProvider.notifier).nextPeriod(CalendarViewMode.week);
   }
 
-  void _nextPeriod(CalendarViewMode viewMode) {
-    _removeOverlay();
-    ref.read(upcomingCalendarUiStateProvider.notifier).nextPeriod(viewMode);
-  }
-
-  void _onDateTapped(DateTime date) {
+  void _onDateTapped(DateTime date, Map<DateTime, List<Task>> tasksByDate) {
     _removeOverlay();
     final normalized = UpcomingCalendarUtils.normalizeDate(date);
-    final tasks = _tasksByDate[normalized];
+    final tasks = tasksByDate[normalized];
     if (tasks == null || tasks.isEmpty) {
       ref.read(upcomingCalendarUiStateProvider.notifier).selectDay(null);
       return;
@@ -144,21 +129,16 @@ class _CalendarContentState extends ConsumerState<CalendarContent> {
   @override
   Widget build(BuildContext context) {
     final now = UpcomingCalendarUtils.today();
-    final viewModeAsync = ref.watch(upcomingCalendarViewModeProvider);
-    final viewMode = viewModeAsync.value ?? CalendarViewMode.month;
     final uiState = ref.watch(upcomingCalendarUiStateProvider);
-    final tasksByDate = _tasksByDate;
-    final dayInfo = _dayInfo;
+    final displayWeekStart = uiState.displayWeekStart;
+    final tasksByDate = _tasksByDateForWeek(displayWeekStart);
+    final dayInfo = _dayInfo(tasksByDate);
     final effectiveSelectedDay = UpcomingCalendarUtils.effectiveSelectedDay(
-      viewMode: viewMode,
+      viewMode: CalendarViewMode.week,
       uiState: uiState,
       tasksByDate: tasksByDate,
       today: now,
     );
-    final displayMonth = uiState.displayMonth;
-    final displayWeekStart = uiState.displayWeekStart;
-    final daysInMonth = UpcomingCalendarUtils.daysInMonth(displayMonth);
-    final firstWeekday = UpcomingCalendarUtils.firstWeekday(displayMonth);
 
     return CompositedTransformTarget(
       link: _calendarLayerLink,
@@ -168,26 +148,8 @@ class _CalendarContentState extends ConsumerState<CalendarContent> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text('This', style: context.typography.sm.copyWith(fontWeight: FontWeight.w600)),
-              CalendarViewToggle(
-                view: viewMode,
-                onChanged: (nextView) {
-                  _switchView(
-                    currentView: viewMode,
-                    nextView: nextView,
-                    uiState: uiState,
-                    selectedDay: effectiveSelectedDay,
-                  );
-                },
-              ),
-            ],
-          ),
-          SizedBox(height: AppConstants.spacing.regular),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
               GestureDetector(
-                onTap: () => _previousPeriod(viewMode),
+                onTap: _previousWeek,
                 child: Icon(
                   fu.FLucideIcons.chevronLeft,
                   size: AppConstants.size.icon.regular,
@@ -196,14 +158,14 @@ class _CalendarContentState extends ConsumerState<CalendarContent> {
               ),
               Text(
                 UpcomingCalendarUtils.periodLabel(
-                  viewMode: viewMode,
-                  displayMonth: displayMonth,
+                  viewMode: CalendarViewMode.week,
+                  displayMonth: uiState.displayMonth,
                   displayWeekStart: displayWeekStart,
                 ),
                 style: context.typography.sm.copyWith(fontWeight: FontWeight.w600),
               ),
               GestureDetector(
-                onTap: () => _nextPeriod(viewMode),
+                onTap: _nextWeek,
                 child: Icon(
                   fu.FLucideIcons.chevronRight,
                   size: AppConstants.size.icon.regular,
@@ -213,42 +175,13 @@ class _CalendarContentState extends ConsumerState<CalendarContent> {
             ],
           ),
           SizedBox(height: AppConstants.spacing.regular),
-          if (viewMode == CalendarViewMode.month) ...[
-            Row(
-              children: ['M', 'T', 'W', 'T', 'F', 'S', 'S']
-                  .map(
-                    (d) => Expanded(
-                      child: Center(
-                        child: Text(
-                          d,
-                          style: context.typography.xs.copyWith(
-                            color: context.colors.mutedForeground,
-                            fontWeight: FontWeight.w500,
-                          ),
-                        ),
-                      ),
-                    ),
-                  )
-                  .toList(),
-            ),
-            SizedBox(height: AppConstants.spacing.small),
-            CalendarMonthGrid<Task>(
-              displayMonth: displayMonth,
-              daysInMonth: daysInMonth,
-              firstWeekday: firstWeekday,
-              dayInfo: dayInfo,
-              now: now,
-              selectedDay: effectiveSelectedDay,
-              onDateTap: _onDateTapped,
-            ),
-          ] else
-            CalendarWeekStrip<Task>(
-              weekStart: displayWeekStart,
-              dayInfo: dayInfo,
-              now: now,
-              selectedDay: effectiveSelectedDay,
-              onDateTap: _onDateTapped,
-            ),
+          CalendarWeekStrip<Task>(
+            weekStart: displayWeekStart,
+            dayInfo: dayInfo,
+            now: now,
+            selectedDay: effectiveSelectedDay,
+            onDateTap: (date) => _onDateTapped(date, tasksByDate),
+          ),
         ],
       ),
     );

--- a/lib/features/home/presentation/widgets/habit_ring.dart
+++ b/lib/features/home/presentation/widgets/habit_ring.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/config/theme/app_theme.dart';
+import '../../../../core/constants/app_constants.dart';
+import '../../../../core/utils/date_time_utils.dart';
+import '../../../tasks/domain/entities/habit_strip_item.dart';
+import '../../../tasks/presentation/commands/task_commands.dart';
+
+/// Circular progress ring for a single habit in the home strip.
+class HabitRing extends ConsumerWidget {
+  final HabitStripItem item;
+
+  const HabitRing({super.key, required this.item});
+
+  Future<void> _onTap() async {
+    if (item.completedToday || item.task.id == null) return;
+    await TaskCommands.completeHabitOccurrence(item.task, DateTimeUtils.now());
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final progress = item.completedToday ? 1.0 : 0.0;
+    final ringColor = item.completedToday
+        ? context.colors.primary
+        : item.dueToday
+        ? context.colors.primary.withValues(alpha: 0.35)
+        : context.colors.mutedForeground.withValues(alpha: 0.25);
+
+    return GestureDetector(
+      onTap: item.completedToday ? null : _onTap,
+      child: SizedBox(
+        width: 72,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: 56,
+              height: 56,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  SizedBox(
+                    width: 56,
+                    height: 56,
+                    child: CircularProgressIndicator(
+                      value: progress == 0 ? 0.08 : progress,
+                      strokeWidth: 3.5,
+                      backgroundColor: context.colors.mutedForeground.withValues(alpha: 0.12),
+                      color: ringColor,
+                    ),
+                  ),
+                  Text(
+                    item.currentStreak > 0 ? '${item.currentStreak}' : '·',
+                    style: context.typography.sm.copyWith(
+                      fontWeight: FontWeight.w700,
+                      color: item.completedToday ? context.colors.primary : context.colors.foreground,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(height: AppConstants.spacing.small),
+            Text(
+              item.task.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
+              style: context.typography.xs.copyWith(
+                color: item.completedToday ? context.colors.mutedForeground : context.colors.foreground,
+                decoration: item.completedToday ? TextDecoration.lineThrough : null,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/habits_strip_section.dart
+++ b/lib/features/home/presentation/widgets/habits_strip_section.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart' as fu;
+
+import '../../../../core/constants/app_constants.dart';
+import '../providers/habits_strip_provider.dart';
+import 'empty_section.dart';
+import 'habit_ring.dart';
+import 'section_header.dart';
+
+class HabitsStripSection extends ConsumerWidget {
+  const HabitsStripSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final habitsAsync = ref.watch(habitsStripProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      spacing: AppConstants.spacing.small,
+      children: [
+        const SectionHeader(title: 'Habits'),
+        habitsAsync.when(
+          loading: () => const Center(child: fu.FCircularProgress()),
+          error: (err, _) => Padding(
+            padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.extraLarge2),
+            child: Text('Error: $err'),
+          ),
+          data: (items) {
+            if (items.isEmpty) {
+              return const EmptySection(icon: fu.FLucideIcons.flame, message: 'No habits yet');
+            }
+            return SizedBox(
+              height: 96,
+              child: ListView.separated(
+                scrollDirection: Axis.horizontal,
+                itemCount: items.length,
+                separatorBuilder: (_, _) => SizedBox(width: AppConstants.spacing.regular),
+                itemBuilder: (context, index) => HabitRing(item: items[index]),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/home_onboarding_card.dart
+++ b/lib/features/home/presentation/widgets/home_onboarding_card.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:forui/forui.dart' as fu;
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/config/theme/app_theme.dart';
+import '../../../../core/constants/app_constants.dart';
+import '../../../../core/routing/routes.dart';
+
+/// Single empty-state card for brand-new users (replaces three empty sections).
+class HomeOnboardingCard extends StatelessWidget {
+  const HomeOnboardingCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return fu.FCard(
+      child: Padding(
+        padding: EdgeInsets.all(AppConstants.spacing.large),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(fu.FLucideIcons.sparkles, size: AppConstants.size.icon.large, color: context.colors.primary),
+            SizedBox(height: AppConstants.spacing.regular),
+            Text('Welcome to Focus', style: context.typography.lg.copyWith(fontWeight: FontWeight.w700)),
+            SizedBox(height: AppConstants.spacing.small),
+            Text(
+              'Create a project and add tasks or habits — your agenda and week strip will fill in here.',
+              style: context.typography.sm.copyWith(color: context.colors.mutedForeground),
+            ),
+            SizedBox(height: AppConstants.spacing.large),
+            fu.FButton(
+              onPress: () => context.push(AppRoutes.createProject.path),
+              prefix: const Icon(fu.FLucideIcons.plus, size: 14),
+              child: const Text('Create project'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/today_agenda_section.dart
+++ b/lib/features/home/presentation/widgets/today_agenda_section.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart' as fu;
+
+import '../../../../core/constants/app_constants.dart';
+import '../providers/today_agenda_provider.dart';
+import 'agenda_task_tile.dart';
+import 'empty_section.dart';
+import 'section_header.dart';
+
+class TodayAgendaSection extends ConsumerWidget {
+  const TodayAgendaSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final agendaAsync = ref.watch(todayAgendaProvider);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      spacing: AppConstants.spacing.small,
+      children: [
+        const SectionHeader(title: "Today's Agenda"),
+        agendaAsync.when(
+          loading: () => const Center(child: fu.FCircularProgress()),
+          error: (err, _) => Padding(
+            padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.extraLarge2),
+            child: Text('Error: $err'),
+          ),
+          data: (items) {
+            if (items.isEmpty) {
+              return const EmptySection(icon: fu.FLucideIcons.listTodo, message: 'Nothing on your agenda today');
+            }
+            return Column(
+              spacing: AppConstants.spacing.small,
+              children: [for (final item in items) AgendaTaskTile(item: item)],
+            );
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/upcoming_calendar_card.dart
+++ b/lib/features/home/presentation/widgets/upcoming_calendar_card.dart
@@ -5,11 +5,9 @@ import 'package:forui/forui.dart' as fu;
 import '../../../../core/constants/app_constants.dart';
 import '../providers/upcoming_tasks_provider.dart';
 import 'calendar_content.dart';
+import 'section_header.dart';
 
-/// A calendar-style view that shows upcoming task deadlines on the home screen.
-///
-/// Supports month and week views, highlighting days with upcoming deadlines.
-/// Tapping a day shows an overlay popup with that day's tasks.
+/// Home "Next 7 Days" section — week strip only (month grid is on Tasks).
 class UpcomingCalendarCard extends ConsumerWidget {
   const UpcomingCalendarCard({super.key});
 
@@ -17,13 +15,20 @@ class UpcomingCalendarCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final upcomingAsync = ref.watch(upcomingTasksProvider);
 
-    return upcomingAsync.when(
-      loading: () => const Center(child: fu.FCircularProgress()),
-      error: (err, _) => Padding(
-        padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.extraLarge2),
-        child: Text('Error loading calendar: $err'),
-      ),
-      data: (tasks) => CalendarContent(tasks: tasks),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      spacing: AppConstants.spacing.small,
+      children: [
+        const SectionHeader(title: 'Next 7 Days'),
+        upcomingAsync.when(
+          loading: () => const Center(child: fu.FCircularProgress()),
+          error: (err, _) => Padding(
+            padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.extraLarge2),
+            child: Text('Error loading calendar: $err'),
+          ),
+          data: (tasks) => CalendarContent(tasks: tasks),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/tasks/data/datasources/task_local_datasource.dart
+++ b/lib/features/tasks/data/datasources/task_local_datasource.dart
@@ -46,6 +46,9 @@ abstract class ITaskLocalDataSource {
   Future<void> softDeleteCompletion(int id);
 
   Stream<List<TaskCompletionTableData>> watchCompletionsForTask(int taskId);
+
+  /// Watches all non-deleted occurrence completions (for agenda / habit strip).
+  Stream<List<TaskCompletionTableData>> watchAllCompletions();
 }
 
 class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
@@ -376,6 +379,14 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
   Stream<List<TaskCompletionTableData>> watchCompletionsForTask(int taskId) {
     return (_db.select(_db.taskCompletionTable)
           ..where((t) => t.taskId.equals(taskId) & t.deletedAt.isNull())
+          ..orderBy([(t) => OrderingTerm.asc(t.occurrenceDate)]))
+        .watch();
+  }
+
+  @override
+  Stream<List<TaskCompletionTableData>> watchAllCompletions() {
+    return (_db.select(_db.taskCompletionTable)
+          ..where((t) => t.deletedAt.isNull())
           ..orderBy([(t) => OrderingTerm.asc(t.occurrenceDate)]))
         .watch();
   }

--- a/lib/features/tasks/data/repositories/task_repository_impl.dart
+++ b/lib/features/tasks/data/repositories/task_repository_impl.dart
@@ -155,4 +155,9 @@ class TaskRepositoryImpl implements ITaskRepository {
   Stream<List<TaskCompletion>> watchCompletionsForTask(int taskId) {
     return _local.watchCompletionsForTask(taskId).map((rows) => rows.map((r) => r.toDomain()).toList());
   }
+
+  @override
+  Stream<List<TaskCompletion>> watchAllCompletions() {
+    return _local.watchAllCompletions().map((rows) => rows.map((r) => r.toDomain()).toList());
+  }
 }

--- a/lib/features/tasks/domain/entities/habit_strip_item.dart
+++ b/lib/features/tasks/domain/entities/habit_strip_item.dart
@@ -1,0 +1,23 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+import 'task.dart';
+
+/// Compact habit summary for the home habits strip.
+@immutable
+class HabitStripItem extends Equatable {
+  final Task task;
+  final bool completedToday;
+  final int currentStreak;
+  final bool dueToday;
+
+  const HabitStripItem({
+    required this.task,
+    required this.completedToday,
+    required this.currentStreak,
+    required this.dueToday,
+  });
+
+  @override
+  List<Object?> get props => [task, completedToday, currentStreak, dueToday];
+}

--- a/lib/features/tasks/domain/entities/today_agenda_item.dart
+++ b/lib/features/tasks/domain/entities/today_agenda_item.dart
@@ -1,0 +1,39 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+import 'task.dart';
+
+/// Why a task appears on Today's Agenda.
+enum TodayAgendaKind {
+  /// Non-recurring task whose deadline is before today.
+  overdue,
+
+  /// Non-recurring task whose deadline is today.
+  dueToday,
+
+  /// Habit occurrence expanded for today via [RecurrenceExpander].
+  habitOccurrence,
+}
+
+/// One actionable row in Today's Agenda.
+@immutable
+class TodayAgendaItem extends Equatable {
+  final Task task;
+  final TodayAgendaKind kind;
+
+  /// Occurrence date for habit rows; deadline date for one-shot rows.
+  final DateTime occurrenceDate;
+
+  /// Whether the checkbox should appear checked (habit completion or task done).
+  final bool isCompleted;
+
+  const TodayAgendaItem({
+    required this.task,
+    required this.kind,
+    required this.occurrenceDate,
+    required this.isCompleted,
+  });
+
+  @override
+  List<Object?> get props => [task, kind, occurrenceDate, isCompleted];
+}

--- a/lib/features/tasks/domain/repositories/i_task_repository.dart
+++ b/lib/features/tasks/domain/repositories/i_task_repository.dart
@@ -52,4 +52,7 @@ abstract class ITaskRepository {
   Future<void> softDeleteCompletion(int id);
 
   Stream<List<TaskCompletion>> watchCompletionsForTask(int taskId);
+
+  /// Watches all non-deleted occurrence completions.
+  Stream<List<TaskCompletion>> watchAllCompletions();
 }

--- a/lib/features/tasks/domain/services/task_service.dart
+++ b/lib/features/tasks/domain/services/task_service.dart
@@ -36,6 +36,10 @@ class TaskService {
 
   Stream<List<TaskCompletion>> watchCompletionsForTask(int taskId) => _repository.watchCompletionsForTask(taskId);
 
+  Stream<List<TaskCompletion>> watchAllCompletions() => _repository.watchAllCompletions();
+
+  Stream<List<Task>> watchTasksWithDeadlines() => _repository.watchTasksWithDeadlines();
+
   //  Write
 
   Future<Result<Task>> createTask({

--- a/lib/features/tasks/domain/services/today_agenda_builder.dart
+++ b/lib/features/tasks/domain/services/today_agenda_builder.dart
@@ -1,0 +1,150 @@
+import '../../../../core/utils/date_time_utils.dart';
+import '../entities/habit_strip_item.dart';
+import '../entities/task.dart';
+import '../entities/task_completion.dart';
+import '../entities/today_agenda_item.dart';
+import 'habit_streak_calculator.dart';
+import 'recurrence_expander.dart';
+
+/// Pure builder for Today's Agenda and the habits strip.
+///
+/// Combines deadline tasks with [RecurrenceExpander] habit occurrences and
+/// completion logs — no I/O.
+abstract final class TodayAgendaBuilder {
+  /// Builds a merged, ordered agenda for [today].
+  ///
+  /// Order: overdue → due today → incomplete habit occurrences → completed habits.
+  static List<TodayAgendaItem> buildAgenda({
+    required List<Task> tasks,
+    required Map<int, List<TaskCompletion>> completionsByTaskId,
+    required DateTime today,
+  }) {
+    final day = DateTimeUtils.dateOnly(today);
+    final items = <TodayAgendaItem>[];
+
+    for (final task in tasks) {
+      if (task.isHabit && task.recurrenceRule != null) {
+        final occurrences = RecurrenceExpander.expand(task, day, day);
+        if (occurrences.isEmpty) continue;
+
+        final occurrenceDate = DateTimeUtils.dateOnly(occurrences.first);
+        final completed = _isCompletedOn(completionsByTaskId[task.id] ?? const [], occurrenceDate);
+        items.add(
+          TodayAgendaItem(
+            task: task,
+            kind: TodayAgendaKind.habitOccurrence,
+            occurrenceDate: occurrenceDate,
+            isCompleted: completed,
+          ),
+        );
+        continue;
+      }
+
+      if (task.isRecurring) continue;
+
+      final end = task.endDate;
+      if (end == null) continue;
+      final endDay = DateTimeUtils.dateOnly(end);
+
+      if (endDay.isBefore(day)) {
+        items.add(
+          TodayAgendaItem(
+            task: task,
+            kind: TodayAgendaKind.overdue,
+            occurrenceDate: endDay,
+            isCompleted: task.isCompleted,
+          ),
+        );
+      } else if (endDay == day) {
+        items.add(
+          TodayAgendaItem(
+            task: task,
+            kind: TodayAgendaKind.dueToday,
+            occurrenceDate: endDay,
+            isCompleted: task.isCompleted,
+          ),
+        );
+      }
+    }
+
+    items.sort(_compareAgendaItems);
+    return items;
+  }
+
+  /// Builds strip items for every habit task (whether or not due today).
+  static List<HabitStripItem> buildHabitStrip({
+    required List<Task> tasks,
+    required Map<int, List<TaskCompletion>> completionsByTaskId,
+    required DateTime today,
+    int streakLookbackDays = 365,
+  }) {
+    final day = DateTimeUtils.dateOnly(today);
+    final windowFrom = day.subtract(Duration(days: streakLookbackDays));
+    final items = <HabitStripItem>[];
+
+    for (final task in tasks) {
+      if (!task.isHabit || task.recurrenceRule == null || task.id == null) continue;
+
+      final rule = task.recurrenceRule!;
+      final anchor = DateTimeUtils.dateOnly(task.recurrenceAnchorDate ?? task.startDate ?? task.createdAt);
+      final completions = completionsByTaskId[task.id!] ?? const <TaskCompletion>[];
+      final completionDates = completions.map((c) => c.occurrenceDate);
+
+      final streak = HabitStreakCalculator.calculate(
+        rule: rule,
+        anchor: anchor,
+        completionDates: completionDates,
+        from: windowFrom,
+        to: day,
+        now: day,
+      );
+
+      final dueToday = RecurrenceExpander.expand(task, day, day).isNotEmpty;
+      final completedToday = _isCompletedOn(completions, day);
+
+      items.add(
+        HabitStripItem(
+          task: task,
+          completedToday: completedToday,
+          currentStreak: streak.currentStreak,
+          dueToday: dueToday,
+        ),
+      );
+    }
+
+    items.sort((a, b) {
+      if (a.dueToday != b.dueToday) return a.dueToday ? -1 : 1;
+      if (a.completedToday != b.completedToday) return a.completedToday ? 1 : -1;
+      return a.task.title.compareTo(b.task.title);
+    });
+
+    return items;
+  }
+
+  static bool _isCompletedOn(List<TaskCompletion> completions, DateTime day) {
+    final key = DateTimeUtils.dateOnly(day);
+    for (final c in completions) {
+      if (DateTimeUtils.dateOnly(c.occurrenceDate) == key) return true;
+    }
+    return false;
+  }
+
+  static int _compareAgendaItems(TodayAgendaItem a, TodayAgendaItem b) {
+    final kindOrder = _kindRank(a.kind).compareTo(_kindRank(b.kind));
+    if (kindOrder != 0) return kindOrder;
+
+    if (a.isCompleted != b.isCompleted) return a.isCompleted ? 1 : -1;
+
+    final aTime = a.task.endDate ?? a.occurrenceDate;
+    final bTime = b.task.endDate ?? b.occurrenceDate;
+    final timeCmp = aTime.compareTo(bTime);
+    if (timeCmp != 0) return timeCmp;
+    return a.task.title.compareTo(b.task.title);
+  }
+
+  static int _kindRank(TodayAgendaKind kind) => switch (kind) {
+    TodayAgendaKind.overdue => 0,
+    TodayAgendaKind.dueToday => 1,
+    TodayAgendaKind.habitOccurrence => 2,
+  };
+}

--- a/lib/features/tasks/presentation/commands/task_commands.dart
+++ b/lib/features/tasks/presentation/commands/task_commands.dart
@@ -2,8 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:focus/core/widgets/confirmation_dialog.dart';
+import 'package:focus/core/di/injection.dart';
 import 'package:focus/core/routing/routes.dart';
+import 'package:focus/core/utils/result.dart';
 import 'package:focus/features/tasks/domain/entities/task.dart';
+import 'package:focus/features/tasks/domain/entities/today_agenda_item.dart';
+import 'package:focus/features/tasks/domain/services/task_service.dart';
 import 'package:focus/features/tasks/presentation/providers/task_provider.dart';
 
 class TaskCommands {
@@ -43,5 +47,40 @@ class TaskCommands {
         onDeleted?.call();
       },
     );
+  }
+
+  /// Completes a one-shot task or logs a habit/recurring occurrence.
+  ///
+  /// Uses [TaskService] directly so home (and other global surfaces) do not
+  /// depend on a project-scoped [TaskNotifier] being mounted.
+  static Future<Result<void>> completeAgendaItem(TodayAgendaItem item) async {
+    final service = getIt<TaskService>();
+    final task = item.task;
+    if (task.id == null) {
+      return const Failure(NotFoundFailure('Task has no id'));
+    }
+
+    if (item.kind == TodayAgendaKind.habitOccurrence || task.isRecurring) {
+      final result = await service.completeOccurrence(task.id!, item.occurrenceDate);
+      return switch (result) {
+        Success() => const Success(null),
+        Failure(:final failure) => Failure(failure),
+      };
+    }
+
+    if (item.isCompleted) return const Success(null);
+    return service.toggleTaskCompletion(task);
+  }
+
+  /// Logs today's completion for a habit from the habits strip.
+  static Future<Result<void>> completeHabitOccurrence(Task task, DateTime occurrenceDate) async {
+    if (task.id == null) {
+      return const Failure(NotFoundFailure('Task has no id'));
+    }
+    final result = await getIt<TaskService>().completeOccurrence(task.id!, occurrenceDate);
+    return switch (result) {
+      Success() => const Success(null),
+      Failure(:final failure) => Failure(failure),
+    };
   }
 }

--- a/lib/features/tasks/presentation/providers/task_notifier_provider.part.dart
+++ b/lib/features/tasks/presentation/providers/task_notifier_provider.part.dart
@@ -84,4 +84,15 @@ class TaskNotifier extends _$TaskNotifier {
         state = AsyncValue.error(failure, StackTrace.current);
     }
   }
+
+  Future<void> completeOccurrence(Task task, DateTime occurrenceDate) async {
+    if (task.id == null) return;
+    final result = await _service.completeOccurrence(task.id!, occurrenceDate);
+    switch (result) {
+      case Success():
+        await _loadTasks(task.projectId.toString());
+      case Failure(:final failure):
+        state = AsyncValue.error(failure, StackTrace.current);
+    }
+  }
 }

--- a/test/domain/tasks/today_agenda_builder_test.dart
+++ b/test/domain/tasks/today_agenda_builder_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/features/tasks/domain/entities/recurrence_rule.dart';
+import 'package:focus/features/tasks/domain/entities/today_agenda_item.dart';
+import 'package:focus/features/tasks/domain/services/today_agenda_builder.dart';
+
+import '../../helpers/fixtures.dart';
+
+void main() {
+  final today = DateTime(2026, 8, 2);
+
+  group('TodayAgendaBuilder.buildAgenda', () {
+    test('includes overdue and due-today one-shot tasks', () {
+      final overdue = buildTask(id: 1, title: 'Late', endDate: DateTime(2026, 7, 30));
+      final dueToday = buildTask(id: 2, title: 'Today', endDate: DateTime(2026, 8, 2, 18));
+      final future = buildTask(id: 3, title: 'Later', endDate: DateTime(2026, 8, 5));
+
+      final items = TodayAgendaBuilder.buildAgenda(
+        tasks: [overdue, dueToday, future],
+        completionsByTaskId: const {},
+        today: today,
+      );
+
+      expect(items.map((i) => i.task.id), [1, 2]);
+      expect(items[0].kind, TodayAgendaKind.overdue);
+      expect(items[1].kind, TodayAgendaKind.dueToday);
+    });
+
+    test('includes habit occurrences expanded for today', () {
+      final habit = buildTask(
+        id: 10,
+        title: 'Meditate',
+        endDate: null,
+        isHabit: true,
+        recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.daily),
+        recurrenceAnchorDate: DateTime(2026, 8, 1),
+        startDate: DateTime(2026, 8, 1),
+      );
+
+      final items = TodayAgendaBuilder.buildAgenda(tasks: [habit], completionsByTaskId: const {}, today: today);
+
+      expect(items, hasLength(1));
+      expect(items.single.kind, TodayAgendaKind.habitOccurrence);
+      expect(items.single.isCompleted, isFalse);
+    });
+
+    test('marks habit complete when completion exists for today', () {
+      final habit = buildTask(
+        id: 10,
+        title: 'Meditate',
+        endDate: null,
+        isHabit: true,
+        recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.daily),
+        recurrenceAnchorDate: DateTime(2026, 8, 1),
+      );
+
+      final items = TodayAgendaBuilder.buildAgenda(
+        tasks: [habit],
+        completionsByTaskId: {
+          10: [buildCompletion(taskId: 10, occurrenceDate: today)],
+        },
+        today: today,
+      );
+
+      expect(items.single.isCompleted, isTrue);
+    });
+
+    test('skips non-habit recurring tasks without deadline kind', () {
+      final recurring = buildTask(
+        id: 5,
+        title: 'Standup',
+        endDate: null,
+        isHabit: false,
+        recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.weekly, byWeekday: [DateTime.sunday]),
+        recurrenceAnchorDate: DateTime(2026, 8, 2),
+      );
+
+      final items = TodayAgendaBuilder.buildAgenda(tasks: [recurring], completionsByTaskId: const {}, today: today);
+
+      expect(items, isEmpty);
+    });
+  });
+
+  group('TodayAgendaBuilder.buildHabitStrip', () {
+    test('computes streak and dueToday for habits', () {
+      final habit = buildTask(
+        id: 10,
+        title: 'Walk',
+        endDate: null,
+        isHabit: true,
+        recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.daily),
+        recurrenceAnchorDate: DateTime(2026, 7, 30),
+      );
+
+      final items = TodayAgendaBuilder.buildHabitStrip(
+        tasks: [habit],
+        completionsByTaskId: {
+          10: [
+            buildCompletion(id: 1, taskId: 10, occurrenceDate: DateTime(2026, 7, 31)),
+            buildCompletion(id: 2, taskId: 10, occurrenceDate: DateTime(2026, 8, 1)),
+          ],
+        },
+        today: today,
+      );
+
+      expect(items, hasLength(1));
+      expect(items.single.dueToday, isTrue);
+      expect(items.single.completedToday, isFalse);
+      expect(items.single.currentStreak, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch feat/phase-5-dashboard into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
112ab61 feat(home): refocus home around today agenda and habits

### Files
- .agents/docs/patterns.md
- lib/features/home/presentation/pages/home_screen.dart
- lib/features/home/presentation/providers/habits_strip_provider.dart
- lib/features/home/presentation/providers/today_agenda_provider.dart
- lib/features/home/presentation/widgets/agenda_task_tile.dart
- lib/features/home/presentation/widgets/calendar_content.dart
- lib/features/home/presentation/widgets/habit_ring.dart
- lib/features/home/presentation/widgets/habits_strip_section.dart
- lib/features/home/presentation/widgets/home_onboarding_card.dart
- lib/features/home/presentation/widgets/today_agenda_section.dart
- lib/features/home/presentation/widgets/upcoming_calendar_card.dart
- lib/features/tasks/data/datasources/task_local_datasource.dart
- lib/features/tasks/data/repositories/task_repository_impl.dart
- lib/features/tasks/domain/entities/habit_strip_item.dart
- lib/features/tasks/domain/entities/today_agenda_item.dart
- lib/features/tasks/domain/repositories/i_task_repository.dart
- lib/features/tasks/domain/services/task_service.dart
- lib/features/tasks/domain/services/today_agenda_builder.dart
- lib/features/tasks/presentation/commands/task_commands.dart
- lib/features/tasks/presentation/providers/task_notifier_provider.part.dart
- test/domain/tasks/today_agenda_builder_test.dart

### Diffstat
 .agents/docs/patterns.md                           |  11 ++
 .../home/presentation/pages/home_screen.dart       |  83 +++++-------
 .../providers/habits_strip_provider.dart           |  29 ++++
 .../providers/today_agenda_provider.dart           |  32 +++++
 .../presentation/widgets/agenda_task_tile.dart     |  88 ++++++++++++
 .../presentation/widgets/calendar_content.dart     | 129 +++++-------------
 .../home/presentation/widgets/habit_ring.dart      |  79 +++++++++++
 .../presentation/widgets/habits_strip_section.dart |  47 +++++++
 .../presentation/widgets/home_onboarding_card.dart |  40 ++++++
 .../presentation/widgets/today_agenda_section.dart |  42 ++++++
 .../widgets/upcoming_calendar_card.dart            |  27 ++--
 .../data/datasources/task_local_datasource.dart    |  11 ++
 .../data/repositories/task_repository_impl.dart    |   5 +
 .../tasks/domain/entities/habit_strip_item.dart    |  23 ++++
 .../tasks/domain/entities/today_agenda_item.dart   |  39 ++++++
 .../domain/repositories/i_task_repository.dart     |   3 +
 .../tasks/domain/services/task_service.dart        |   4 +
 .../domain/services/today_agenda_builder.dart      | 150 +++++++++++++++++++++
 .../tasks/presentation/commands/task_commands.dart |  39 ++++++
 .../providers/task_notifier_provider.part.dart     |  11 ++
 test/domain/tasks/today_agenda_builder_test.dart   | 111 +++++++++++++++
 21 files changed, 842 insertions(+), 161 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
