### PR TITLE
feat(reports): Phase 6 habit insights and CSV export

### DIFF
--- a/.agents/docs/architecture.md
+++ b/.agents/docs/architecture.md
@@ -135,6 +135,8 @@ Navigation UX split:
 - Mobile shell: 4-item bottom navigation (`Home`, `Tasks`, `Projects`, `Inbox`)
 - Desktop/tablet shell: side rail keeps separate `Reports` and `Notifications` entries
 - Settings is a utility destination (header/rail action), not a primary tab
+- Reports expands window-scoped insights (habit consistency, estimates, time breakdowns,
+  throughput) via `ITaskStatsRepository` SQL aggregates; CSV export copies the active window
 
 ## Layout Architecture
 

--- a/.agents/docs/feature_plans.md
+++ b/.agents/docs/feature_plans.md
@@ -50,6 +50,11 @@ Suggested scope:
 - Better empty states and no-data messaging
 - Evaluate caching/aggregation improvements for heavier stats views
 
+Status (Phase 6):
+- Habit consistency, estimate accuracy, time-by-project/tag, throughput, and CSV export
+  are implemented on `ReportsScreen` via window-scoped SQL aggregates in
+  `task_stats_local_datasource.dart` and `ReportInsightsCalculator`.
+
 ## Backlog Candidates
 
 - Import/export and backup restore workflows

--- a/.agents/docs/patterns.md
+++ b/.agents/docs/patterns.md
@@ -394,6 +394,37 @@ Gotchas:
 - Compact boards page one column at a time; expanded boards show all four columns.
 - Calendar day-cell drops reschedule `endDate` (skip recurring tasks — occurrences are expanded).
 
+## Reports Insights Aggregates
+
+Phase 6 report sections read window-scoped SQL aggregates from `ITaskStatsLocalDataSource`,
+mapped through `ITaskStatsRepository`, then bound to `reportsInsightsWindowProvider`.
+
+```dart
+// Window key stays ISO `start|end` (same as dailyStatsForRangeProvider)
+final range = ProductivityInsightsUtils.dateRangeForWindow(window);
+
+// SQL aggregates (watch + readsFrom) — prefer DB-side SUM/COUNT/GROUP BY
+watchEstimateAccuracy(start, end);
+watchTimeByProject(start, end);
+watchTimeByTag(start, end);
+watchTaskCompletionsByDate(start, end);
+watchAverageCycleTime(start, end);
+watchHabitCompletionHeatmap(start, end);
+
+// Habit rate/streak still uses pure HabitStreakCalculator after SQL loads sources
+ReportInsightsCalculator.buildHabitConsistency(sources: ..., from: ..., to: ...);
+
+// CSV is a pure string builder — UI copies to clipboard
+ReportInsightsCalculator.buildCsvExport(...);
+```
+
+Gotchas:
+- Keep custom-painted charts (no chart package). Habit heatmap reuses `YearGridPainter`.
+- Cycle time approximates in-progress start as first focus session (else `startDate` / `createdAt`)
+  because there is no status-history table yet.
+- Tag time double-counts sessions on multi-tagged tasks (intentional for tag breakdowns).
+- Export respects the selected insights window; heatmap uses the current calendar year.
+
 ## Mandatory Follow-Up
 
 When a new pattern is introduced in production code, add it here with:

--- a/lib/features/reports/presentation/providers/report_insights_providers.dart
+++ b/lib/features/reports/presentation/providers/report_insights_providers.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../../core/utils/datetime_formatter.dart';
+import '../../../tasks/domain/entities/estimate_accuracy_stat.dart';
+import '../../../tasks/domain/entities/habit_consistency_stat.dart';
+import '../../../tasks/domain/entities/task_throughput_stats.dart';
+import '../../../tasks/domain/entities/time_breakdown_item.dart';
+import '../../../tasks/presentation/providers/task_stats_provider.dart';
+import '../utils/productivity_insights_utils.dart';
+import 'reports_insights_window_provider.dart';
+
+String _rangeKeyForWindow(InsightsWindowMode window) {
+  final range = ProductivityInsightsUtils.dateRangeForWindow(window);
+  return '${range.start.toShortDateKey()}|${range.end.toShortDateKey()}';
+}
+
+({String start, String end, bool weekly}) _parseRange(String rangeKey, InsightsWindowMode window) {
+  final parts = rangeKey.split('|');
+  return (start: parts[0], end: parts[1], weekly: window == InsightsWindowMode.weekly);
+}
+
+/// Habit consistency for the selected insights window.
+final habitConsistencyProvider = StreamProvider.autoDispose<List<HabitConsistencyStat>>((ref) {
+  final window = ref.watch(reportsInsightsWindowProvider).value ?? InsightsWindowMode.weekly;
+  final rangeKey = _rangeKeyForWindow(window);
+  final parsed = _parseRange(rangeKey, window);
+  final repository = ref.watch(taskStatsRepositoryProvider);
+  return repository.watchHabitConsistency(parsed.start, parsed.end);
+});
+
+/// Habit completion heatmap for the current calendar year.
+final habitHeatmapProvider = StreamProvider.autoDispose<Map<String, int>>((ref) {
+  final year = DateTime.now().year;
+  final repository = ref.watch(taskStatsRepositoryProvider);
+  return repository.watchHabitCompletionHeatmap('$year-01-01', '$year-12-31');
+});
+
+/// Estimate accuracy for the selected insights window.
+final estimateAccuracyProvider = StreamProvider.autoDispose<EstimateAccuracySummary>((ref) {
+  final window = ref.watch(reportsInsightsWindowProvider).value ?? InsightsWindowMode.weekly;
+  final rangeKey = _rangeKeyForWindow(window);
+  final parsed = _parseRange(rangeKey, window);
+  final repository = ref.watch(taskStatsRepositoryProvider);
+  return repository.watchEstimateAccuracy(parsed.start, parsed.end);
+});
+
+/// Focus time by project for the selected insights window.
+final timeByProjectProvider = StreamProvider.autoDispose<List<TimeBreakdownItem>>((ref) {
+  final window = ref.watch(reportsInsightsWindowProvider).value ?? InsightsWindowMode.weekly;
+  final rangeKey = _rangeKeyForWindow(window);
+  final parsed = _parseRange(rangeKey, window);
+  final repository = ref.watch(taskStatsRepositoryProvider);
+  return repository.watchTimeByProject(parsed.start, parsed.end);
+});
+
+/// Focus time by tag for the selected insights window.
+final timeByTagProvider = StreamProvider.autoDispose<List<TimeBreakdownItem>>((ref) {
+  final window = ref.watch(reportsInsightsWindowProvider).value ?? InsightsWindowMode.weekly;
+  final rangeKey = _rangeKeyForWindow(window);
+  final parsed = _parseRange(rangeKey, window);
+  final repository = ref.watch(taskStatsRepositoryProvider);
+  return repository.watchTimeByTag(parsed.start, parsed.end);
+});
+
+/// Task throughput for the selected insights window.
+final taskThroughputProvider = StreamProvider.autoDispose<TaskThroughputStats>((ref) {
+  final window = ref.watch(reportsInsightsWindowProvider).value ?? InsightsWindowMode.weekly;
+  final rangeKey = _rangeKeyForWindow(window);
+  final parsed = _parseRange(rangeKey, window);
+  final repository = ref.watch(taskStatsRepositoryProvider);
+  return repository.watchTaskThroughput(startDate: parsed.start, endDate: parsed.end, weeklyWindow: parsed.weekly);
+});

--- a/lib/features/reports/presentation/screens/reports_screen.dart
+++ b/lib/features/reports/presentation/screens/reports_screen.dart
@@ -12,10 +12,15 @@ import '../../../home/presentation/widgets/today_summary_card.dart';
 import '../../../home/presentation/widgets/year_activity_graph.dart';
 import '../../../tasks/domain/entities/global_stats.dart';
 import '../../../tasks/presentation/providers/task_stats_provider.dart';
+import '../widgets/estimate_accuracy_section.dart';
+import '../widgets/habit_consistency_section.dart';
 import '../widgets/productivity_insights_section.dart';
+import '../widgets/reports_csv_export_button.dart';
+import '../widgets/task_throughput_section.dart';
+import '../widgets/time_breakdown_section.dart';
 
 /// Dedicated Reports screen that houses overall stats, activity heatmap,
-/// and streak information previously shown on the home screen.
+/// productivity insights, and Phase 6 report expansions.
 class ReportsScreen extends ConsumerWidget {
   const ReportsScreen({super.key});
 
@@ -38,6 +43,7 @@ class ReportsScreen extends ConsumerWidget {
           ),
         ],
         title: Text('Reports', style: context.typography.xl2.copyWith(fontWeight: FontWeight.w700)),
+        suffixes: const [ReportsCsvExportButton()],
       ),
       child: SingleChildScrollView(
         child: Column(
@@ -45,15 +51,21 @@ class ReportsScreen extends ConsumerWidget {
           spacing: AppConstants.spacing.regular,
           children: [
             TodaySummaryCard(stats: stats),
-            // Overall stats
             SizedBox(height: AppConstants.spacing.regular),
             SectionHeader(title: 'Overall Stats'),
             GlobalStatsRow(stats: stats),
             SizedBox(height: AppConstants.spacing.regular),
-            // Activity heatmap
             const YearActivityGraph(),
             SizedBox(height: AppConstants.spacing.regular),
             const ProductivityInsightsSection(),
+            SizedBox(height: AppConstants.spacing.large),
+            const HabitConsistencySection(),
+            SizedBox(height: AppConstants.spacing.large),
+            const EstimateAccuracySection(),
+            SizedBox(height: AppConstants.spacing.large),
+            const TimeBreakdownSection(),
+            SizedBox(height: AppConstants.spacing.large),
+            const TaskThroughputSection(),
             SizedBox(height: AppConstants.spacing.regular),
           ],
         ),

--- a/lib/features/reports/presentation/widgets/estimate_accuracy_section.dart
+++ b/lib/features/reports/presentation/widgets/estimate_accuracy_section.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart' as fu;
+
+import '../../../../core/config/theme/app_theme.dart';
+import '../../../../core/constants/app_constants.dart';
+import '../../../tasks/domain/entities/estimate_accuracy_stat.dart';
+import '../providers/report_insights_providers.dart';
+
+class EstimateAccuracySection extends ConsumerWidget {
+  const EstimateAccuracySection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(estimateAccuracyProvider);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Estimate Accuracy', style: context.typography.md.copyWith(fontWeight: FontWeight.w700)),
+        SizedBox(height: AppConstants.spacing.regular),
+        async.when(
+          loading: () => const SizedBox(height: 80, child: Center(child: fu.FCircularProgress())),
+          error: (err, _) => Text('Error: $err', style: context.typography.sm),
+          data: (summary) {
+            if (!summary.hasData) {
+              return Text(
+                'Add estimates and complete focus sessions to see accuracy',
+                style: context.typography.sm.copyWith(color: context.colors.mutedForeground),
+              );
+            }
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _BiasInsight(biasRatio: summary.typicalBiasRatio),
+                SizedBox(height: AppConstants.spacing.regular),
+                for (final task in summary.tasks.take(8)) ...[
+                  _EstimateRow(stat: task),
+                  SizedBox(height: AppConstants.spacing.small),
+                ],
+              ],
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _BiasInsight extends StatelessWidget {
+  final double biasRatio;
+
+  const _BiasInsight({required this.biasRatio});
+
+  @override
+  Widget build(BuildContext context) {
+    final percent = (biasRatio.abs() * 100).round();
+    final message = biasRatio >= 0
+        ? 'You typically underestimate by $percent%'
+        : 'You typically overestimate by $percent%';
+    return Container(
+      width: double.infinity,
+      padding: EdgeInsets.all(AppConstants.spacing.regular),
+      decoration: BoxDecoration(
+        color: context.colors.primary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(AppConstants.border.radius.regular),
+      ),
+      child: Text(message, style: context.typography.sm.copyWith(fontWeight: FontWeight.w600)),
+    );
+  }
+}
+
+class _EstimateRow extends StatelessWidget {
+  final EstimateAccuracyStat stat;
+
+  const _EstimateRow({required this.stat});
+
+  @override
+  Widget build(BuildContext context) {
+    final deltaPercent = (stat.deltaRatio * 100).round();
+    final deltaLabel = deltaPercent >= 0 ? '+$deltaPercent%' : '$deltaPercent%';
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            stat.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: context.typography.sm.copyWith(fontWeight: FontWeight.w500),
+          ),
+        ),
+        Text(
+          '${stat.estimatedMinutes}m → ${stat.actualMinutes}m',
+          style: context.typography.xs.copyWith(color: context.colors.mutedForeground),
+        ),
+        SizedBox(width: AppConstants.spacing.small),
+        Text(
+          deltaLabel,
+          style: context.typography.xs.copyWith(
+            fontWeight: FontWeight.w600,
+            color: deltaPercent >= 0 ? context.colors.primary : context.colors.mutedForeground,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/reports/presentation/widgets/habit_consistency_section.dart
+++ b/lib/features/reports/presentation/widgets/habit_consistency_section.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart' as fu;
+
+import '../../../../core/config/theme/app_theme.dart';
+import '../../../../core/constants/app_constants.dart';
+import '../../../../core/utils/datetime_formatter.dart';
+import '../../../home/presentation/utils/activity_graph_constants.dart';
+import '../../../home/presentation/utils/activity_graph_utils.dart';
+import '../../../home/presentation/widgets/year_grid_painter.dart';
+import '../../../tasks/domain/entities/habit_consistency_stat.dart';
+import '../providers/report_insights_providers.dart';
+
+class HabitConsistencySection extends ConsumerWidget {
+  const HabitConsistencySection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final habitsAsync = ref.watch(habitConsistencyProvider);
+    final heatmapAsync = ref.watch(habitHeatmapProvider);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Habit Consistency', style: context.typography.md.copyWith(fontWeight: FontWeight.w700)),
+        SizedBox(height: AppConstants.spacing.regular),
+        habitsAsync.when(
+          loading: () => const SizedBox(height: 80, child: Center(child: fu.FCircularProgress())),
+          error: (err, _) => Text('Error: $err', style: context.typography.sm),
+          data: (habits) {
+            if (habits.isEmpty) {
+              return Text(
+                'No habits in this window yet',
+                style: context.typography.sm.copyWith(color: context.colors.mutedForeground),
+              );
+            }
+            return Column(
+              children: [
+                for (final habit in habits) ...[
+                  _HabitConsistencyTile(habit: habit),
+                  SizedBox(height: AppConstants.spacing.small),
+                ],
+              ],
+            );
+          },
+        ),
+        SizedBox(height: AppConstants.spacing.large),
+        Text('Habit Heatmap', style: context.typography.sm.copyWith(fontWeight: FontWeight.w600)),
+        SizedBox(height: AppConstants.spacing.regular),
+        heatmapAsync.when(
+          loading: () => const SizedBox(height: 120, child: Center(child: fu.FCircularProgress())),
+          error: (err, _) => Text('Error: $err', style: context.typography.sm),
+          data: (lookup) => _HabitHeatmap(lookup: lookup),
+        ),
+      ],
+    );
+  }
+}
+
+class _HabitConsistencyTile extends StatelessWidget {
+  final HabitConsistencyStat habit;
+
+  const _HabitConsistencyTile({required this.habit});
+
+  @override
+  Widget build(BuildContext context) {
+    final percent = (habit.completionRate * 100).round();
+    return Container(
+      padding: EdgeInsets.all(AppConstants.spacing.regular),
+      decoration: BoxDecoration(
+        border: Border.all(color: context.colors.border),
+        borderRadius: BorderRadius.circular(AppConstants.border.radius.regular),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(habit.title, style: context.typography.sm.copyWith(fontWeight: FontWeight.w600)),
+                SizedBox(height: AppConstants.spacing.extraSmall),
+                Text(
+                  '$percent% · ${habit.completedCount}/${habit.scheduledCount} scheduled',
+                  style: context.typography.xs.copyWith(color: context.colors.mutedForeground),
+                ),
+              ],
+            ),
+          ),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text(
+                '${habit.currentStreak} day streak',
+                style: context.typography.sm.copyWith(fontWeight: FontWeight.w600),
+              ),
+              Text(
+                'Best ${habit.longestStreak}',
+                style: context.typography.xs.copyWith(color: context.colors.mutedForeground),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HabitHeatmap extends StatelessWidget {
+  final Map<String, int> lookup;
+
+  const _HabitHeatmap({required this.lookup});
+
+  @override
+  Widget build(BuildContext context) {
+    final year = DateTime.now().year;
+    final jan1 = DateTime(year, 1, 1);
+    final dec31 = DateTime(year, 12, 31);
+    final totalWeeks = DateTimeExtensions.weekIndex(dec31, jan1) + 1;
+    final gridWidth = ActivityGraphConstants.dayLabelWidth + totalWeeks * ActivityGraphConstants.cellStep;
+    final todayKey = ActivityGraphUtils.today().toShortDateKey();
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: SizedBox(
+        width: gridWidth,
+        height: ActivityGraphConstants.monthLabelHeight + ActivityGraphConstants.graphHeight,
+        child: CustomPaint(
+          size: Size(gridWidth, ActivityGraphConstants.monthLabelHeight + ActivityGraphConstants.graphHeight),
+          painter: YearGridPainter(
+            year: year,
+            lookup: lookup,
+            cellColor: context.colors.primary,
+            emptyColor: context.colors.mutedForeground.withValues(alpha: 0.12),
+            textColor: context.colors.mutedForeground,
+            textStyle: context.typography.xs,
+            highlightDateKey: todayKey,
+            highlightColor: context.colors.primary,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/reports/presentation/widgets/horizontal_bar_chart.dart
+++ b/lib/features/reports/presentation/widgets/horizontal_bar_chart.dart
@@ -1,0 +1,87 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../../../core/config/theme/app_theme.dart';
+import '../../../../core/constants/app_constants.dart';
+import '../../../tasks/domain/entities/time_breakdown_item.dart';
+
+/// Horizontal bar breakdown for project/tag time reports.
+class HorizontalBarChart extends StatelessWidget {
+  final List<TimeBreakdownItem> items;
+  final String emptyMessage;
+
+  const HorizontalBarChart({super.key, required this.items, this.emptyMessage = 'No focus time in this window'});
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) {
+      return Padding(
+        padding: EdgeInsets.symmetric(vertical: AppConstants.spacing.regular),
+        child: Text(emptyMessage, style: context.typography.sm.copyWith(color: context.colors.mutedForeground)),
+      );
+    }
+    final maxSeconds = items.fold<int>(0, (maxValue, item) => math.max(maxValue, item.focusSeconds));
+    return Column(
+      children: [
+        for (final item in items) ...[
+          _BarRow(item: item, maxSeconds: maxSeconds),
+          SizedBox(height: AppConstants.spacing.small),
+        ],
+      ],
+    );
+  }
+}
+
+class _BarRow extends StatelessWidget {
+  final TimeBreakdownItem item;
+  final int maxSeconds;
+
+  const _BarRow({required this.item, required this.maxSeconds});
+
+  @override
+  Widget build(BuildContext context) {
+    final fraction = maxSeconds <= 0 ? 0.0 : item.focusSeconds / maxSeconds;
+    final barColor = item.color != null ? Color(item.color!) : context.colors.primary;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: Text(
+                item.name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: context.typography.sm.copyWith(fontWeight: FontWeight.w500),
+              ),
+            ),
+            Text(
+              _formatDuration(item.focusSeconds),
+              style: context.typography.xs.copyWith(color: context.colors.mutedForeground),
+            ),
+          ],
+        ),
+        SizedBox(height: AppConstants.spacing.extraSmall),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(AppConstants.border.radius.small),
+          child: LinearProgressIndicator(
+            value: fraction.clamp(0.0, 1.0),
+            minHeight: 8,
+            backgroundColor: context.colors.mutedForeground.withValues(alpha: 0.12),
+            color: barColor,
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _formatDuration(int seconds) {
+    if (seconds < 60) return '${seconds}s';
+    final minutes = seconds ~/ 60;
+    if (minutes < 60) return '${minutes}m';
+    final hours = minutes / 60;
+    if ((hours - hours.round()).abs() < 0.05) return '${hours.round()}h';
+    return '${hours.toStringAsFixed(1)}h';
+  }
+}

--- a/lib/features/reports/presentation/widgets/reports_csv_export_button.dart
+++ b/lib/features/reports/presentation/widgets/reports_csv_export_button.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart' as fu;
+
+import '../../../../core/constants/app_constants.dart';
+import '../../../../core/utils/datetime_formatter.dart';
+import '../../../tasks/domain/entities/estimate_accuracy_stat.dart';
+import '../../../tasks/domain/entities/task_throughput_stats.dart';
+import '../../../tasks/domain/services/report_insights_calculator.dart';
+import '../providers/report_insights_providers.dart';
+import '../providers/reports_insights_window_provider.dart';
+import '../utils/productivity_insights_utils.dart';
+
+/// Copies a CSV snapshot of the current report window to the clipboard.
+class ReportsCsvExportButton extends ConsumerWidget {
+  const ReportsCsvExportButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return fu.FHeaderAction(
+      icon: Icon(fu.FLucideIcons.download, size: AppConstants.size.icon.regular),
+      onPress: () => _export(context, ref),
+    );
+  }
+
+  Future<void> _export(BuildContext context, WidgetRef ref) async {
+    final window = ref.read(reportsInsightsWindowProvider).value ?? InsightsWindowMode.weekly;
+    final range = ProductivityInsightsUtils.dateRangeForWindow(window);
+    final habits = ref.read(habitConsistencyProvider).value ?? const [];
+    final estimates =
+        ref.read(estimateAccuracyProvider).value ?? const EstimateAccuracySummary(tasks: [], typicalBiasRatio: 0);
+    final byProject = ref.read(timeByProjectProvider).value ?? const [];
+    final byTag = ref.read(timeByTagProvider).value ?? const [];
+    final throughput =
+        ref.read(taskThroughputProvider).value ??
+        const TaskThroughputStats(buckets: [], averageCycleSeconds: null, cycleSampleCount: 0);
+    final csv = ReportInsightsCalculator.buildCsvExport(
+      windowLabel: window.storageValue,
+      startDate: range.start.toShortDateKey(),
+      endDate: range.end.toShortDateKey(),
+      habits: habits,
+      estimates: estimates,
+      byProject: byProject,
+      byTag: byTag,
+      throughput: throughput,
+    );
+    await Clipboard.setData(ClipboardData(text: csv));
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Report CSV copied to clipboard')));
+  }
+}

--- a/lib/features/reports/presentation/widgets/task_throughput_section.dart
+++ b/lib/features/reports/presentation/widgets/task_throughput_section.dart
@@ -1,0 +1,118 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart' as fu;
+
+import '../../../../core/config/theme/app_theme.dart';
+import '../../../../core/constants/app_constants.dart';
+import '../../../tasks/domain/entities/task_throughput_stats.dart';
+import '../providers/report_insights_providers.dart';
+import '../providers/reports_insights_window_provider.dart';
+
+class TaskThroughputSection extends ConsumerWidget {
+  const TaskThroughputSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final window = ref.watch(reportsInsightsWindowProvider).value ?? InsightsWindowMode.weekly;
+    final async = ref.watch(taskThroughputProvider);
+    final title = window == InsightsWindowMode.weekly ? 'Completed per Day' : 'Completed per Week';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Task Throughput', style: context.typography.md.copyWith(fontWeight: FontWeight.w700)),
+        SizedBox(height: AppConstants.spacing.regular),
+        async.when(
+          loading: () => const SizedBox(height: 120, child: Center(child: fu.FCircularProgress())),
+          error: (err, _) => Text('Error: $err', style: context.typography.sm),
+          data: (stats) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: context.typography.sm.copyWith(fontWeight: FontWeight.w600)),
+                SizedBox(height: AppConstants.spacing.regular),
+                _ThroughputBars(stats: stats),
+                SizedBox(height: AppConstants.spacing.regular),
+                _CycleTimeInsight(stats: stats),
+              ],
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _ThroughputBars extends StatelessWidget {
+  final TaskThroughputStats stats;
+
+  const _ThroughputBars({required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    if (stats.buckets.isEmpty) {
+      return Text(
+        'No completions in this window',
+        style: context.typography.sm.copyWith(color: context.colors.mutedForeground),
+      );
+    }
+    final maxCount = stats.buckets.fold<int>(0, (maxValue, b) => math.max(maxValue, b.completedCount));
+    const barHeight = 72.0;
+    return SizedBox(
+      height: 120,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          for (final bucket in stats.buckets)
+            Expanded(
+              child: Padding(
+                padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.extraSmall),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Text(
+                      '${bucket.completedCount}',
+                      style: context.typography.xs.copyWith(color: context.colors.mutedForeground),
+                    ),
+                    SizedBox(height: AppConstants.spacing.extraSmall),
+                    Container(
+                      height: maxCount <= 0 ? 2 : (bucket.completedCount / maxCount * barHeight).clamp(2.0, barHeight),
+                      decoration: BoxDecoration(
+                        color: context.colors.primary,
+                        borderRadius: BorderRadius.circular(AppConstants.border.radius.small),
+                      ),
+                    ),
+                    SizedBox(height: AppConstants.spacing.small),
+                    Text(bucket.label, style: context.typography.xs.copyWith(color: context.colors.mutedForeground)),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CycleTimeInsight extends StatelessWidget {
+  final TaskThroughputStats stats;
+
+  const _CycleTimeInsight({required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    final hours = stats.averageCycleHours;
+    if (hours == null || stats.cycleSampleCount == 0) {
+      return Text(
+        'Complete tasks to measure average cycle time',
+        style: context.typography.sm.copyWith(color: context.colors.mutedForeground),
+      );
+    }
+    final label = hours < 1 ? '${(hours * 60).round()}m' : '${hours.toStringAsFixed(1)}h';
+    return Text(
+      'Average cycle time $label (in progress → done, ${stats.cycleSampleCount} tasks)',
+      style: context.typography.sm.copyWith(color: context.colors.mutedForeground),
+    );
+  }
+}

--- a/lib/features/reports/presentation/widgets/time_breakdown_section.dart
+++ b/lib/features/reports/presentation/widgets/time_breakdown_section.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart' as fu;
+
+import '../../../../core/config/theme/app_theme.dart';
+import '../../../../core/constants/app_constants.dart';
+import '../providers/report_insights_providers.dart';
+import 'horizontal_bar_chart.dart';
+
+class TimeBreakdownSection extends ConsumerWidget {
+  const TimeBreakdownSection({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final byProject = ref.watch(timeByProjectProvider);
+    final byTag = ref.watch(timeByTagProvider);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Time by Project', style: context.typography.md.copyWith(fontWeight: FontWeight.w700)),
+        SizedBox(height: AppConstants.spacing.regular),
+        byProject.when(
+          loading: () => const SizedBox(height: 64, child: Center(child: fu.FCircularProgress())),
+          error: (err, _) => Text('Error: $err', style: context.typography.sm),
+          data: (items) => HorizontalBarChart(items: items, emptyMessage: 'No project focus time in this window'),
+        ),
+        SizedBox(height: AppConstants.spacing.large),
+        Text('Time by Tag', style: context.typography.md.copyWith(fontWeight: FontWeight.w700)),
+        SizedBox(height: AppConstants.spacing.regular),
+        byTag.when(
+          loading: () => const SizedBox(height: 64, child: Center(child: fu.FCircularProgress())),
+          error: (err, _) => Text('Error: $err', style: context.typography.sm),
+          data: (items) => HorizontalBarChart(items: items, emptyMessage: 'No tagged focus time in this window'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/tasks/data/datasources/task_stats_local_datasource.dart
+++ b/lib/features/tasks/data/datasources/task_stats_local_datasource.dart
@@ -3,7 +3,9 @@ import 'package:drift/drift.dart';
 import '../../../../core/services/db_service.dart';
 import '../../../../core/services/log_service.dart';
 import '../../../session/domain/entities/session_state.dart';
+import '../../domain/entities/task_status.dart';
 import '../models/global_stats_model.dart';
+import '../models/report_stats_models.dart';
 import '../models/task_stats_model.dart';
 
 abstract class ITaskStatsLocalDataSource {
@@ -29,6 +31,27 @@ abstract class ITaskStatsLocalDataSource {
   /// [startDate] and [endDate] are ISO `YYYY-MM-DD` strings.
   /// Ideal for lazy-loading monthly pages in a horizontal scroll graph.
   Stream<List<DailySessionStatsData>> watchDailyStatsForRange(String startDate, String endDate);
+
+  /// Watches habit metadata plus completion dates in `[startDate, endDate]`.
+  Stream<List<HabitConsistencySourceRow>> watchHabitConsistencySources(String startDate, String endDate);
+
+  /// Watches habit completion counts by day for a heatmap range.
+  Stream<Map<String, int>> watchHabitCompletionHeatmap(String startDate, String endDate);
+
+  /// Watches estimated vs actual focus minutes per task in the window.
+  Stream<List<EstimateAccuracyRow>> watchEstimateAccuracy(String startDate, String endDate);
+
+  /// Watches focus seconds grouped by project for sessions in the window.
+  Stream<List<TimeBreakdownRow>> watchTimeByProject(String startDate, String endDate);
+
+  /// Watches focus seconds grouped by tag for sessions in the window.
+  Stream<List<TimeBreakdownRow>> watchTimeByTag(String startDate, String endDate);
+
+  /// Watches task + habit completion counts keyed by ISO date.
+  Stream<Map<String, int>> watchTaskCompletionsByDate(String startDate, String endDate);
+
+  /// Watches average cycle seconds (work-start proxy → done) for the window.
+  Stream<CycleTimeAggregateRow> watchAverageCycleTime(String startDate, String endDate);
 }
 
 class TaskStatsLocalDataSourceImpl implements ITaskStatsLocalDataSource {
@@ -204,5 +227,240 @@ class TaskStatsLocalDataSourceImpl implements ITaskStatsLocalDataSource {
           ..where((t) => t.date.isBiggerOrEqualValue(startDate) & t.date.isSmallerOrEqualValue(endDate))
           ..orderBy([(t) => OrderingTerm.asc(t.date)]))
         .watch();
+  }
+
+  @override
+  Stream<List<HabitConsistencySourceRow>> watchHabitConsistencySources(String startDate, String endDate) {
+    return _db
+        .customSelect(
+          'SELECT id, title, recurrence_rule, recurrence_anchor_date, start_date, created_at '
+          'FROM task_table '
+          'WHERE is_habit = 1 AND deleted_at IS NULL AND recurrence_rule IS NOT NULL',
+          readsFrom: {_db.taskTable, _db.taskCompletionTable},
+        )
+        .watch()
+        .asyncMap((rows) async {
+          final completionRows = await _db
+              .customSelect(
+                'SELECT task_id, occurrence_date '
+                'FROM task_completion_table '
+                'WHERE deleted_at IS NULL '
+                'AND occurrence_date >= ? AND occurrence_date <= ?',
+                variables: [Variable<String>(startDate), Variable<String>(endDate)],
+                readsFrom: {_db.taskCompletionTable},
+              )
+              .get();
+          final byTask = <int, List<String>>{};
+          for (final row in completionRows) {
+            final taskId = row.read<int>('task_id');
+            byTask.putIfAbsent(taskId, () => []).add(row.read<String>('occurrence_date'));
+          }
+          return [
+            for (final row in rows)
+              HabitConsistencySourceRow(
+                taskId: row.read<int>('id'),
+                title: row.read<String>('title'),
+                recurrenceRuleJson: row.read<String>('recurrence_rule'),
+                recurrenceAnchorDate: row.readNullable<DateTime>('recurrence_anchor_date'),
+                startDate: row.readNullable<DateTime>('start_date'),
+                createdAt: row.read<DateTime>('created_at'),
+                completionDateKeys: byTask[row.read<int>('id')] ?? const [],
+              ),
+          ];
+        });
+  }
+
+  @override
+  Stream<Map<String, int>> watchHabitCompletionHeatmap(String startDate, String endDate) {
+    return _db
+        .customSelect(
+          'SELECT tc.occurrence_date AS d, COUNT(*) AS cnt '
+          'FROM task_completion_table tc '
+          'INNER JOIN task_table t ON t.id = tc.task_id '
+          'WHERE tc.deleted_at IS NULL AND t.deleted_at IS NULL AND t.is_habit = 1 '
+          'AND tc.occurrence_date >= ? AND tc.occurrence_date <= ? '
+          'GROUP BY tc.occurrence_date',
+          variables: [Variable<String>(startDate), Variable<String>(endDate)],
+          readsFrom: {_db.taskCompletionTable, _db.taskTable},
+        )
+        .watch()
+        .map((rows) {
+          final map = <String, int>{};
+          for (final row in rows) {
+            map[row.read<String>('d')] = row.read<int>('cnt');
+          }
+          return map;
+        });
+  }
+
+  @override
+  Stream<List<EstimateAccuracyRow>> watchEstimateAccuracy(String startDate, String endDate) {
+    return _db
+        .customSelect(
+          'SELECT t.id AS task_id, t.title AS title, t.estimated_minutes AS estimated_minutes, '
+          'CAST(COALESCE(SUM(MIN(s.elapsed_seconds, s.focus_duration_minutes * 60)), 0) / 60 AS INTEGER) '
+          'AS actual_minutes '
+          'FROM task_table t '
+          'INNER JOIN focus_session_table s ON s.task_id = t.id AND s.deleted_at IS NULL '
+          "AND date(s.start_time, 'unixepoch', 'localtime') >= ? "
+          "AND date(s.start_time, 'unixepoch', 'localtime') <= ? "
+          'WHERE t.deleted_at IS NULL '
+          'AND t.estimated_minutes IS NOT NULL AND t.estimated_minutes > 0 '
+          'GROUP BY t.id, t.title, t.estimated_minutes '
+          'HAVING actual_minutes > 0 '
+          'ORDER BY actual_minutes DESC',
+          variables: [Variable<String>(startDate), Variable<String>(endDate)],
+          readsFrom: {_db.taskTable, _db.focusSessionTable},
+        )
+        .watch()
+        .map(
+          (rows) => [
+            for (final row in rows)
+              EstimateAccuracyRow(
+                taskId: row.read<int>('task_id'),
+                title: row.read<String>('title'),
+                estimatedMinutes: row.read<int>('estimated_minutes'),
+                actualMinutes: row.read<int>('actual_minutes'),
+              ),
+          ],
+        );
+  }
+
+  @override
+  Stream<List<TimeBreakdownRow>> watchTimeByProject(String startDate, String endDate) {
+    return _db
+        .customSelect(
+          'SELECT p.id AS id, p.title AS name, '
+          'COALESCE(SUM(MIN(s.elapsed_seconds, s.focus_duration_minutes * 60)), 0) AS focus_seconds, '
+          'p.color AS color '
+          'FROM project_table p '
+          'INNER JOIN task_table t ON t.project_id = p.id AND t.deleted_at IS NULL '
+          'INNER JOIN focus_session_table s ON s.task_id = t.id AND s.deleted_at IS NULL '
+          "AND date(s.start_time, 'unixepoch', 'localtime') >= ? "
+          "AND date(s.start_time, 'unixepoch', 'localtime') <= ? "
+          'WHERE p.deleted_at IS NULL '
+          'GROUP BY p.id, p.title, p.color '
+          'HAVING focus_seconds > 0 '
+          'ORDER BY focus_seconds DESC',
+          variables: [Variable<String>(startDate), Variable<String>(endDate)],
+          readsFrom: {_db.projectTable, _db.taskTable, _db.focusSessionTable},
+        )
+        .watch()
+        .map(
+          (rows) => [
+            for (final row in rows)
+              TimeBreakdownRow(
+                id: row.read<int>('id'),
+                name: row.read<String>('name'),
+                focusSeconds: row.read<int>('focus_seconds'),
+                color: row.readNullable<int>('color'),
+              ),
+          ],
+        );
+  }
+
+  @override
+  Stream<List<TimeBreakdownRow>> watchTimeByTag(String startDate, String endDate) {
+    return _db
+        .customSelect(
+          'SELECT tag.id AS id, tag.name AS name, '
+          'COALESCE(SUM(MIN(s.elapsed_seconds, s.focus_duration_minutes * 60)), 0) AS focus_seconds, '
+          'tag.color AS color '
+          'FROM tag_table tag '
+          'INNER JOIN task_tag_table tt ON tt.tag_id = tag.id '
+          'INNER JOIN focus_session_table s ON s.task_id = tt.task_id AND s.deleted_at IS NULL '
+          "AND date(s.start_time, 'unixepoch', 'localtime') >= ? "
+          "AND date(s.start_time, 'unixepoch', 'localtime') <= ? "
+          'WHERE tag.deleted_at IS NULL '
+          'GROUP BY tag.id, tag.name, tag.color '
+          'HAVING focus_seconds > 0 '
+          'ORDER BY focus_seconds DESC',
+          variables: [Variable<String>(startDate), Variable<String>(endDate)],
+          readsFrom: {_db.tagTable, _db.taskTagTable, _db.focusSessionTable},
+        )
+        .watch()
+        .map(
+          (rows) => [
+            for (final row in rows)
+              TimeBreakdownRow(
+                id: row.read<int>('id'),
+                name: row.read<String>('name'),
+                focusSeconds: row.read<int>('focus_seconds'),
+                color: row.readNullable<int>('color'),
+              ),
+          ],
+        );
+  }
+
+  @override
+  Stream<Map<String, int>> watchTaskCompletionsByDate(String startDate, String endDate) {
+    final doneStatus = TaskStatus.done.index;
+    return _db
+        .customSelect(
+          'SELECT d, SUM(cnt) AS cnt FROM ('
+          "SELECT date(updated_at, 'unixepoch', 'localtime') AS d, COUNT(*) AS cnt "
+          'FROM task_table '
+          'WHERE status = $doneStatus AND deleted_at IS NULL AND is_habit = 0 '
+          "AND date(updated_at, 'unixepoch', 'localtime') >= ? "
+          "AND date(updated_at, 'unixepoch', 'localtime') <= ? "
+          'GROUP BY d '
+          'UNION ALL '
+          'SELECT occurrence_date AS d, COUNT(*) AS cnt '
+          'FROM task_completion_table '
+          'WHERE deleted_at IS NULL '
+          'AND occurrence_date >= ? AND occurrence_date <= ? '
+          'GROUP BY occurrence_date'
+          ') GROUP BY d',
+          variables: [
+            Variable<String>(startDate),
+            Variable<String>(endDate),
+            Variable<String>(startDate),
+            Variable<String>(endDate),
+          ],
+          readsFrom: {_db.taskTable, _db.taskCompletionTable},
+        )
+        .watch()
+        .map((rows) {
+          final map = <String, int>{};
+          for (final row in rows) {
+            map[row.read<String>('d')] = row.read<int>('cnt');
+          }
+          return map;
+        });
+  }
+
+  @override
+  Stream<CycleTimeAggregateRow> watchAverageCycleTime(String startDate, String endDate) {
+    final doneStatus = TaskStatus.done.index;
+    return _db
+        .customSelect(
+          'SELECT '
+          'AVG('
+          't.updated_at - COALESCE('
+          '(SELECT MIN(fs.start_time) FROM focus_session_table fs '
+          'WHERE fs.task_id = t.id AND fs.deleted_at IS NULL), '
+          't.start_date, t.created_at'
+          ')'
+          ') AS avg_cycle_seconds, '
+          'COUNT(*) AS sample_count '
+          'FROM task_table t '
+          'WHERE t.status = $doneStatus AND t.deleted_at IS NULL AND t.is_habit = 0 '
+          "AND date(t.updated_at, 'unixepoch', 'localtime') >= ? "
+          "AND date(t.updated_at, 'unixepoch', 'localtime') <= ? "
+          'AND t.updated_at > COALESCE('
+          '(SELECT MIN(fs.start_time) FROM focus_session_table fs '
+          'WHERE fs.task_id = t.id AND fs.deleted_at IS NULL), '
+          't.start_date, t.created_at'
+          ')',
+          variables: [Variable<String>(startDate), Variable<String>(endDate)],
+          readsFrom: {_db.taskTable, _db.focusSessionTable},
+        )
+        .watchSingle()
+        .map((row) {
+          final sampleCount = row.read<int>('sample_count');
+          if (sampleCount <= 0) return CycleTimeAggregateRow.empty;
+          final avg = row.readNullable<double>('avg_cycle_seconds');
+          return CycleTimeAggregateRow(averageCycleSeconds: avg, sampleCount: sampleCount);
+        });
   }
 }

--- a/lib/features/tasks/data/models/report_stats_models.dart
+++ b/lib/features/tasks/data/models/report_stats_models.dart
@@ -1,0 +1,54 @@
+/// Lightweight SQL row models for Phase 6 report aggregates.
+library;
+
+class HabitConsistencySourceRow {
+  final int taskId;
+  final String title;
+  final String recurrenceRuleJson;
+  final DateTime? recurrenceAnchorDate;
+  final DateTime? startDate;
+  final DateTime createdAt;
+  final List<String> completionDateKeys;
+
+  const HabitConsistencySourceRow({
+    required this.taskId,
+    required this.title,
+    required this.recurrenceRuleJson,
+    required this.recurrenceAnchorDate,
+    required this.startDate,
+    required this.createdAt,
+    required this.completionDateKeys,
+  });
+}
+
+class EstimateAccuracyRow {
+  final int taskId;
+  final String title;
+  final int estimatedMinutes;
+  final int actualMinutes;
+
+  const EstimateAccuracyRow({
+    required this.taskId,
+    required this.title,
+    required this.estimatedMinutes,
+    required this.actualMinutes,
+  });
+}
+
+class TimeBreakdownRow {
+  final int id;
+  final String name;
+  final int focusSeconds;
+  final int? color;
+
+  const TimeBreakdownRow({required this.id, required this.name, required this.focusSeconds, this.color});
+}
+
+class CycleTimeAggregateRow {
+  final double? averageCycleSeconds;
+  final int sampleCount;
+
+  const CycleTimeAggregateRow({required this.averageCycleSeconds, required this.sampleCount});
+
+  static const empty = CycleTimeAggregateRow(averageCycleSeconds: null, sampleCount: 0);
+}

--- a/lib/features/tasks/data/repositories/task_stats_repository_impl.dart
+++ b/lib/features/tasks/data/repositories/task_stats_repository_impl.dart
@@ -2,10 +2,16 @@ import '../../../../core/services/log_service.dart';
 import '../../../session/data/mappers/focus_session_mappers.dart';
 import '../../../session/domain/entities/focus_session.dart';
 import '../../domain/entities/daily_session_stats.dart';
+import '../../domain/entities/estimate_accuracy_stat.dart';
 import '../../domain/entities/global_stats.dart';
+import '../../domain/entities/habit_consistency_stat.dart';
+import '../../domain/entities/recurrence_rule.dart';
 import '../../domain/entities/task.dart';
 import '../../domain/entities/task_stats.dart';
+import '../../domain/entities/task_throughput_stats.dart';
+import '../../domain/entities/time_breakdown_item.dart';
 import '../../domain/repositories/i_task_stats_repository.dart';
+import '../../domain/services/report_insights_calculator.dart';
 import '../datasources/task_stats_local_datasource.dart';
 import '../mappers/global_stats_mappers.dart';
 import '../mappers/task_extensions.dart';
@@ -87,5 +93,144 @@ class TaskStatsRepositoryImpl implements ITaskStatsRepository {
       _log.error('Error watching recent tasks', tag: 'TaskStatsRepository', error: e, stackTrace: st as StackTrace?);
       throw e;
     });
+  }
+
+  @override
+  Stream<List<HabitConsistencyStat>> watchHabitConsistency(String startDate, String endDate) {
+    final from = DateTime.parse(startDate);
+    final to = DateTime.parse(endDate);
+    return _local
+        .watchHabitConsistencySources(startDate, endDate)
+        .map((rows) {
+          final sources = <HabitConsistencySource>[];
+          for (final row in rows) {
+            final rule = RecurrenceRule.tryParseJson(row.recurrenceRuleJson);
+            if (rule == null) continue;
+            final anchor = row.recurrenceAnchorDate ?? row.startDate ?? row.createdAt;
+            sources.add(
+              HabitConsistencySource(
+                taskId: row.taskId,
+                title: row.title,
+                rule: rule,
+                anchor: anchor,
+                completionDates: [for (final key in row.completionDateKeys) DateTime.parse(key)],
+              ),
+            );
+          }
+          return ReportInsightsCalculator.buildHabitConsistency(sources: sources, from: from, to: to);
+        })
+        .handleError((e, st) {
+          _log.error(
+            'Error watching habit consistency',
+            tag: 'TaskStatsRepository',
+            error: e,
+            stackTrace: st as StackTrace?,
+          );
+          throw e;
+        });
+  }
+
+  @override
+  Stream<Map<String, int>> watchHabitCompletionHeatmap(String startDate, String endDate) {
+    return _local.watchHabitCompletionHeatmap(startDate, endDate).handleError((e, st) {
+      _log.error('Error watching habit heatmap', tag: 'TaskStatsRepository', error: e, stackTrace: st as StackTrace?);
+      throw e;
+    });
+  }
+
+  @override
+  Stream<EstimateAccuracySummary> watchEstimateAccuracy(String startDate, String endDate) {
+    return _local
+        .watchEstimateAccuracy(startDate, endDate)
+        .map(
+          (rows) => ReportInsightsCalculator.buildEstimateAccuracy([
+            for (final row in rows)
+              EstimateAccuracyStat(
+                taskId: row.taskId,
+                title: row.title,
+                estimatedMinutes: row.estimatedMinutes,
+                actualMinutes: row.actualMinutes,
+              ),
+          ]),
+        )
+        .handleError((e, st) {
+          _log.error(
+            'Error watching estimate accuracy',
+            tag: 'TaskStatsRepository',
+            error: e,
+            stackTrace: st as StackTrace?,
+          );
+          throw e;
+        });
+  }
+
+  @override
+  Stream<List<TimeBreakdownItem>> watchTimeByProject(String startDate, String endDate) {
+    return _local
+        .watchTimeByProject(startDate, endDate)
+        .map(
+          (rows) => ReportInsightsCalculator.normalizeBreakdown([
+            for (final row in rows)
+              TimeBreakdownItem(id: row.id, name: row.name, focusSeconds: row.focusSeconds, color: row.color),
+          ]),
+        )
+        .handleError((e, st) {
+          _log.error(
+            'Error watching time by project',
+            tag: 'TaskStatsRepository',
+            error: e,
+            stackTrace: st as StackTrace?,
+          );
+          throw e;
+        });
+  }
+
+  @override
+  Stream<List<TimeBreakdownItem>> watchTimeByTag(String startDate, String endDate) {
+    return _local
+        .watchTimeByTag(startDate, endDate)
+        .map(
+          (rows) => ReportInsightsCalculator.normalizeBreakdown([
+            for (final row in rows)
+              TimeBreakdownItem(id: row.id, name: row.name, focusSeconds: row.focusSeconds, color: row.color),
+          ]),
+        )
+        .handleError((e, st) {
+          _log.error('Error watching time by tag', tag: 'TaskStatsRepository', error: e, stackTrace: st as StackTrace?);
+          throw e;
+        });
+  }
+
+  @override
+  Stream<TaskThroughputStats> watchTaskThroughput({
+    required String startDate,
+    required String endDate,
+    required bool weeklyWindow,
+  }) {
+    final from = DateTime.parse(startDate);
+    final to = DateTime.parse(endDate);
+    return _local
+        .watchTaskCompletionsByDate(startDate, endDate)
+        .asyncExpand((byDate) {
+          return _local.watchAverageCycleTime(startDate, endDate).map((cycle) {
+            return ReportInsightsCalculator.buildThroughputStats(
+              completedByDate: byDate,
+              from: from,
+              to: to,
+              weeklyWindow: weeklyWindow,
+              averageCycleSeconds: cycle.averageCycleSeconds,
+              cycleSampleCount: cycle.sampleCount,
+            );
+          });
+        })
+        .handleError((e, st) {
+          _log.error(
+            'Error watching task throughput',
+            tag: 'TaskStatsRepository',
+            error: e,
+            stackTrace: st as StackTrace?,
+          );
+          throw e;
+        });
   }
 }

--- a/lib/features/tasks/domain/entities/estimate_accuracy_stat.dart
+++ b/lib/features/tasks/domain/entities/estimate_accuracy_stat.dart
@@ -1,0 +1,43 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// Estimated versus actual focus minutes for a single task in a window.
+@immutable
+class EstimateAccuracyStat extends Equatable {
+  final int taskId;
+  final String title;
+  final int estimatedMinutes;
+  final int actualMinutes;
+
+  const EstimateAccuracyStat({
+    required this.taskId,
+    required this.title,
+    required this.estimatedMinutes,
+    required this.actualMinutes,
+  });
+
+  /// Positive when actual exceeds estimate (underestimated).
+  double get deltaRatio {
+    if (estimatedMinutes <= 0) return 0;
+    return (actualMinutes - estimatedMinutes) / estimatedMinutes;
+  }
+
+  @override
+  List<Object?> get props => [taskId, title, estimatedMinutes, actualMinutes];
+}
+
+/// Aggregate estimate accuracy insight across tasks in a window.
+@immutable
+class EstimateAccuracySummary extends Equatable {
+  final List<EstimateAccuracyStat> tasks;
+
+  /// Typical bias as a fraction of estimate. Positive = underestimate.
+  final double typicalBiasRatio;
+
+  const EstimateAccuracySummary({required this.tasks, required this.typicalBiasRatio});
+
+  bool get hasData => tasks.isNotEmpty;
+
+  @override
+  List<Object?> get props => [tasks, typicalBiasRatio];
+}

--- a/lib/features/tasks/domain/entities/habit_consistency_stat.dart
+++ b/lib/features/tasks/domain/entities/habit_consistency_stat.dart
@@ -1,0 +1,35 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// Per-habit consistency metrics for a report insights window.
+@immutable
+class HabitConsistencyStat extends Equatable {
+  final int taskId;
+  final String title;
+  final double completionRate;
+  final int currentStreak;
+  final int longestStreak;
+  final int scheduledCount;
+  final int completedCount;
+
+  const HabitConsistencyStat({
+    required this.taskId,
+    required this.title,
+    required this.completionRate,
+    required this.currentStreak,
+    required this.longestStreak,
+    required this.scheduledCount,
+    required this.completedCount,
+  });
+
+  @override
+  List<Object?> get props => [
+    taskId,
+    title,
+    completionRate,
+    currentStreak,
+    longestStreak,
+    scheduledCount,
+    completedCount,
+  ];
+}

--- a/lib/features/tasks/domain/entities/task_throughput_stats.dart
+++ b/lib/features/tasks/domain/entities/task_throughput_stats.dart
@@ -1,0 +1,39 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// Completions counted for a single day or week bucket.
+@immutable
+class ThroughputBucket extends Equatable {
+  final String label;
+  final String periodKey;
+  final int completedCount;
+
+  const ThroughputBucket({required this.label, required this.periodKey, required this.completedCount});
+
+  @override
+  List<Object?> get props => [label, periodKey, completedCount];
+}
+
+/// Task throughput for a report window, including cycle-time insight.
+@immutable
+class TaskThroughputStats extends Equatable {
+  final List<ThroughputBucket> buckets;
+
+  /// Average seconds from work-start proxy to done. Null when no samples.
+  final double? averageCycleSeconds;
+
+  final int cycleSampleCount;
+
+  const TaskThroughputStats({required this.buckets, required this.averageCycleSeconds, required this.cycleSampleCount});
+
+  double? get averageCycleHours {
+    final seconds = averageCycleSeconds;
+    if (seconds == null) return null;
+    return seconds / 3600;
+  }
+
+  int get totalCompleted => buckets.fold(0, (sum, b) => sum + b.completedCount);
+
+  @override
+  List<Object?> get props => [buckets, averageCycleSeconds, cycleSampleCount];
+}

--- a/lib/features/tasks/domain/entities/time_breakdown_item.dart
+++ b/lib/features/tasks/domain/entities/time_breakdown_item.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+/// Named focus-time bucket used for project or tag breakdowns.
+@immutable
+class TimeBreakdownItem extends Equatable {
+  final int id;
+  final String name;
+  final int focusSeconds;
+  final int? color;
+
+  const TimeBreakdownItem({required this.id, required this.name, required this.focusSeconds, this.color});
+
+  int get focusMinutes => focusSeconds ~/ 60;
+
+  double get focusHours => focusSeconds / 3600;
+
+  @override
+  List<Object?> get props => [id, name, focusSeconds, color];
+}

--- a/lib/features/tasks/domain/repositories/i_task_stats_repository.dart
+++ b/lib/features/tasks/domain/repositories/i_task_stats_repository.dart
@@ -1,8 +1,12 @@
 import '../../../session/domain/entities/focus_session.dart';
 import '../entities/daily_session_stats.dart';
+import '../entities/estimate_accuracy_stat.dart';
 import '../entities/global_stats.dart';
+import '../entities/habit_consistency_stat.dart';
 import '../entities/task.dart';
 import '../entities/task_stats.dart';
+import '../entities/task_throughput_stats.dart';
+import '../entities/time_breakdown_item.dart';
 
 abstract class ITaskStatsRepository {
   /// Watches aggregated stats for a task, computed at the ORM level.
@@ -24,4 +28,28 @@ abstract class ITaskStatsRepository {
 
   /// Watches recently updated tasks (across all projects), root level only.
   Stream<List<Task>> watchRecentTasks({int limit = 5});
+
+  /// Watches per-habit consistency for the inclusive ISO date window.
+  Stream<List<HabitConsistencyStat>> watchHabitConsistency(String startDate, String endDate);
+
+  /// Watches habit completion counts by day (`YYYY-MM-DD` → count).
+  Stream<Map<String, int>> watchHabitCompletionHeatmap(String startDate, String endDate);
+
+  /// Watches estimate accuracy summary for sessions in the window.
+  Stream<EstimateAccuracySummary> watchEstimateAccuracy(String startDate, String endDate);
+
+  /// Watches focus time by project for sessions in the window.
+  Stream<List<TimeBreakdownItem>> watchTimeByProject(String startDate, String endDate);
+
+  /// Watches focus time by tag for sessions in the window.
+  Stream<List<TimeBreakdownItem>> watchTimeByTag(String startDate, String endDate);
+
+  /// Watches throughput buckets and average cycle time for the window.
+  ///
+  /// [weeklyWindow] controls day vs week bucket labels.
+  Stream<TaskThroughputStats> watchTaskThroughput({
+    required String startDate,
+    required String endDate,
+    required bool weeklyWindow,
+  });
 }

--- a/lib/features/tasks/domain/services/report_insights_calculator.dart
+++ b/lib/features/tasks/domain/services/report_insights_calculator.dart
@@ -1,0 +1,236 @@
+import '../entities/estimate_accuracy_stat.dart';
+import '../entities/habit_consistency_stat.dart';
+import '../entities/recurrence_rule.dart';
+import '../entities/task_throughput_stats.dart';
+import '../entities/time_breakdown_item.dart';
+import 'habit_streak_calculator.dart';
+
+/// Raw habit row used to compute [HabitConsistencyStat] for a window.
+class HabitConsistencySource {
+  final int taskId;
+  final String title;
+  final RecurrenceRule rule;
+  final DateTime anchor;
+  final List<DateTime> completionDates;
+
+  const HabitConsistencySource({
+    required this.taskId,
+    required this.title,
+    required this.rule,
+    required this.anchor,
+    required this.completionDates,
+  });
+}
+
+/// Pure calculation helpers for Phase 6 report insights.
+abstract final class ReportInsightsCalculator {
+  /// Builds per-habit consistency stats via [HabitStreakCalculator].
+  static List<HabitConsistencyStat> buildHabitConsistency({
+    required List<HabitConsistencySource> sources,
+    required DateTime from,
+    required DateTime to,
+    DateTime? now,
+  }) {
+    final effectiveNow = now ?? DateTime.now();
+    final stats = <HabitConsistencyStat>[];
+    for (final source in sources) {
+      final result = HabitStreakCalculator.calculate(
+        rule: source.rule,
+        anchor: source.anchor,
+        completionDates: source.completionDates,
+        from: from,
+        to: to,
+        now: effectiveNow,
+      );
+      stats.add(
+        HabitConsistencyStat(
+          taskId: source.taskId,
+          title: source.title,
+          completionRate: result.completionRate,
+          currentStreak: result.currentStreak,
+          longestStreak: result.longestStreak,
+          scheduledCount: result.scheduledCount,
+          completedCount: result.completedCount,
+        ),
+      );
+    }
+    stats.sort((a, b) {
+      final rateCmp = b.completionRate.compareTo(a.completionRate);
+      if (rateCmp != 0) return rateCmp;
+      return a.title.toLowerCase().compareTo(b.title.toLowerCase());
+    });
+    return stats;
+  }
+
+  /// Aggregates estimate bias: positive ratio means typical underestimate.
+  static EstimateAccuracySummary buildEstimateAccuracy(List<EstimateAccuracyStat> tasks) {
+    if (tasks.isEmpty) {
+      return const EstimateAccuracySummary(tasks: [], typicalBiasRatio: 0);
+    }
+    var totalEstimated = 0;
+    var totalActual = 0;
+    for (final task in tasks) {
+      totalEstimated += task.estimatedMinutes;
+      totalActual += task.actualMinutes;
+    }
+    final bias = totalEstimated == 0 ? 0.0 : (totalActual - totalEstimated) / totalEstimated;
+    final sorted = [...tasks]..sort((a, b) => b.deltaRatio.abs().compareTo(a.deltaRatio.abs()));
+    return EstimateAccuracySummary(tasks: sorted, typicalBiasRatio: bias);
+  }
+
+  /// Groups daily completion counts into day or week buckets for the window.
+  static List<ThroughputBucket> buildThroughputBuckets({
+    required Map<String, int> completedByDate,
+    required DateTime from,
+    required DateTime to,
+    required bool weeklyWindow,
+  }) {
+    if (weeklyWindow) {
+      return _dailyBuckets(completedByDate: completedByDate, from: from, to: to);
+    }
+    return _weeklyBuckets(completedByDate: completedByDate, from: from, to: to);
+  }
+
+  static TaskThroughputStats buildThroughputStats({
+    required Map<String, int> completedByDate,
+    required DateTime from,
+    required DateTime to,
+    required bool weeklyWindow,
+    required double? averageCycleSeconds,
+    required int cycleSampleCount,
+  }) {
+    return TaskThroughputStats(
+      buckets: buildThroughputBuckets(completedByDate: completedByDate, from: from, to: to, weeklyWindow: weeklyWindow),
+      averageCycleSeconds: averageCycleSeconds,
+      cycleSampleCount: cycleSampleCount,
+    );
+  }
+
+  /// Normalizes breakdown items and drops zero-second rows.
+  static List<TimeBreakdownItem> normalizeBreakdown(List<TimeBreakdownItem> items) {
+    final filtered = items.where((item) => item.focusSeconds > 0).toList()
+      ..sort((a, b) => b.focusSeconds.compareTo(a.focusSeconds));
+    return filtered;
+  }
+
+  /// Builds a CSV document for the current report window.
+  static String buildCsvExport({
+    required String windowLabel,
+    required String startDate,
+    required String endDate,
+    required List<HabitConsistencyStat> habits,
+    required EstimateAccuracySummary estimates,
+    required List<TimeBreakdownItem> byProject,
+    required List<TimeBreakdownItem> byTag,
+    required TaskThroughputStats throughput,
+  }) {
+    final buffer = StringBuffer();
+    buffer.writeln('section,key,value,extra');
+    buffer.writeln(_csvRow(['meta', 'window', windowLabel, '']));
+    buffer.writeln(_csvRow(['meta', 'start_date', startDate, '']));
+    buffer.writeln(_csvRow(['meta', 'end_date', endDate, '']));
+    for (final habit in habits) {
+      buffer.writeln(
+        _csvRow([
+          'habit_consistency',
+          habit.title,
+          (habit.completionRate * 100).toStringAsFixed(1),
+          'streak=${habit.currentStreak};longest=${habit.longestStreak};completed=${habit.completedCount}/${habit.scheduledCount}',
+        ]),
+      );
+    }
+    buffer.writeln(
+      _csvRow([
+        'estimate_accuracy',
+        'typical_bias_percent',
+        (estimates.typicalBiasRatio * 100).toStringAsFixed(1),
+        estimates.typicalBiasRatio >= 0 ? 'underestimate' : 'overestimate',
+      ]),
+    );
+    for (final task in estimates.tasks) {
+      buffer.writeln(
+        _csvRow(['estimate_accuracy', task.title, task.actualMinutes.toString(), 'estimated=${task.estimatedMinutes}']),
+      );
+    }
+    for (final item in byProject) {
+      buffer.writeln(_csvRow(['time_by_project', item.name, item.focusMinutes.toString(), 'minutes']));
+    }
+    for (final item in byTag) {
+      buffer.writeln(_csvRow(['time_by_tag', item.name, item.focusMinutes.toString(), 'minutes']));
+    }
+    for (final bucket in throughput.buckets) {
+      buffer.writeln(_csvRow(['throughput', bucket.label, bucket.completedCount.toString(), bucket.periodKey]));
+    }
+    if (throughput.averageCycleHours != null) {
+      buffer.writeln(
+        _csvRow([
+          'throughput',
+          'average_cycle_hours',
+          throughput.averageCycleHours!.toStringAsFixed(2),
+          'samples=${throughput.cycleSampleCount}',
+        ]),
+      );
+    }
+    return buffer.toString();
+  }
+
+  static List<ThroughputBucket> _dailyBuckets({
+    required Map<String, int> completedByDate,
+    required DateTime from,
+    required DateTime to,
+  }) {
+    const names = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    final buckets = <ThroughputBucket>[];
+    var cursor = DateTime(from.year, from.month, from.day);
+    final end = DateTime(to.year, to.month, to.day);
+    while (!cursor.isAfter(end)) {
+      final key = _dateKey(cursor);
+      buckets.add(
+        ThroughputBucket(label: names[cursor.weekday - 1], periodKey: key, completedCount: completedByDate[key] ?? 0),
+      );
+      cursor = cursor.add(const Duration(days: 1));
+    }
+    return buckets;
+  }
+
+  static List<ThroughputBucket> _weeklyBuckets({
+    required Map<String, int> completedByDate,
+    required DateTime from,
+    required DateTime to,
+  }) {
+    final monthStart = DateTime(from.year, from.month, 1);
+    final daysInMonth = DateTime(from.year, from.month + 1, 0).day;
+    final leadingOffset = monthStart.weekday - 1;
+    final weekCount = ((leadingOffset + daysInMonth - 1) ~/ 7) + 1;
+    final counts = List<int>.filled(weekCount, 0);
+    final end = DateTime(to.year, to.month, to.day);
+    var cursor = DateTime(from.year, from.month, from.day);
+    while (!cursor.isAfter(end)) {
+      if (cursor.month == from.month) {
+        final weekIndex = (leadingOffset + cursor.day - 1) ~/ 7;
+        counts[weekIndex] += completedByDate[_dateKey(cursor)] ?? 0;
+      }
+      cursor = cursor.add(const Duration(days: 1));
+    }
+    return List.generate(
+      weekCount,
+      (index) => ThroughputBucket(label: 'W${index + 1}', periodKey: 'W${index + 1}', completedCount: counts[index]),
+    );
+  }
+
+  static String _dateKey(DateTime dt) =>
+      '${dt.year.toString().padLeft(4, '0')}-'
+      '${dt.month.toString().padLeft(2, '0')}-'
+      '${dt.day.toString().padLeft(2, '0')}';
+
+  static String _csvRow(List<String> cells) {
+    return cells.map(_escapeCsv).join(',');
+  }
+
+  static String _escapeCsv(String value) {
+    if (value.contains(',') || value.contains('"') || value.contains('\n')) {
+      return '"${value.replaceAll('"', '""')}"';
+    }
+    return value;
+  }
+}

--- a/test/domain/tasks/report_insights_calculator_test.dart
+++ b/test/domain/tasks/report_insights_calculator_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/features/tasks/domain/entities/estimate_accuracy_stat.dart';
+import 'package:focus/features/tasks/domain/entities/recurrence_rule.dart';
+import 'package:focus/features/tasks/domain/entities/time_breakdown_item.dart';
+import 'package:focus/features/tasks/domain/services/report_insights_calculator.dart';
+
+void main() {
+  group('ReportInsightsCalculator', () {
+    const daily = RecurrenceRule(frequency: RecurrenceFrequency.daily);
+    final anchor = DateTime(2026, 8, 1);
+
+    test('buildHabitConsistency computes rate and streak per habit', () {
+      final stats = ReportInsightsCalculator.buildHabitConsistency(
+        sources: [
+          HabitConsistencySource(
+            taskId: 1,
+            title: 'Meditate',
+            rule: daily,
+            anchor: anchor,
+            completionDates: [DateTime(2026, 8, 1), DateTime(2026, 8, 2), DateTime(2026, 8, 3)],
+          ),
+        ],
+        from: DateTime(2026, 8, 1),
+        to: DateTime(2026, 8, 4),
+        now: DateTime(2026, 8, 4),
+      );
+      expect(stats, hasLength(1));
+      expect(stats.first.completionRate, 0.75);
+      expect(stats.first.currentStreak, 3);
+      expect(stats.first.longestStreak, 3);
+    });
+
+    test('buildEstimateAccuracy reports typical underestimate bias', () {
+      final summary = ReportInsightsCalculator.buildEstimateAccuracy(const [
+        EstimateAccuracyStat(taskId: 1, title: 'A', estimatedMinutes: 60, actualMinutes: 90),
+        EstimateAccuracyStat(taskId: 2, title: 'B', estimatedMinutes: 40, actualMinutes: 50),
+      ]);
+      expect(summary.hasData, isTrue);
+      // (140 - 100) / 100 = 0.4
+      expect(summary.typicalBiasRatio, closeTo(0.4, 0.0001));
+    });
+
+    test('buildEstimateAccuracy returns zero bias for empty input', () {
+      final summary = ReportInsightsCalculator.buildEstimateAccuracy(const []);
+      expect(summary.hasData, isFalse);
+      expect(summary.typicalBiasRatio, 0);
+    });
+
+    test('buildThroughputBuckets fills daily labels for weekly window', () {
+      final buckets = ReportInsightsCalculator.buildThroughputBuckets(
+        completedByDate: {'2026-08-03': 2, '2026-08-05': 1},
+        from: DateTime(2026, 8, 3),
+        to: DateTime(2026, 8, 9),
+        weeklyWindow: true,
+      );
+      expect(buckets, hasLength(7));
+      expect(buckets.first.label, 'Mon');
+      expect(buckets.first.completedCount, 2);
+      expect(buckets[2].completedCount, 1);
+    });
+
+    test('buildThroughputBuckets groups into weeks for monthly window', () {
+      final buckets = ReportInsightsCalculator.buildThroughputBuckets(
+        completedByDate: {'2026-08-01': 1, '2026-08-10': 3, '2026-08-20': 2},
+        from: DateTime(2026, 8, 1),
+        to: DateTime(2026, 8, 31),
+        weeklyWindow: false,
+      );
+      expect(buckets.length, greaterThanOrEqualTo(4));
+      expect(buckets.fold<int>(0, (sum, b) => sum + b.completedCount), 6);
+    });
+
+    test('normalizeBreakdown drops zeros and sorts descending', () {
+      final items = ReportInsightsCalculator.normalizeBreakdown(const [
+        TimeBreakdownItem(id: 1, name: 'Low', focusSeconds: 60),
+        TimeBreakdownItem(id: 2, name: 'Zero', focusSeconds: 0),
+        TimeBreakdownItem(id: 3, name: 'High', focusSeconds: 600),
+      ]);
+      expect(items.map((e) => e.name).toList(), ['High', 'Low']);
+    });
+
+    test('buildCsvExport escapes commas and includes sections', () {
+      final csv = ReportInsightsCalculator.buildCsvExport(
+        windowLabel: 'weekly',
+        startDate: '2026-08-03',
+        endDate: '2026-08-09',
+        habits: const [],
+        estimates: const EstimateAccuracySummary(tasks: [], typicalBiasRatio: 0.25),
+        byProject: const [TimeBreakdownItem(id: 1, name: 'Work, Inc', focusSeconds: 3600)],
+        byTag: const [],
+        throughput: ReportInsightsCalculator.buildThroughputStats(
+          completedByDate: const {},
+          from: DateTime(2026, 8, 3),
+          to: DateTime(2026, 8, 9),
+          weeklyWindow: true,
+          averageCycleSeconds: 7200,
+          cycleSampleCount: 1,
+        ),
+      );
+      expect(csv, contains('section,key,value,extra'));
+      expect(csv, contains('"Work, Inc"'));
+      expect(csv, contains('typical_bias_percent'));
+      expect(csv, contains('average_cycle_hours'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch feat/phase-6-reports into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
12e88a4 feat(reports): expand reports with habits estimates and CSV

### Files
- .agents/docs/architecture.md
- .agents/docs/feature_plans.md
- .agents/docs/patterns.md
- lib/features/reports/presentation/providers/report_insights_providers.dart
- lib/features/reports/presentation/screens/reports_screen.dart
- lib/features/reports/presentation/widgets/estimate_accuracy_section.dart
- lib/features/reports/presentation/widgets/habit_consistency_section.dart
- lib/features/reports/presentation/widgets/horizontal_bar_chart.dart
- lib/features/reports/presentation/widgets/reports_csv_export_button.dart
- lib/features/reports/presentation/widgets/task_throughput_section.dart
- lib/features/reports/presentation/widgets/time_breakdown_section.dart
- lib/features/tasks/data/datasources/task_stats_local_datasource.dart
- lib/features/tasks/data/models/report_stats_models.dart
- lib/features/tasks/data/repositories/task_stats_repository_impl.dart
- lib/features/tasks/domain/entities/estimate_accuracy_stat.dart
- lib/features/tasks/domain/entities/habit_consistency_stat.dart
- lib/features/tasks/domain/entities/task_throughput_stats.dart
- lib/features/tasks/domain/entities/time_breakdown_item.dart
- lib/features/tasks/domain/repositories/i_task_stats_repository.dart
- lib/features/tasks/domain/services/report_insights_calculator.dart
- test/domain/tasks/report_insights_calculator_test.dart

### Diffstat
 .agents/docs/architecture.md                       |   2 +
 .agents/docs/feature_plans.md                      |   5 +
 .agents/docs/patterns.md                           |  31 +++
 .../providers/report_insights_providers.dart       |  72 ++++++
 .../presentation/screens/reports_screen.dart       |  18 +-
 .../widgets/estimate_accuracy_section.dart         | 106 +++++++++
 .../widgets/habit_consistency_section.dart         | 141 +++++++++++
 .../presentation/widgets/horizontal_bar_chart.dart |  87 +++++++
 .../widgets/reports_csv_export_button.dart         |  52 +++++
 .../widgets/task_throughput_section.dart           | 118 ++++++++++
 .../widgets/time_breakdown_section.dart            |  38 +++
 .../datasources/task_stats_local_datasource.dart   | 258 +++++++++++++++++++++
 .../tasks/data/models/report_stats_models.dart     |  54 +++++
 .../repositories/task_stats_repository_impl.dart   | 145 ++++++++++++
 .../domain/entities/estimate_accuracy_stat.dart    |  43 ++++
 .../domain/entities/habit_consistency_stat.dart    |  35 +++
 .../domain/entities/task_throughput_stats.dart     |  39 ++++
 .../tasks/domain/entities/time_breakdown_item.dart |  20 ++
 .../repositories/i_task_stats_repository.dart      |  28 +++
 .../services/report_insights_calculator.dart       | 236 +++++++++++++++++++
 .../tasks/report_insights_calculator_test.dart     | 106 +++++++++
 21 files changed, 1631 insertions(+), 3 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
