### PR TITLE
feat(sync): Phase 7 UUID sync rewrite and backup

### DIFF
--- a/.agents/docs/architecture.md
+++ b/.agents/docs/architecture.md
@@ -160,7 +160,7 @@ Rules for schema changes:
 4. Regenerate code.
 5. Verify migration behavior with existing user data.
 
-Current sync-ready schema (v8) includes on `project_table`, `task_table`, and `focus_session_table`:
+Current sync-ready schema (v9) includes on `project_table`, `task_table`, and `focus_session_table`:
 - `uuid` (TEXT, unique) — stable sync identity, generated on create and backfilled on migration
 - `deleted_at` (nullable DateTime) — soft-delete tombstone; all reads filter `deletedAt IS NULL`
 
@@ -178,10 +178,20 @@ Recurrence / habits (v8) adds:
 - Occurrences are expanded in pure domain code (`RecurrenceExpander`); habits are recurring tasks
   with `isHabit = true` and streaks via `HabitStreakCalculator`
 
+Sync rewrite (v9) adds:
+- `task_tag_table.uuid`, `created_at`, `updated_at`, `deleted_at` — junction tombstones for multi-device sync
+- Cloud/local `SyncData` envelope is schema-versioned (`kSyncSchemaVersion = 2`); peers refuse newer payloads
+- Entities in the envelope reference peers by UUID (`projectUuid`, `parentTaskUuid`, `milestoneUuid`, `taskUuid`, `tagUuid`)
+- Coverage: projects, milestones, tags, tasks, task-tag links, completions, focus sessions, whitelisted settings
+  (timer + audio). Excluded: `device_id`, desktop-local prefs, UI view-mode prefs
+- Merge is pure (`SyncMergeEngine`): UUID-keyed union of local+remote, tombstone LWW, dependency-ordered apply
+- Auto-sync via `SyncAutoSyncService` (foreground/background + debounced `DataChangeBus` mutations) gated by `sync_enabled`
+- Local JSON backup/restore reuses `SyncData` serialization (`SyncBackupService`)
+
 Deletes are soft deletes. `ON DELETE CASCADE` no longer fires for app-level deletes, so project/task
 deletion must cascade soft-deletes to dependents inside a transaction (including milestones,
-completions, and clearing `task_tag` associations). `SyncPurgeService` hard-deletes tombstones older
-than the retention window (default 30 days), including completion rows before tasks. A stable
+completions, and soft-deleted `task_tag` associations). `SyncPurgeService` hard-deletes tombstones older
+than the retention window (default 30 days), including completion and task-tag rows before tasks. A stable
 `device_id` setting UUID is generated once on first launch for sync provenance.
 
 Current task schema also includes reminder configuration fields:

--- a/.agents/docs/audit_results.md
+++ b/.agents/docs/audit_results.md
@@ -1,0 +1,20 @@
+# Focus Audit Snapshot
+
+Last updated: Phase 7 sync rewrite (`feat/phase-7-sync-rewrite`).
+
+## Current Risk Profile
+
+| Area | Risk | Notes |
+|------|------|-------|
+| Sync merge conflicts | Medium | Pure merge is unit-tested; apply/upsert path is integration-sensitive across UUID→id maps |
+| Schema migration v8→v9 | Low | Idempotent task_tag column add; migration harness covers onCreate + legacy upgrades |
+| Auto-sync debounce | Low | 8s debounce; skips when unsigned-in or `sync_enabled=false`; manual Sync Now forces |
+| Backup restore | Medium | Destructive replace of sync-covered tables — gated by confirmation dialog |
+| Focus session clocks | Low | Sessions lack DB `updatedAt`; merge uses `deletedAt ?? endTime ?? startTime` |
+
+## Known Gaps / Follow-ups
+
+- No end-to-end Google Drive integration test (mocked cloud service recommended).
+- Settings LWW depends on `${key}__updated_at` side-car keys written by `SettingsRepositoryImpl`.
+- Concurrent delete-vs-edit (both changed since last sync) still surfaces as a user conflict.
+- macOS file picker may require User Selected File entitlements for backup export/import.

--- a/.agents/docs/feature_plans.md
+++ b/.agents/docs/feature_plans.md
@@ -55,9 +55,19 @@ Status (Phase 6):
   are implemented on `ReportsScreen` via window-scoped SQL aggregates in
   `task_stats_local_datasource.dart` and `ReportInsightsCalculator`.
 
+### 5. Sync Rewrite (Phase 7 — High)
+
+Goal:
+- UUID-keyed multi-device sync with tombstones, extended entity coverage, auto-sync, and backup.
+
+Status (Phase 7):
+- `SyncData` schema v2 references peers by UUID; refuses newer remote schemas.
+- Pure `SyncMergeEngine` + `SyncEngine`/`SyncLocalDataSource` bulk gather/apply.
+- Auto-sync (`sync_enabled`, lifecycle, mutation debounce) and local JSON backup/restore.
+- DB schema v9 adds soft-delete fields on `task_tag_table`.
+
 ## Backlog Candidates
 
-- Import/export and backup restore workflows
 - Extended keyboard and desktop productivity shortcuts
 - Advanced session analytics and trend surfacing
 

--- a/.agents/docs/patterns.md
+++ b/.agents/docs/patterns.md
@@ -425,6 +425,42 @@ Gotchas:
 - Tag time double-counts sessions on multi-tagged tasks (intentional for tag breakdowns).
 - Export respects the selected insights window; heatmap uses the current calendar year.
 
+## Sync Merge + Auto Sync
+
+Phase 7 rewrote cloud sync around UUID identity and a pure merge engine:
+
+```dart
+// Pure — unit-tested in test/domain/sync/sync_merge_engine_test.dart
+final result = const SyncMergeEngine().merge(local, remote, lastSyncedAt);
+// result.merged is SyncData keyed by uuid; conflicts use String entityId
+
+// I/O orchestration
+await syncEngine.performSync(force: true); // manual Sync Now ignores sync_enabled
+await syncEngine.performSync();            // auto path respects sync_enabled
+
+// Local gather/apply is bulk (no per-project N+1)
+final bundle = await syncLocalDataSource.gatherLocalData();
+await syncLocalDataSource.applyMergedData(merged);
+```
+
+Dependency apply order: projects → milestones → tags → tasks (by depth) → task-tags →
+completions → sessions → settings.
+
+Auto-sync triggers:
+- App foreground / background (`SyncAutoSyncService` + `WidgetsBindingObserver`)
+- Debounced after mutation batches (`DataChangeBus` from repository writes)
+- Manual "Sync Now" always available
+
+Backup/restore:
+- Export/import SyncData JSON via `SyncBackupService` + `file_picker`
+- Restore requires explicit confirmation and replaces sync-covered local data
+
+Gotchas:
+- Refuse remote/backup `schemaVersion` newer than `kSyncSchemaVersion`.
+- Do not sync `device_id`, desktop prefs, or UI view-mode keys.
+- Focus sessions derive merge clocks from `deletedAt ?? endTime ?? startTime` (no DB `updatedAt`).
+- Task↔tag links soft-delete (do not hard-delete) so tombstones can propagate.
+
 ## Mandatory Follow-Up
 
 When a new pattern is introduced in production code, add it here with:

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -23,8 +23,11 @@ import '../../features/settings/data/datasources/settings_local_datasource.dart'
 import '../../features/settings/data/repositories/settings_repository_impl.dart';
 import '../../features/settings/domain/repositories/i_settings_repository.dart';
 import '../../features/settings/domain/services/settings_service.dart';
+import '../../features/sync/data/datasources/sync_local_datasource.dart';
 import '../../features/sync/data/services/google_drive_service.dart';
 import '../../features/sync/domain/services/i_cloud_storage_service.dart';
+import '../../features/sync/domain/services/sync_auto_sync_service.dart';
+import '../../features/sync/domain/services/sync_backup_service.dart';
 import '../../features/sync/domain/services/sync_engine.dart';
 import '../../features/sync/domain/services/sync_purge_service.dart';
 import '../../features/tags/data/datasources/tag_local_datasource.dart';
@@ -41,6 +44,7 @@ import '../../features/tasks/domain/services/task_notification_service.dart';
 import '../../features/tasks/domain/services/task_service.dart';
 import '../services/audio_service.dart';
 import '../services/audio_session_manager.dart';
+import '../services/data_change_bus.dart';
 import '../services/db_service.dart';
 import '../services/desktop_lifecycle_service.dart';
 import '../services/focus_audio_handler.dart';
@@ -55,6 +59,7 @@ Future<void> setupDependencyInjection() async {
   // Core Infrastructure Services
   getIt
     ..registerSingleton<AppDatabase>(AppDatabase())
+    ..registerSingleton<DataChangeBus>(DataChangeBus())
     ..registerLazySingleton<AudioService>(() => AudioService());
 
   // Platform-specific services
@@ -97,21 +102,27 @@ Future<void> setupDependencyInjection() async {
 void _initProjectsDi() {
   getIt
     ..registerLazySingleton<IProjectLocalDataSource>(() => ProjectLocalDataSourceImpl(getIt<AppDatabase>()))
-    ..registerLazySingleton<IProjectRepository>(() => ProjectRepositoryImpl(getIt<IProjectLocalDataSource>()))
+    ..registerLazySingleton<IProjectRepository>(
+      () => ProjectRepositoryImpl(getIt<IProjectLocalDataSource>(), getIt<DataChangeBus>()),
+    )
     ..registerLazySingleton<ProjectService>(() => ProjectService(getIt<IProjectRepository>()));
 }
 
 void _initMilestonesDi() {
   getIt
     ..registerLazySingleton<IMilestoneLocalDataSource>(() => MilestoneLocalDataSourceImpl(getIt<AppDatabase>()))
-    ..registerLazySingleton<IMilestoneRepository>(() => MilestoneRepositoryImpl(getIt<IMilestoneLocalDataSource>()))
+    ..registerLazySingleton<IMilestoneRepository>(
+      () => MilestoneRepositoryImpl(getIt<IMilestoneLocalDataSource>(), getIt<DataChangeBus>()),
+    )
     ..registerLazySingleton<MilestoneService>(() => MilestoneService(getIt<IMilestoneRepository>()));
 }
 
 void _initTagsDi() {
   getIt
     ..registerLazySingleton<ITagLocalDataSource>(() => TagLocalDataSourceImpl(getIt<AppDatabase>()))
-    ..registerLazySingleton<ITagRepository>(() => TagRepositoryImpl(getIt<ITagLocalDataSource>()))
+    ..registerLazySingleton<ITagRepository>(
+      () => TagRepositoryImpl(getIt<ITagLocalDataSource>(), getIt<DataChangeBus>()),
+    )
     ..registerLazySingleton<TagService>(() => TagService(getIt<ITagRepository>()));
 }
 
@@ -132,7 +143,9 @@ void _initTasksDi() {
   getIt
     ..registerLazySingleton<ITaskLocalDataSource>(() => TaskLocalDataSourceImpl(getIt<AppDatabase>()))
     ..registerLazySingleton<ITaskStatsLocalDataSource>(() => TaskStatsLocalDataSourceImpl(getIt<AppDatabase>()))
-    ..registerLazySingleton<ITaskRepository>(() => TaskRepositoryImpl(getIt<ITaskLocalDataSource>()))
+    ..registerLazySingleton<ITaskRepository>(
+      () => TaskRepositoryImpl(getIt<ITaskLocalDataSource>(), getIt<DataChangeBus>()),
+    )
     ..registerLazySingleton<ITaskStatsRepository>(() => TaskStatsRepositoryImpl(getIt<ITaskStatsLocalDataSource>()))
     ..registerLazySingleton<TaskNotificationService>(
       () => TaskNotificationService(getIt<INotificationService>(), getIt<ITaskRepository>()),
@@ -143,14 +156,18 @@ void _initTasksDi() {
 void _initSettingsDi() {
   getIt
     ..registerLazySingleton<ISettingsLocalDataSource>(() => SettingsLocalDataSourceImpl(getIt<AppDatabase>()))
-    ..registerLazySingleton<ISettingsRepository>(() => SettingsRepositoryImpl(getIt<ISettingsLocalDataSource>()))
+    ..registerLazySingleton<ISettingsRepository>(
+      () => SettingsRepositoryImpl(getIt<ISettingsLocalDataSource>(), getIt<DataChangeBus>()),
+    )
     ..registerLazySingleton<SettingsService>(() => SettingsService(getIt<ISettingsRepository>()));
 }
 
 void _initSessionDi() {
   getIt
     ..registerLazySingleton<IFocusLocalDataSource>(() => FocusLocalDataSourceImpl(getIt<AppDatabase>()))
-    ..registerLazySingleton<IFocusSessionRepository>(() => FocusSessionRepositoryImpl(getIt<IFocusLocalDataSource>()))
+    ..registerLazySingleton<IFocusSessionRepository>(
+      () => FocusSessionRepositoryImpl(getIt<IFocusLocalDataSource>(), getIt<DataChangeBus>()),
+    )
     ..registerLazySingleton<FocusSessionService>(
       () => FocusSessionService(getIt<IFocusSessionRepository>(), getIt<ITaskRepository>()),
     )
@@ -172,13 +189,17 @@ void _initSessionDi() {
 void _initSyncDi() {
   getIt
     ..registerLazySingleton<ICloudStorageService>(() => GoogleDriveService())
+    ..registerLazySingleton<ISyncLocalDataSource>(() => SyncLocalDataSourceImpl(getIt<AppDatabase>()))
     ..registerLazySingleton<SyncPurgeService>(() => SyncPurgeService(getIt<AppDatabase>()))
     ..registerLazySingleton<SyncEngine>(
-      () => SyncEngine(
-        getIt<ICloudStorageService>(),
-        getIt<IProjectRepository>(),
-        getIt<ITaskRepository>(),
-        getIt<ISettingsRepository>(),
+      () => SyncEngine(getIt<ICloudStorageService>(), getIt<ISyncLocalDataSource>(), getIt<ISettingsRepository>()),
+    )
+    ..registerLazySingleton<SyncBackupService>(() => SyncBackupService(getIt<SyncEngine>()))
+    ..registerLazySingleton<SyncAutoSyncService>(
+      () => SyncAutoSyncService(
+        syncEngine: getIt<SyncEngine>(),
+        cloudService: getIt<ICloudStorageService>(),
+        dataChangeBus: getIt<DataChangeBus>(),
       ),
     );
 }

--- a/lib/core/services/data_change_bus.dart
+++ b/lib/core/services/data_change_bus.dart
@@ -1,0 +1,17 @@
+/// Lightweight bus for local data mutations that should trigger auto-sync.
+///
+/// Domain/data layers emit [notify] after successful writes. Sync listens
+/// and debounces a cloud sync without creating a feature→feature dependency.
+class DataChangeBus {
+  final List<void Function()> _listeners = [];
+
+  void addListener(void Function() listener) => _listeners.add(listener);
+
+  void removeListener(void Function() listener) => _listeners.remove(listener);
+
+  void notify() {
+    for (final listener in List.of(_listeners)) {
+      listener();
+    }
+  }
+}

--- a/lib/core/services/db_service.dart
+++ b/lib/core/services/db_service.dart
@@ -43,7 +43,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 8;
+  int get schemaVersion => 9;
 
   /// Recalculates the [dailySessionStatsTable] row for the given
   /// local calendar [dateKey] (format `YYYY-MM-DD`).
@@ -277,6 +277,46 @@ class AppDatabase extends _$AppDatabase {
           'CREATE UNIQUE INDEX IF NOT EXISTS task_completion_task_occurrence_live_idx '
           'ON task_completion_table(task_id, occurrence_date) WHERE deleted_at IS NULL',
         );
+      }
+
+      // v8 → v9: Task↔tag link tombstones for multi-device sync.
+      // Idempotent: v7 `createTable` on current code already emits these columns.
+      if (from < 9) {
+        final info = await customSelect("PRAGMA table_info('task_tag_table')").get();
+        final columns = {for (final row in info) row.read<String>('name')};
+        if (!columns.contains('uuid')) {
+          await customStatement('ALTER TABLE task_tag_table ADD COLUMN uuid TEXT');
+          await customStatement('ALTER TABLE task_tag_table ADD COLUMN created_at INTEGER');
+          await customStatement('ALTER TABLE task_tag_table ADD COLUMN updated_at INTEGER');
+          await customStatement('ALTER TABLE task_tag_table ADD COLUMN deleted_at INTEGER');
+
+          final nowMs = DateTime.now().millisecondsSinceEpoch;
+          final rows = await customSelect('SELECT task_id, tag_id FROM task_tag_table WHERE uuid IS NULL').get();
+          for (final row in rows) {
+            await customStatement(
+              'UPDATE task_tag_table SET uuid = ?, created_at = ?, updated_at = ? '
+              'WHERE task_id = ? AND tag_id = ?',
+              [generateUuid(), nowMs, nowMs, row.read<int>('task_id'), row.read<int>('tag_id')],
+            );
+          }
+        } else {
+          // Columns exist but legacy rows may still lack uuid values.
+          final nowMs = DateTime.now().millisecondsSinceEpoch;
+          final rows = await customSelect(
+            'SELECT task_id, tag_id FROM task_tag_table WHERE uuid IS NULL OR uuid = \'\'',
+          ).get();
+          for (final row in rows) {
+            await customStatement(
+              'UPDATE task_tag_table SET uuid = ?, '
+              'created_at = COALESCE(created_at, ?), updated_at = COALESCE(updated_at, ?) '
+              'WHERE task_id = ? AND tag_id = ?',
+              [generateUuid(), nowMs, nowMs, row.read<int>('task_id'), row.read<int>('tag_id')],
+            );
+          }
+        }
+
+        await customStatement('CREATE UNIQUE INDEX IF NOT EXISTS task_tag_uuid_idx ON task_tag_table(uuid)');
+        await customStatement('CREATE INDEX IF NOT EXISTS task_tag_deleted_at_idx ON task_tag_table(deleted_at)');
       }
     },
     beforeOpen: (details) async {

--- a/lib/core/services/db_service.g.dart
+++ b/lib/core/services/db_service.g.dart
@@ -4038,7 +4038,7 @@ class TagTableCompanion extends UpdateCompanion<TagTableData> {
   }
 }
 
-class $TaskTagTableTable extends TaskTagTable with TableInfo<$TaskTagTableTable, TaskTagTableData> {
+class $TaskTagTableTable extends TaskTagTable with TableInfo<$TaskTagTableTable, TaskTagData> {
   @override
   final GeneratedDatabase attachedDatabase;
   final String? _alias;
@@ -4063,15 +4063,52 @@ class $TaskTagTableTable extends TaskTagTable with TableInfo<$TaskTagTableTable,
     requiredDuringInsert: true,
     defaultConstraints: GeneratedColumn.constraintIsAlways('REFERENCES tag_table (id) ON DELETE CASCADE'),
   );
+  static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
   @override
-  List<GeneratedColumn> get $columns => [taskId, tagId];
+  late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
+    'uuid',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _deletedAtMeta = const VerificationMeta('deletedAt');
+  @override
+  late final GeneratedColumn<DateTime> deletedAt = GeneratedColumn<DateTime>(
+    'deleted_at',
+    aliasedName,
+    true,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: false,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [taskId, tagId, uuid, createdAt, updatedAt, deletedAt];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
   String get actualTableName => $name;
   static const String $name = 'task_tag_table';
   @override
-  VerificationContext validateIntegrity(Insertable<TaskTagTableData> instance, {bool isInserting = false}) {
+  VerificationContext validateIntegrity(Insertable<TaskTagData> instance, {bool isInserting = false}) {
     final context = VerificationContext();
     final data = instance.toColumns(true);
     if (data.containsKey('task_id')) {
@@ -4084,17 +4121,39 @@ class $TaskTagTableTable extends TaskTagTable with TableInfo<$TaskTagTableTable,
     } else if (isInserting) {
       context.missing(_tagIdMeta);
     }
+    if (data.containsKey('uuid')) {
+      context.handle(_uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
+    } else if (isInserting) {
+      context.missing(_uuidMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta, createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta, updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    if (data.containsKey('deleted_at')) {
+      context.handle(_deletedAtMeta, deletedAt.isAcceptableOrUnknown(data['deleted_at']!, _deletedAtMeta));
+    }
     return context;
   }
 
   @override
   Set<GeneratedColumn> get $primaryKey => {taskId, tagId};
   @override
-  TaskTagTableData map(Map<String, dynamic> data, {String? tablePrefix}) {
+  TaskTagData map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
-    return TaskTagTableData(
+    return TaskTagData(
       taskId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}task_id'])!,
       tagId: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}tag_id'])!,
+      uuid: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
+      createdAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at'])!,
+      deletedAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}deleted_at']),
     );
   }
 
@@ -4104,86 +4163,191 @@ class $TaskTagTableTable extends TaskTagTable with TableInfo<$TaskTagTableTable,
   }
 }
 
-class TaskTagTableData extends DataClass implements Insertable<TaskTagTableData> {
+class TaskTagData extends DataClass implements Insertable<TaskTagData> {
   final int taskId;
   final int tagId;
-  const TaskTagTableData({required this.taskId, required this.tagId});
+  final String uuid;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? deletedAt;
+  const TaskTagData({
+    required this.taskId,
+    required this.tagId,
+    required this.uuid,
+    required this.createdAt,
+    required this.updatedAt,
+    this.deletedAt,
+  });
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['task_id'] = Variable<int>(taskId);
     map['tag_id'] = Variable<int>(tagId);
+    map['uuid'] = Variable<String>(uuid);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    if (!nullToAbsent || deletedAt != null) {
+      map['deleted_at'] = Variable<DateTime>(deletedAt);
+    }
     return map;
   }
 
   TaskTagTableCompanion toCompanion(bool nullToAbsent) {
-    return TaskTagTableCompanion(taskId: Value(taskId), tagId: Value(tagId));
+    return TaskTagTableCompanion(
+      taskId: Value(taskId),
+      tagId: Value(tagId),
+      uuid: Value(uuid),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+      deletedAt: deletedAt == null && nullToAbsent ? const Value.absent() : Value(deletedAt),
+    );
   }
 
-  factory TaskTagTableData.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
+  factory TaskTagData.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
-    return TaskTagTableData(
+    return TaskTagData(
       taskId: serializer.fromJson<int>(json['taskId']),
       tagId: serializer.fromJson<int>(json['tagId']),
+      uuid: serializer.fromJson<String>(json['uuid']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+      deletedAt: serializer.fromJson<DateTime?>(json['deletedAt']),
     );
   }
   @override
   Map<String, dynamic> toJson({ValueSerializer? serializer}) {
     serializer ??= driftRuntimeOptions.defaultSerializer;
-    return <String, dynamic>{'taskId': serializer.toJson<int>(taskId), 'tagId': serializer.toJson<int>(tagId)};
+    return <String, dynamic>{
+      'taskId': serializer.toJson<int>(taskId),
+      'tagId': serializer.toJson<int>(tagId),
+      'uuid': serializer.toJson<String>(uuid),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+      'deletedAt': serializer.toJson<DateTime?>(deletedAt),
+    };
   }
 
-  TaskTagTableData copyWith({int? taskId, int? tagId}) =>
-      TaskTagTableData(taskId: taskId ?? this.taskId, tagId: tagId ?? this.tagId);
-  TaskTagTableData copyWithCompanion(TaskTagTableCompanion data) {
-    return TaskTagTableData(
+  TaskTagData copyWith({
+    int? taskId,
+    int? tagId,
+    String? uuid,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    Value<DateTime?> deletedAt = const Value.absent(),
+  }) => TaskTagData(
+    taskId: taskId ?? this.taskId,
+    tagId: tagId ?? this.tagId,
+    uuid: uuid ?? this.uuid,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+    deletedAt: deletedAt.present ? deletedAt.value : this.deletedAt,
+  );
+  TaskTagData copyWithCompanion(TaskTagTableCompanion data) {
+    return TaskTagData(
       taskId: data.taskId.present ? data.taskId.value : this.taskId,
       tagId: data.tagId.present ? data.tagId.value : this.tagId,
+      uuid: data.uuid.present ? data.uuid.value : this.uuid,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+      deletedAt: data.deletedAt.present ? data.deletedAt.value : this.deletedAt,
     );
   }
 
   @override
   String toString() {
-    return (StringBuffer('TaskTagTableData(')
+    return (StringBuffer('TaskTagData(')
           ..write('taskId: $taskId, ')
-          ..write('tagId: $tagId')
+          ..write('tagId: $tagId, ')
+          ..write('uuid: $uuid, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(taskId, tagId);
+  int get hashCode => Object.hash(taskId, tagId, uuid, createdAt, updatedAt, deletedAt);
   @override
   bool operator ==(Object other) =>
-      identical(this, other) || (other is TaskTagTableData && other.taskId == this.taskId && other.tagId == this.tagId);
+      identical(this, other) ||
+      (other is TaskTagData &&
+          other.taskId == this.taskId &&
+          other.tagId == this.tagId &&
+          other.uuid == this.uuid &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt &&
+          other.deletedAt == this.deletedAt);
 }
 
-class TaskTagTableCompanion extends UpdateCompanion<TaskTagTableData> {
+class TaskTagTableCompanion extends UpdateCompanion<TaskTagData> {
   final Value<int> taskId;
   final Value<int> tagId;
+  final Value<String> uuid;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  final Value<DateTime?> deletedAt;
   final Value<int> rowid;
   const TaskTagTableCompanion({
     this.taskId = const Value.absent(),
     this.tagId = const Value.absent(),
+    this.uuid = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.deletedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
-  TaskTagTableCompanion.insert({required int taskId, required int tagId, this.rowid = const Value.absent()})
-    : taskId = Value(taskId),
-      tagId = Value(tagId);
-  static Insertable<TaskTagTableData> custom({
+  TaskTagTableCompanion.insert({
+    required int taskId,
+    required int tagId,
+    required String uuid,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+    this.deletedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  }) : taskId = Value(taskId),
+       tagId = Value(tagId),
+       uuid = Value(uuid),
+       createdAt = Value(createdAt),
+       updatedAt = Value(updatedAt);
+  static Insertable<TaskTagData> custom({
     Expression<int>? taskId,
     Expression<int>? tagId,
+    Expression<String>? uuid,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+    Expression<DateTime>? deletedAt,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
       if (taskId != null) 'task_id': taskId,
       if (tagId != null) 'tag_id': tagId,
+      if (uuid != null) 'uuid': uuid,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (deletedAt != null) 'deleted_at': deletedAt,
       if (rowid != null) 'rowid': rowid,
     });
   }
 
-  TaskTagTableCompanion copyWith({Value<int>? taskId, Value<int>? tagId, Value<int>? rowid}) {
-    return TaskTagTableCompanion(taskId: taskId ?? this.taskId, tagId: tagId ?? this.tagId, rowid: rowid ?? this.rowid);
+  TaskTagTableCompanion copyWith({
+    Value<int>? taskId,
+    Value<int>? tagId,
+    Value<String>? uuid,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+    Value<DateTime?>? deletedAt,
+    Value<int>? rowid,
+  }) {
+    return TaskTagTableCompanion(
+      taskId: taskId ?? this.taskId,
+      tagId: tagId ?? this.tagId,
+      uuid: uuid ?? this.uuid,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      deletedAt: deletedAt ?? this.deletedAt,
+      rowid: rowid ?? this.rowid,
+    );
   }
 
   @override
@@ -4194,6 +4358,18 @@ class TaskTagTableCompanion extends UpdateCompanion<TaskTagTableData> {
     }
     if (tagId.present) {
       map['tag_id'] = Variable<int>(tagId.value);
+    }
+    if (uuid.present) {
+      map['uuid'] = Variable<String>(uuid.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    if (deletedAt.present) {
+      map['deleted_at'] = Variable<DateTime>(deletedAt.value);
     }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
@@ -4206,6 +4382,10 @@ class TaskTagTableCompanion extends UpdateCompanion<TaskTagTableData> {
     return (StringBuffer('TaskTagTableCompanion(')
           ..write('taskId: $taskId, ')
           ..write('tagId: $tagId, ')
+          ..write('uuid: $uuid, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('deletedAt: $deletedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -4756,6 +4936,14 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'CREATE INDEX tag_deleted_at_idx ON tag_table (deleted_at)',
   );
   late final Index tagNameIdx = Index('tag_name_idx', 'CREATE INDEX tag_name_idx ON tag_table (name)');
+  late final Index taskTagUuidIdx = Index(
+    'task_tag_uuid_idx',
+    'CREATE UNIQUE INDEX task_tag_uuid_idx ON task_tag_table (uuid)',
+  );
+  late final Index taskTagDeletedAtIdx = Index(
+    'task_tag_deleted_at_idx',
+    'CREATE INDEX task_tag_deleted_at_idx ON task_tag_table (deleted_at)',
+  );
   late final Index milestoneUuidIdx = Index(
     'milestone_uuid_idx',
     'CREATE UNIQUE INDEX milestone_uuid_idx ON milestone_table (uuid)',
@@ -4825,6 +5013,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     tagUuidIdx,
     tagDeletedAtIdx,
     tagNameIdx,
+    taskTagUuidIdx,
+    taskTagDeletedAtIdx,
     milestoneUuidIdx,
     milestoneProjectIdIdx,
     milestoneDeletedAtIdx,
@@ -5705,7 +5895,7 @@ final class $$TaskTableTableReferences extends BaseReferences<_$AppDatabase, $Ta
     return ProcessedTableManager(manager.$state.copyWith(prefetchedData: cache));
   }
 
-  static MultiTypedResultKey<$TaskTagTableTable, List<TaskTagTableData>> _taskTagTableRefsTable(_$AppDatabase db) =>
+  static MultiTypedResultKey<$TaskTagTableTable, List<TaskTagData>> _taskTagTableRefsTable(_$AppDatabase db) =>
       MultiTypedResultKey.fromTable(db.taskTagTable, aliasName: 'task_table__id__task_tag_table__task_id');
 
   $$TaskTagTableTableProcessedTableManager get taskTagTableRefs {
@@ -6411,7 +6601,7 @@ class $$TaskTableTableTableManager
                           typedResults: items,
                         ),
                       if (taskTagTableRefs)
-                        await $_getPrefetchedData<TaskTableData, $TaskTableTable, TaskTagTableData>(
+                        await $_getPrefetchedData<TaskTableData, $TaskTableTable, TaskTagData>(
                           currentTable: table,
                           referencedTable: $$TaskTableTableReferences._taskTagTableRefsTable(db),
                           managerFromTypedResult: (p0) => $$TaskTableTableReferences(db, table, p0).taskTagTableRefs,
@@ -7331,7 +7521,7 @@ typedef $$TagTableTableUpdateCompanionBuilder =
 final class $$TagTableTableReferences extends BaseReferences<_$AppDatabase, $TagTableTable, TagTableData> {
   $$TagTableTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
-  static MultiTypedResultKey<$TaskTagTableTable, List<TaskTagTableData>> _taskTagTableRefsTable(_$AppDatabase db) =>
+  static MultiTypedResultKey<$TaskTagTableTable, List<TaskTagData>> _taskTagTableRefsTable(_$AppDatabase db) =>
       MultiTypedResultKey.fromTable(db.taskTagTable, aliasName: 'tag_table__id__task_tag_table__tag_id');
 
   $$TaskTagTableTableProcessedTableManager get taskTagTableRefs {
@@ -7528,7 +7718,7 @@ class $$TagTableTableTableManager
               getPrefetchedDataCallback: (items) async {
                 return [
                   if (taskTagTableRefs)
-                    await $_getPrefetchedData<TagTableData, $TagTableTable, TaskTagTableData>(
+                    await $_getPrefetchedData<TagTableData, $TagTableTable, TaskTagData>(
                       currentTable: table,
                       referencedTable: $$TagTableTableReferences._taskTagTableRefsTable(db),
                       managerFromTypedResult: (p0) => $$TagTableTableReferences(db, table, p0).taskTagTableRefs,
@@ -7559,11 +7749,27 @@ typedef $$TagTableTableProcessedTableManager =
       PrefetchHooks Function({bool taskTagTableRefs})
     >;
 typedef $$TaskTagTableTableCreateCompanionBuilder =
-    TaskTagTableCompanion Function({required int taskId, required int tagId, Value<int> rowid});
+    TaskTagTableCompanion Function({
+      required int taskId,
+      required int tagId,
+      required String uuid,
+      required DateTime createdAt,
+      required DateTime updatedAt,
+      Value<DateTime?> deletedAt,
+      Value<int> rowid,
+    });
 typedef $$TaskTagTableTableUpdateCompanionBuilder =
-    TaskTagTableCompanion Function({Value<int> taskId, Value<int> tagId, Value<int> rowid});
+    TaskTagTableCompanion Function({
+      Value<int> taskId,
+      Value<int> tagId,
+      Value<String> uuid,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+      Value<DateTime?> deletedAt,
+      Value<int> rowid,
+    });
 
-final class $$TaskTagTableTableReferences extends BaseReferences<_$AppDatabase, $TaskTagTableTable, TaskTagTableData> {
+final class $$TaskTagTableTableReferences extends BaseReferences<_$AppDatabase, $TaskTagTableTable, TaskTagData> {
   $$TaskTagTableTableReferences(super.$_db, super.$_table, super.$_typedResult);
 
   static $TaskTableTable _taskIdTable(_$AppDatabase db) =>
@@ -7599,6 +7805,17 @@ class $$TaskTagTableTableFilterComposer extends Composer<_$AppDatabase, $TaskTag
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnFilters<String> get uuid => $composableBuilder(column: $table.uuid, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => ColumnFilters(column));
+
   $$TaskTableTableFilterComposer get taskId {
     final $$TaskTableTableFilterComposer composer = $composerBuilder(
       composer: this,
@@ -7644,6 +7861,18 @@ class $$TaskTagTableTableOrderingComposer extends Composer<_$AppDatabase, $TaskT
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  ColumnOrderings<String> get uuid =>
+      $composableBuilder(column: $table.uuid, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get deletedAt =>
+      $composableBuilder(column: $table.deletedAt, builder: (column) => ColumnOrderings(column));
+
   $$TaskTableTableOrderingComposer get taskId {
     final $$TaskTableTableOrderingComposer composer = $composerBuilder(
       composer: this,
@@ -7689,6 +7918,14 @@ class $$TaskTagTableTableAnnotationComposer extends Composer<_$AppDatabase, $Tas
     super.$addJoinBuilderToRootComposer,
     super.$removeJoinBuilderFromRootComposer,
   });
+  GeneratedColumn<String> get uuid => $composableBuilder(column: $table.uuid, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt => $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt => $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get deletedAt => $composableBuilder(column: $table.deletedAt, builder: (column) => column);
+
   $$TaskTableTableAnnotationComposer get taskId {
     final $$TaskTableTableAnnotationComposer composer = $composerBuilder(
       composer: this,
@@ -7731,14 +7968,14 @@ class $$TaskTagTableTableTableManager
         RootTableManager<
           _$AppDatabase,
           $TaskTagTableTable,
-          TaskTagTableData,
+          TaskTagData,
           $$TaskTagTableTableFilterComposer,
           $$TaskTagTableTableOrderingComposer,
           $$TaskTagTableTableAnnotationComposer,
           $$TaskTagTableTableCreateCompanionBuilder,
           $$TaskTagTableTableUpdateCompanionBuilder,
-          (TaskTagTableData, $$TaskTagTableTableReferences),
-          TaskTagTableData,
+          (TaskTagData, $$TaskTagTableTableReferences),
+          TaskTagData,
           PrefetchHooks Function({bool taskId, bool tagId})
         > {
   $$TaskTagTableTableTableManager(_$AppDatabase db, $TaskTagTableTable table)
@@ -7753,11 +7990,38 @@ class $$TaskTagTableTableTableManager
               ({
                 Value<int> taskId = const Value.absent(),
                 Value<int> tagId = const Value.absent(),
+                Value<String> uuid = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+                Value<DateTime?> deletedAt = const Value.absent(),
                 Value<int> rowid = const Value.absent(),
-              }) => TaskTagTableCompanion(taskId: taskId, tagId: tagId, rowid: rowid),
+              }) => TaskTagTableCompanion(
+                taskId: taskId,
+                tagId: tagId,
+                uuid: uuid,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                deletedAt: deletedAt,
+                rowid: rowid,
+              ),
           createCompanionCallback:
-              ({required int taskId, required int tagId, Value<int> rowid = const Value.absent()}) =>
-                  TaskTagTableCompanion.insert(taskId: taskId, tagId: tagId, rowid: rowid),
+              ({
+                required int taskId,
+                required int tagId,
+                required String uuid,
+                required DateTime createdAt,
+                required DateTime updatedAt,
+                Value<DateTime?> deletedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => TaskTagTableCompanion.insert(
+                taskId: taskId,
+                tagId: tagId,
+                uuid: uuid,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+                deletedAt: deletedAt,
+                rowid: rowid,
+              ),
           withReferenceMapper: (p0) =>
               p0.map((e) => (e.readTable(table), $$TaskTagTableTableReferences(db, table, e))).toList(),
           prefetchHooksCallback: ({taskId = false, tagId = false}) {
@@ -7816,14 +8080,14 @@ typedef $$TaskTagTableTableProcessedTableManager =
     ProcessedTableManager<
       _$AppDatabase,
       $TaskTagTableTable,
-      TaskTagTableData,
+      TaskTagData,
       $$TaskTagTableTableFilterComposer,
       $$TaskTagTableTableOrderingComposer,
       $$TaskTagTableTableAnnotationComposer,
       $$TaskTagTableTableCreateCompanionBuilder,
       $$TaskTagTableTableUpdateCompanionBuilder,
-      (TaskTagTableData, $$TaskTagTableTableReferences),
-      TaskTagTableData,
+      (TaskTagData, $$TaskTagTableTableReferences),
+      TaskTagData,
       PrefetchHooks Function({bool taskId, bool tagId})
     >;
 typedef $$TaskCompletionTableTableCreateCompanionBuilder =

--- a/lib/features/milestones/data/repositories/milestone_repository_impl.dart
+++ b/lib/features/milestones/data/repositories/milestone_repository_impl.dart
@@ -1,3 +1,4 @@
+import '../../../../core/services/data_change_bus.dart';
 import '../../../../core/services/log_service.dart';
 import '../../domain/entities/milestone.dart';
 import '../../domain/entities/milestone_extensions.dart';
@@ -8,9 +9,12 @@ import '../mappers/milestone_extensions.dart';
 final _log = LogService.instance;
 
 class MilestoneRepositoryImpl implements IMilestoneRepository {
-  MilestoneRepositoryImpl(this._local);
+  MilestoneRepositoryImpl(this._local, [this._dataChangeBus]);
 
   final IMilestoneLocalDataSource _local;
+  final DataChangeBus? _dataChangeBus;
+
+  void _emitChange() => _dataChangeBus?.notify();
 
   @override
   Future<List<Milestone>> getMilestonesByProjectId(int projectId) async {
@@ -29,6 +33,7 @@ class MilestoneRepositoryImpl implements IMilestoneRepository {
     try {
       final id = await _local.createMilestone(milestone.toCompanion());
       _log.debug('Milestone created (id=$id)', tag: 'MilestoneRepository');
+      _emitChange();
       return milestone.copyWith(id: id);
     } catch (e, st) {
       _log.error('Failed to create milestone', tag: 'MilestoneRepository', error: e, stackTrace: st);
@@ -40,6 +45,7 @@ class MilestoneRepositoryImpl implements IMilestoneRepository {
   Future<void> updateMilestone(Milestone milestone) async {
     try {
       await _local.updateMilestone(milestone.toCompanion());
+      _emitChange();
     } catch (e, st) {
       _log.error(
         'Failed to update milestone (id=${milestone.id})',
@@ -55,6 +61,7 @@ class MilestoneRepositoryImpl implements IMilestoneRepository {
   Future<void> deleteMilestone(int id) async {
     try {
       await _local.deleteMilestone(id);
+      _emitChange();
     } catch (e, st) {
       _log.error('Failed to delete milestone (id=$id)', tag: 'MilestoneRepository', error: e, stackTrace: st);
       rethrow;

--- a/lib/features/projects/data/datasources/project_local_datasource.dart
+++ b/lib/features/projects/data/datasources/project_local_datasource.dart
@@ -87,7 +87,9 @@ class ProjectLocalDataSourceImpl implements IProjectLocalDataSource {
           await (_db.update(_db.taskCompletionTable)..where((t) => t.taskId.isIn(taskIds) & t.deletedAt.isNull()))
               .write(TaskCompletionTableCompanion(deletedAt: Value(now), updatedAt: Value(now)));
 
-          await (_db.delete(_db.taskTagTable)..where((t) => t.taskId.isIn(taskIds))).go();
+          await (_db.update(_db.taskTagTable)..where((t) => t.taskId.isIn(taskIds) & t.deletedAt.isNull())).write(
+            TaskTagTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
+          );
 
           await (_db.update(_db.taskTable)..where((t) => t.projectId.equals(id) & t.deletedAt.isNull())).write(
             TaskTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),

--- a/lib/features/projects/data/repositories/project_repository_impl.dart
+++ b/lib/features/projects/data/repositories/project_repository_impl.dart
@@ -1,3 +1,4 @@
+import '../../../../core/services/data_change_bus.dart';
 import '../../../../core/services/log_service.dart';
 import '../../domain/entities/project.dart';
 import '../../domain/entities/project_extensions.dart';
@@ -11,8 +12,11 @@ final _log = LogService.instance;
 
 class ProjectRepositoryImpl implements IProjectRepository {
   final IProjectLocalDataSource _localDataSource;
+  final DataChangeBus? _dataChangeBus;
 
-  ProjectRepositoryImpl(this._localDataSource);
+  ProjectRepositoryImpl(this._localDataSource, [this._dataChangeBus]);
+
+  void _emitChange() => _dataChangeBus?.notify();
 
   @override
   Future<List<Project>> getAllProjects() async {
@@ -32,6 +36,7 @@ class ProjectRepositoryImpl implements IProjectRepository {
       final companion = project.toCompanion();
       final id = await _localDataSource.createProject(companion);
       _log.debug('Project row inserted (id=$id)', tag: 'ProjectRepository');
+      _emitChange();
       return project.copyWith(id: id);
     } catch (e, st) {
       _log.error('Failed to insert project', tag: 'ProjectRepository', error: e, stackTrace: st);
@@ -44,6 +49,7 @@ class ProjectRepositoryImpl implements IProjectRepository {
     try {
       final companion = project.toCompanion();
       await _localDataSource.updateProject(companion);
+      _emitChange();
     } catch (e, st) {
       _log.error('Failed to update project (id=${project.id})', tag: 'ProjectRepository', error: e, stackTrace: st);
       rethrow;
@@ -54,6 +60,7 @@ class ProjectRepositoryImpl implements IProjectRepository {
   Future<void> deleteProject(int id) async {
     try {
       await _localDataSource.deleteProject(id);
+      _emitChange();
     } catch (e, st) {
       _log.error('Failed to delete project (id=$id)', tag: 'ProjectRepository', error: e, stackTrace: st);
       rethrow;

--- a/lib/features/session/data/repositories/focus_session_repository_impl.dart
+++ b/lib/features/session/data/repositories/focus_session_repository_impl.dart
@@ -1,3 +1,4 @@
+import '../../../../core/services/data_change_bus.dart';
 import '../../../../core/services/log_service.dart';
 import '../../domain/entities/focus_session.dart';
 import '../../domain/entities/focus_session_extensions.dart';
@@ -9,8 +10,11 @@ final _log = LogService.instance;
 
 class FocusSessionRepositoryImpl implements IFocusSessionRepository {
   final IFocusLocalDataSource _local;
+  final DataChangeBus? _dataChangeBus;
 
-  FocusSessionRepositoryImpl(this._local);
+  FocusSessionRepositoryImpl(this._local, [this._dataChangeBus]);
+
+  void _emitChange() => _dataChangeBus?.notify();
 
   @override
   Future<FocusSession> startSession(FocusSession session) async {
@@ -19,6 +23,7 @@ class FocusSessionRepositoryImpl implements IFocusSessionRepository {
       final id = await _local.createSession(companion);
       final saved = session.copyWith(id: id);
       _log.debug('Session persisted (id=$id)', tag: 'FocusSessionRepository');
+      _emitChange();
       return saved;
     } catch (e, st) {
       _log.error('Failed to persist session', tag: 'FocusSessionRepository', error: e, stackTrace: st);
@@ -32,6 +37,7 @@ class FocusSessionRepositoryImpl implements IFocusSessionRepository {
     try {
       final companion = session.toCompanion();
       await _local.updateSession(companion);
+      _emitChange();
     } catch (e, st) {
       _log.error(
         'Failed to update session (id=${session.id})',
@@ -68,6 +74,7 @@ class FocusSessionRepositoryImpl implements IFocusSessionRepository {
   Future<void> deleteSession(int id) async {
     try {
       await _local.deleteSession(id);
+      _emitChange();
     } catch (e, st) {
       _log.error('Failed to delete session (id=$id)', tag: 'FocusSessionRepository', error: e, stackTrace: st);
       rethrow;

--- a/lib/features/settings/data/repositories/settings_repository_impl.dart
+++ b/lib/features/settings/data/repositories/settings_repository_impl.dart
@@ -1,3 +1,4 @@
+import '../../../../core/services/data_change_bus.dart';
 import '../../../../core/services/log_service.dart';
 import '../../domain/entities/setting.dart';
 import '../../domain/repositories/i_settings_repository.dart';
@@ -7,8 +8,11 @@ final _log = LogService.instance;
 
 class SettingsRepositoryImpl implements ISettingsRepository {
   final ISettingsLocalDataSource _local;
+  final DataChangeBus? _dataChangeBus;
 
-  SettingsRepositoryImpl(this._local);
+  SettingsRepositoryImpl(this._local, [this._dataChangeBus]);
+
+  void _emitChange() => _dataChangeBus?.notify();
 
   @override
   Future<String?> getValue(String key) => _local.getValue(key);
@@ -17,6 +21,10 @@ class SettingsRepositoryImpl implements ISettingsRepository {
   Future<void> setValue(String key, String value) async {
     try {
       await _local.setValue(key, value);
+      if (SettingsKeys.syncableKeys.contains(key)) {
+        await _local.setValue(SettingsKeys.updatedAtKey(key), DateTime.now().toIso8601String());
+        _emitChange();
+      }
     } catch (e, st) {
       _log.error('Failed to write setting "$key"', tag: 'SettingsRepository', error: e, stackTrace: st);
       rethrow;

--- a/lib/features/settings/domain/entities/setting.dart
+++ b/lib/features/settings/domain/entities/setting.dart
@@ -40,6 +40,21 @@ abstract final class SettingsKeys {
 
   /// Stable per-install device UUID used for sync provenance.
   static const String deviceId = 'device_id';
+
+  /// Timer + audio preference keys that participate in cloud sync / backup.
+  ///
+  /// Excludes [deviceId], desktop-local prefs, and UI view-mode prefs.
+  static const Set<String> syncableKeys = {
+    alarmSoundId,
+    ambienceSoundId,
+    ambienceVolume,
+    ambienceEnabled,
+    focusDurationMinutes,
+    breakDurationMinutes,
+  };
+
+  /// Side-car timestamp key for a syncable preference (LWW merge clock).
+  static String updatedAtKey(String key) => '${key}__updated_at';
 }
 
 /// Domain entity representing a user preference.

--- a/lib/features/sync/data/datasources/sync_local_datasource.dart
+++ b/lib/features/sync/data/datasources/sync_local_datasource.dart
@@ -1,0 +1,603 @@
+import 'package:drift/drift.dart';
+
+import '../../../../core/services/db_service.dart';
+import '../../../../core/services/log_service.dart';
+import '../../../projects/domain/entities/project_status.dart';
+import '../../../session/domain/entities/session_state.dart';
+import '../../../settings/domain/entities/setting.dart';
+import '../../../tasks/domain/entities/task_priority.dart';
+import '../../../tasks/domain/entities/task_reminder_mode.dart';
+import '../../../tasks/domain/entities/task_status.dart';
+import '../../domain/entities/sync_data.dart';
+
+final _log = LogService.instance;
+
+/// Bulk local read/write surface used exclusively by [SyncEngine].
+///
+/// Gather includes soft-deleted rows so tombstones can propagate. Apply
+/// upserts by UUID and resolves peer references via UUID → local id maps.
+abstract interface class ISyncLocalDataSource {
+  Future<SyncData> gatherLocalData();
+
+  /// Replace local sync-covered rows with [merged] (UUID upsert).
+  ///
+  /// Used after a successful merge and for local backup restore.
+  Future<void> applyMergedData(SyncData merged);
+
+  /// Wipe sync-covered tables then apply [merged]. Used by restore.
+  Future<void> replaceAllWith(SyncData merged);
+}
+
+class SyncLocalDataSourceImpl implements ISyncLocalDataSource {
+  SyncLocalDataSourceImpl(this._db);
+
+  final AppDatabase _db;
+
+  @override
+  Future<SyncData> gatherLocalData() async {
+    final projects = await _db.select(_db.projectTable).get();
+    final milestones = await _db.select(_db.milestoneTable).get();
+    final tags = await _db.select(_db.tagTable).get();
+    final tasks = await _db.select(_db.taskTable).get();
+    final taskTags = await _db.select(_db.taskTagTable).get();
+    final completions = await _db.select(_db.taskCompletionTable).get();
+    final sessions = await _db.select(_db.focusSessionTable).get();
+    final settingsRows = await _db.select(_db.settingsTable).get();
+
+    final projectIdToUuid = {for (final p in projects) p.id: p.uuid};
+    final milestoneIdToUuid = {for (final m in milestones) m.id: m.uuid};
+    final tagIdToUuid = {for (final t in tags) t.id: t.uuid};
+    final taskIdToUuid = {for (final t in tasks) t.id: t.uuid};
+
+    final settingsMap = {for (final s in settingsRows) s.key: s.value};
+
+    return SyncData(
+      schemaVersion: kSyncSchemaVersion,
+      syncTimestamp: DateTime.now(),
+      projects: [
+        for (final p in projects)
+          SyncProjectData(
+            uuid: p.uuid,
+            title: p.title,
+            description: p.description,
+            statusIndex: p.status.index,
+            color: p.color,
+            startDate: p.startDate,
+            deadline: p.deadline,
+            createdAt: p.createdAt,
+            updatedAt: p.updatedAt,
+            deletedAt: p.deletedAt,
+          ),
+      ],
+      milestones: [
+        for (final m in milestones)
+          if (projectIdToUuid.containsKey(m.projectId))
+            SyncMilestoneData(
+              uuid: m.uuid,
+              projectUuid: projectIdToUuid[m.projectId]!,
+              title: m.title,
+              targetDate: m.targetDate,
+              createdAt: m.createdAt,
+              updatedAt: m.updatedAt,
+              deletedAt: m.deletedAt,
+            ),
+      ],
+      tags: [
+        for (final t in tags)
+          SyncTagData(
+            uuid: t.uuid,
+            name: t.name,
+            color: t.color,
+            createdAt: t.createdAt,
+            updatedAt: t.updatedAt,
+            deletedAt: t.deletedAt,
+          ),
+      ],
+      tasks: [
+        for (final t in tasks)
+          if (projectIdToUuid.containsKey(t.projectId))
+            SyncTaskData(
+              uuid: t.uuid,
+              projectUuid: projectIdToUuid[t.projectId]!,
+              parentTaskUuid: t.parentTaskId != null ? taskIdToUuid[t.parentTaskId!] : null,
+              title: t.title,
+              description: t.description,
+              priorityIndex: t.priority.index,
+              statusIndex: t.status.index,
+              reminderModeIndex: t.reminderMode.index,
+              customReminderMinutesBefore: t.customReminderMinutesBefore,
+              startDate: t.startDate,
+              endDate: t.endDate,
+              depth: t.depth,
+              estimatedMinutes: t.estimatedMinutes,
+              sortOrder: t.sortOrder,
+              milestoneUuid: t.milestoneId != null ? milestoneIdToUuid[t.milestoneId!] : null,
+              recurrenceRuleJson: t.recurrenceRule,
+              recurrenceAnchorDate: t.recurrenceAnchorDate,
+              isHabit: t.isHabit,
+              isCompleted: t.status == TaskStatus.done,
+              createdAt: t.createdAt,
+              updatedAt: t.updatedAt,
+              deletedAt: t.deletedAt,
+            ),
+      ]..sort((a, b) => a.depth.compareTo(b.depth)),
+      taskTags: [
+        for (final link in taskTags)
+          if (taskIdToUuid.containsKey(link.taskId) && tagIdToUuid.containsKey(link.tagId))
+            SyncTaskTagData(
+              uuid: link.uuid,
+              taskUuid: taskIdToUuid[link.taskId]!,
+              tagUuid: tagIdToUuid[link.tagId]!,
+              createdAt: link.createdAt,
+              updatedAt: link.updatedAt,
+              deletedAt: link.deletedAt,
+            ),
+      ],
+      completions: [
+        for (final c in completions)
+          if (taskIdToUuid.containsKey(c.taskId))
+            SyncTaskCompletionData(
+              uuid: c.uuid,
+              taskUuid: taskIdToUuid[c.taskId]!,
+              occurrenceDate: DateTime.parse(c.occurrenceDate),
+              completedAt: c.completedAt,
+              createdAt: c.createdAt,
+              updatedAt: c.updatedAt,
+              deletedAt: c.deletedAt,
+            ),
+      ],
+      sessions: [
+        for (final s in sessions)
+          SyncFocusSessionData(
+            uuid: s.uuid,
+            taskUuid: s.taskId != null ? taskIdToUuid[s.taskId!] : null,
+            focusDurationMinutes: s.focusDurationMinutes,
+            breakDurationMinutes: s.breakDurationMinutes,
+            startTime: s.startTime,
+            endTime: s.endTime,
+            stateIndex: s.state.index,
+            elapsedSeconds: s.elapsedSeconds,
+            focusPhaseEndedAt: s.focusPhaseEndedAt,
+            createdAt: s.startTime,
+            updatedAt: s.deletedAt ?? s.endTime ?? s.startTime,
+            deletedAt: s.deletedAt,
+          ),
+      ],
+      settings: [
+        for (final key in kSyncableSettingsKeys)
+          if (settingsMap.containsKey(key))
+            SyncSettingData(
+              key: key,
+              value: settingsMap[key]!,
+              updatedAt:
+                  DateTime.tryParse(settingsMap[SettingsKeys.updatedAtKey(key)] ?? '') ??
+                  DateTime.fromMillisecondsSinceEpoch(0),
+            ),
+      ],
+    );
+  }
+
+  @override
+  Future<void> applyMergedData(SyncData merged) async {
+    await _db.transaction(() async {
+      await _upsertAll(merged);
+    });
+  }
+
+  @override
+  Future<void> replaceAllWith(SyncData merged) async {
+    await _db.transaction(() async {
+      await _db.delete(_db.taskTagTable).go();
+      await _db.delete(_db.taskCompletionTable).go();
+      await _db.delete(_db.focusSessionTable).go();
+      await _db.delete(_db.taskTable).go();
+      await _db.delete(_db.milestoneTable).go();
+      await _db.delete(_db.tagTable).go();
+      await _db.delete(_db.projectTable).go();
+      // Clear only syncable settings (+ their clocks); leave device/desktop prefs.
+      for (final key in kSyncableSettingsKeys) {
+        await (_db.delete(_db.settingsTable)..where((t) => t.key.equals(key))).go();
+        await (_db.delete(_db.settingsTable)..where((t) => t.key.equals(SettingsKeys.updatedAtKey(key)))).go();
+      }
+      await _upsertAll(merged);
+    });
+  }
+
+  Future<void> _upsertAll(SyncData merged) async {
+    final projectUuidToId = await _upsertProjects(merged.projects);
+    final milestoneUuidToId = await _upsertMilestones(merged.milestones, projectUuidToId);
+    final tagUuidToId = await _upsertTags(merged.tags);
+    final taskUuidToId = await _upsertTasks(merged.tasks, projectUuidToId, milestoneUuidToId);
+    await _upsertTaskTags(merged.taskTags, taskUuidToId, tagUuidToId);
+    await _upsertCompletions(merged.completions, taskUuidToId);
+    await _upsertSessions(merged.sessions, taskUuidToId);
+    await _upsertSettings(merged.settings);
+  }
+
+  Future<Map<String, int>> _upsertProjects(List<SyncProjectData> projects) async {
+    final existing = await _db.select(_db.projectTable).get();
+    final byUuid = {for (final p in existing) p.uuid: p};
+    final map = <String, int>{};
+
+    for (final p in projects) {
+      final status = _safeEnum(ProjectStatus.values, p.statusIndex, ProjectStatus.active);
+      final current = byUuid[p.uuid];
+      if (current == null) {
+        final id = await _db
+            .into(_db.projectTable)
+            .insert(
+              ProjectTableCompanion.insert(
+                uuid: p.uuid,
+                title: p.title,
+                description: Value(p.description),
+                status: Value(status),
+                color: Value(p.color),
+                startDate: Value(p.startDate),
+                deadline: Value(p.deadline),
+                createdAt: p.createdAt,
+                updatedAt: p.updatedAt,
+                deletedAt: Value(p.deletedAt),
+              ),
+            );
+        map[p.uuid] = id;
+      } else {
+        await (_db.update(_db.projectTable)..where((t) => t.id.equals(current.id))).write(
+          ProjectTableCompanion(
+            title: Value(p.title),
+            description: Value(p.description),
+            status: Value(status),
+            color: Value(p.color),
+            startDate: Value(p.startDate),
+            deadline: Value(p.deadline),
+            createdAt: Value(p.createdAt),
+            updatedAt: Value(p.updatedAt),
+            deletedAt: Value(p.deletedAt),
+          ),
+        );
+        map[p.uuid] = current.id;
+      }
+    }
+
+    // Retain local-only projects in the id map for FK resolution of local-only children.
+    for (final p in existing) {
+      map.putIfAbsent(p.uuid, () => p.id);
+    }
+    return map;
+  }
+
+  Future<Map<String, int>> _upsertMilestones(
+    List<SyncMilestoneData> milestones,
+    Map<String, int> projectUuidToId,
+  ) async {
+    final existing = await _db.select(_db.milestoneTable).get();
+    final byUuid = {for (final m in existing) m.uuid: m};
+    final map = <String, int>{};
+
+    for (final m in milestones) {
+      final projectId = projectUuidToId[m.projectUuid];
+      if (projectId == null) {
+        _log.warning('Skipping milestone ${m.uuid}: missing project ${m.projectUuid}', tag: 'SyncLocalDS');
+        continue;
+      }
+      final current = byUuid[m.uuid];
+      if (current == null) {
+        final id = await _db
+            .into(_db.milestoneTable)
+            .insert(
+              MilestoneTableCompanion.insert(
+                uuid: m.uuid,
+                projectId: projectId,
+                title: m.title,
+                targetDate: Value(m.targetDate),
+                createdAt: m.createdAt,
+                updatedAt: m.updatedAt,
+                deletedAt: Value(m.deletedAt),
+              ),
+            );
+        map[m.uuid] = id;
+      } else {
+        await (_db.update(_db.milestoneTable)..where((t) => t.id.equals(current.id))).write(
+          MilestoneTableCompanion(
+            projectId: Value(projectId),
+            title: Value(m.title),
+            targetDate: Value(m.targetDate),
+            createdAt: Value(m.createdAt),
+            updatedAt: Value(m.updatedAt),
+            deletedAt: Value(m.deletedAt),
+          ),
+        );
+        map[m.uuid] = current.id;
+      }
+    }
+
+    for (final m in existing) {
+      map.putIfAbsent(m.uuid, () => m.id);
+    }
+    return map;
+  }
+
+  Future<Map<String, int>> _upsertTags(List<SyncTagData> tags) async {
+    final existing = await _db.select(_db.tagTable).get();
+    final byUuid = {for (final t in existing) t.uuid: t};
+    final map = <String, int>{};
+
+    for (final t in tags) {
+      final current = byUuid[t.uuid];
+      if (current == null) {
+        final id = await _db
+            .into(_db.tagTable)
+            .insert(
+              TagTableCompanion.insert(
+                uuid: t.uuid,
+                name: t.name,
+                color: Value(t.color),
+                createdAt: t.createdAt,
+                updatedAt: t.updatedAt,
+                deletedAt: Value(t.deletedAt),
+              ),
+            );
+        map[t.uuid] = id;
+      } else {
+        await (_db.update(_db.tagTable)..where((t2) => t2.id.equals(current.id))).write(
+          TagTableCompanion(
+            name: Value(t.name),
+            color: Value(t.color),
+            createdAt: Value(t.createdAt),
+            updatedAt: Value(t.updatedAt),
+            deletedAt: Value(t.deletedAt),
+          ),
+        );
+        map[t.uuid] = current.id;
+      }
+    }
+
+    for (final t in existing) {
+      map.putIfAbsent(t.uuid, () => t.id);
+    }
+    return map;
+  }
+
+  Future<Map<String, int>> _upsertTasks(
+    List<SyncTaskData> tasks,
+    Map<String, int> projectUuidToId,
+    Map<String, int> milestoneUuidToId,
+  ) async {
+    final existing = await _db.select(_db.taskTable).get();
+    final byUuid = {for (final t in existing) t.uuid: t};
+    final map = {for (final t in existing) t.uuid: t.id};
+
+    // Already sorted by depth in merge; still sort defensively.
+    final ordered = [...tasks]..sort((a, b) => a.depth.compareTo(b.depth));
+
+    for (final t in ordered) {
+      final projectId = projectUuidToId[t.projectUuid];
+      if (projectId == null) {
+        _log.warning('Skipping task ${t.uuid}: missing project ${t.projectUuid}', tag: 'SyncLocalDS');
+        continue;
+      }
+      final parentId = t.parentTaskUuid != null ? map[t.parentTaskUuid!] : null;
+      final milestoneId = t.milestoneUuid != null ? milestoneUuidToId[t.milestoneUuid!] : null;
+      final status = _safeEnum(TaskStatus.values, t.statusIndex, t.isCompleted ? TaskStatus.done : TaskStatus.todo);
+      final priority = _safeEnum(TaskPriority.values, t.priorityIndex, TaskPriority.medium);
+      final reminder = _safeEnum(TaskReminderMode.values, t.reminderModeIndex, TaskReminderMode.smart);
+      final current = byUuid[t.uuid];
+
+      if (current == null) {
+        final id = await _db
+            .into(_db.taskTable)
+            .insert(
+              TaskTableCompanion.insert(
+                uuid: t.uuid,
+                projectId: projectId,
+                parentTaskId: Value(parentId),
+                title: t.title,
+                description: Value(t.description),
+                priority: priority,
+                status: Value(status),
+                isCompleted: Value(status == TaskStatus.done),
+                reminderMode: Value(reminder),
+                customReminderMinutesBefore: Value(t.customReminderMinutesBefore),
+                startDate: Value(t.startDate),
+                endDate: Value(t.endDate),
+                depth: t.depth,
+                estimatedMinutes: Value(t.estimatedMinutes),
+                sortOrder: Value(t.sortOrder),
+                milestoneId: Value(milestoneId),
+                recurrenceRule: Value(t.recurrenceRuleJson),
+                recurrenceAnchorDate: Value(t.recurrenceAnchorDate),
+                isHabit: Value(t.isHabit),
+                createdAt: t.createdAt,
+                updatedAt: t.updatedAt,
+                deletedAt: Value(t.deletedAt),
+              ),
+            );
+        map[t.uuid] = id;
+      } else {
+        await (_db.update(_db.taskTable)..where((row) => row.id.equals(current.id))).write(
+          TaskTableCompanion(
+            projectId: Value(projectId),
+            parentTaskId: Value(parentId),
+            title: Value(t.title),
+            description: Value(t.description),
+            priority: Value(priority),
+            status: Value(status),
+            isCompleted: Value(status == TaskStatus.done),
+            reminderMode: Value(reminder),
+            customReminderMinutesBefore: Value(t.customReminderMinutesBefore),
+            startDate: Value(t.startDate),
+            endDate: Value(t.endDate),
+            depth: Value(t.depth),
+            estimatedMinutes: Value(t.estimatedMinutes),
+            sortOrder: Value(t.sortOrder),
+            milestoneId: Value(milestoneId),
+            recurrenceRule: Value(t.recurrenceRuleJson),
+            recurrenceAnchorDate: Value(t.recurrenceAnchorDate),
+            isHabit: Value(t.isHabit),
+            createdAt: Value(t.createdAt),
+            updatedAt: Value(t.updatedAt),
+            deletedAt: Value(t.deletedAt),
+          ),
+        );
+        map[t.uuid] = current.id;
+      }
+    }
+
+    return map;
+  }
+
+  Future<void> _upsertTaskTags(
+    List<SyncTaskTagData> links,
+    Map<String, int> taskUuidToId,
+    Map<String, int> tagUuidToId,
+  ) async {
+    final existing = await _db.select(_db.taskTagTable).get();
+    final byUuid = {for (final l in existing) l.uuid: l};
+
+    for (final link in links) {
+      final taskId = taskUuidToId[link.taskUuid];
+      final tagId = tagUuidToId[link.tagUuid];
+      if (taskId == null || tagId == null) {
+        _log.warning('Skipping task-tag ${link.uuid}: missing task/tag', tag: 'SyncLocalDS');
+        continue;
+      }
+
+      final current = byUuid[link.uuid];
+      if (current == null) {
+        // May collide on (taskId, tagId) if uuid differs — revive/update that row.
+        final byPair = existing.where((e) => e.taskId == taskId && e.tagId == tagId).firstOrNull;
+        if (byPair != null) {
+          await (_db.update(_db.taskTagTable)..where((t) => t.taskId.equals(taskId) & t.tagId.equals(tagId))).write(
+            TaskTagTableCompanion(
+              uuid: Value(link.uuid),
+              createdAt: Value(link.createdAt),
+              updatedAt: Value(link.updatedAt),
+              deletedAt: Value(link.deletedAt),
+            ),
+          );
+        } else {
+          await _db
+              .into(_db.taskTagTable)
+              .insert(
+                TaskTagTableCompanion.insert(
+                  taskId: taskId,
+                  tagId: tagId,
+                  uuid: link.uuid,
+                  createdAt: link.createdAt,
+                  updatedAt: link.updatedAt,
+                  deletedAt: Value(link.deletedAt),
+                ),
+              );
+        }
+      } else {
+        await (_db.update(_db.taskTagTable)
+              ..where((t) => t.taskId.equals(current.taskId) & t.tagId.equals(current.tagId)))
+            .write(TaskTagTableCompanion(updatedAt: Value(link.updatedAt), deletedAt: Value(link.deletedAt)));
+      }
+    }
+  }
+
+  Future<void> _upsertCompletions(List<SyncTaskCompletionData> completions, Map<String, int> taskUuidToId) async {
+    final existing = await _db.select(_db.taskCompletionTable).get();
+    final byUuid = {for (final c in existing) c.uuid: c};
+
+    for (final c in completions) {
+      final taskId = taskUuidToId[c.taskUuid];
+      if (taskId == null) continue;
+      final occurrenceKey =
+          '${c.occurrenceDate.year.toString().padLeft(4, '0')}-'
+          '${c.occurrenceDate.month.toString().padLeft(2, '0')}-'
+          '${c.occurrenceDate.day.toString().padLeft(2, '0')}';
+      final current = byUuid[c.uuid];
+
+      if (current == null) {
+        await _db
+            .into(_db.taskCompletionTable)
+            .insert(
+              TaskCompletionTableCompanion.insert(
+                uuid: c.uuid,
+                taskId: taskId,
+                occurrenceDate: occurrenceKey,
+                completedAt: c.completedAt,
+                createdAt: c.createdAt,
+                updatedAt: c.updatedAt,
+                deletedAt: Value(c.deletedAt),
+              ),
+            );
+      } else {
+        await (_db.update(_db.taskCompletionTable)..where((t) => t.id.equals(current.id))).write(
+          TaskCompletionTableCompanion(
+            taskId: Value(taskId),
+            occurrenceDate: Value(occurrenceKey),
+            completedAt: Value(c.completedAt),
+            createdAt: Value(c.createdAt),
+            updatedAt: Value(c.updatedAt),
+            deletedAt: Value(c.deletedAt),
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _upsertSessions(List<SyncFocusSessionData> sessions, Map<String, int> taskUuidToId) async {
+    final existing = await _db.select(_db.focusSessionTable).get();
+    final byUuid = {for (final s in existing) s.uuid: s};
+
+    for (final s in sessions) {
+      final taskId = s.taskUuid != null ? taskUuidToId[s.taskUuid!] : null;
+      final state = _safeEnum(SessionState.values, s.stateIndex, SessionState.completed);
+      final current = byUuid[s.uuid];
+
+      if (current == null) {
+        await _db
+            .into(_db.focusSessionTable)
+            .insert(
+              FocusSessionTableCompanion.insert(
+                uuid: s.uuid,
+                taskId: Value(taskId),
+                focusDurationMinutes: s.focusDurationMinutes,
+                breakDurationMinutes: s.breakDurationMinutes,
+                startTime: s.startTime,
+                endTime: Value(s.endTime),
+                state: state,
+                elapsedSeconds: Value(s.elapsedSeconds),
+                focusPhaseEndedAt: Value(s.focusPhaseEndedAt),
+                deletedAt: Value(s.deletedAt),
+              ),
+            );
+      } else {
+        await (_db.update(_db.focusSessionTable)..where((t) => t.id.equals(current.id))).write(
+          FocusSessionTableCompanion(
+            taskId: Value(taskId),
+            focusDurationMinutes: Value(s.focusDurationMinutes),
+            breakDurationMinutes: Value(s.breakDurationMinutes),
+            startTime: Value(s.startTime),
+            endTime: Value(s.endTime),
+            state: Value(state),
+            elapsedSeconds: Value(s.elapsedSeconds),
+            focusPhaseEndedAt: Value(s.focusPhaseEndedAt),
+            deletedAt: Value(s.deletedAt),
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _upsertSettings(List<SyncSettingData> settings) async {
+    for (final s in settings) {
+      if (!kSyncableSettingsKeys.contains(s.key)) continue;
+      await _db
+          .into(_db.settingsTable)
+          .insertOnConflictUpdate(SettingsTableCompanion.insert(key: s.key, value: s.value));
+      await _db
+          .into(_db.settingsTable)
+          .insertOnConflictUpdate(
+            SettingsTableCompanion.insert(key: SettingsKeys.updatedAtKey(s.key), value: s.updatedAt.toIso8601String()),
+          );
+    }
+  }
+}
+
+T _safeEnum<T>(List<T> values, int index, T fallback) {
+  if (index >= 0 && index < values.length) return values[index];
+  return fallback;
+}

--- a/lib/features/sync/domain/entities/sync_data.dart
+++ b/lib/features/sync/domain/entities/sync_data.dart
@@ -1,39 +1,140 @@
 import 'dart:convert';
 
 import '../../../../core/utils/id_utils.dart';
+import '../../../settings/domain/entities/setting.dart';
 import '../../../tasks/domain/entities/recurrence_rule.dart';
-import '../../../tasks/domain/entities/task.dart';
 import '../../../tasks/domain/entities/task_priority.dart';
 import '../../../tasks/domain/entities/task_reminder_mode.dart';
 import '../../../tasks/domain/entities/task_status.dart';
-import '../../../projects/domain/entities/project.dart';
 import '../../../projects/domain/entities/project_status.dart';
+import '../../../session/domain/entities/session_state.dart';
 
-/// Serializable data envelope for cloud sync.
+/// Current SyncData envelope schema. Bump when the payload shape changes.
 ///
-/// Contains all projects and tasks along with metadata needed for
-/// conflict detection and merge operations.
+/// Devices must refuse to merge payloads whose [schemaVersion] is *newer*
+/// than this constant (older / equal versions are accepted).
+const int kSyncSchemaVersion = 2;
+
+/// Whitelisted settings keys included in cloud sync and local backup.
+const Set<String> kSyncableSettingsKeys = SettingsKeys.syncableKeys;
+
+/// Serializable data envelope for cloud sync and local backup/restore.
 class SyncData {
+  final int schemaVersion;
   final DateTime syncTimestamp;
   final List<SyncProjectData> projects;
+  final List<SyncMilestoneData> milestones;
+  final List<SyncTagData> tags;
   final List<SyncTaskData> tasks;
+  final List<SyncTaskTagData> taskTags;
+  final List<SyncTaskCompletionData> completions;
+  final List<SyncFocusSessionData> sessions;
+  final List<SyncSettingData> settings;
 
-  const SyncData({required this.syncTimestamp, required this.projects, required this.tasks});
+  const SyncData({
+    this.schemaVersion = kSyncSchemaVersion,
+    required this.syncTimestamp,
+    this.projects = const [],
+    this.milestones = const [],
+    this.tags = const [],
+    this.tasks = const [],
+    this.taskTags = const [],
+    this.completions = const [],
+    this.sessions = const [],
+    this.settings = const [],
+  });
 
   factory SyncData.fromJson(Map<String, dynamic> json) {
+    final schemaVersion = (json['schemaVersion'] as int?) ?? 1;
+    final projects = (json['projects'] as List<dynamic>? ?? const [])
+        .map((e) => SyncProjectData.fromJson(e as Map<String, dynamic>))
+        .toList();
+
+    // Legacy v1 payloads referenced peers by local int ids. Resolve to UUIDs
+    // when possible so merge can key by UUID.
+    final projectIdToUuid = <int, String>{
+      for (final p in projects)
+        if (p.legacyId != null) p.legacyId!: p.uuid,
+    };
+
+    final milestones = (json['milestones'] as List<dynamic>? ?? const [])
+        .map((e) => SyncMilestoneData.fromJson(e as Map<String, dynamic>, projectIdToUuid: projectIdToUuid))
+        .toList();
+    final milestoneIdToUuid = <int, String>{
+      for (final m in milestones)
+        if (m.legacyId != null) m.legacyId!: m.uuid,
+    };
+
+    final tags = (json['tags'] as List<dynamic>? ?? const [])
+        .map((e) => SyncTagData.fromJson(e as Map<String, dynamic>))
+        .toList();
+    final tagIdToUuid = <int, String>{
+      for (final t in tags)
+        if (t.legacyId != null) t.legacyId!: t.uuid,
+    };
+
+    final tasks = (json['tasks'] as List<dynamic>? ?? const [])
+        .map(
+          (e) => SyncTaskData.fromJson(
+            e as Map<String, dynamic>,
+            projectIdToUuid: projectIdToUuid,
+            milestoneIdToUuid: milestoneIdToUuid,
+          ),
+        )
+        .toList();
+    final taskIdToUuid = <int, String>{
+      for (final t in tasks)
+        if (t.legacyId != null) t.legacyId!: t.uuid,
+    };
+
+    // Second pass: resolve parentTaskUuid from legacy parentTaskId.
+    final resolvedTasks = [
+      for (final t in tasks)
+        t.parentTaskUuid == null && t.legacyParentTaskId != null && taskIdToUuid.containsKey(t.legacyParentTaskId)
+            ? t.copyWith(parentTaskUuid: taskIdToUuid[t.legacyParentTaskId])
+            : t,
+    ];
+
     return SyncData(
+      schemaVersion: schemaVersion,
       syncTimestamp: DateTime.parse(json['syncTimestamp'] as String),
-      projects: (json['projects'] as List<dynamic>)
-          .map((e) => SyncProjectData.fromJson(e as Map<String, dynamic>))
+      projects: projects,
+      milestones: milestones,
+      tags: tags,
+      tasks: resolvedTasks,
+      taskTags: (json['taskTags'] as List<dynamic>? ?? const [])
+          .map(
+            (e) => SyncTaskTagData.fromJson(
+              e as Map<String, dynamic>,
+              taskIdToUuid: taskIdToUuid,
+              tagIdToUuid: tagIdToUuid,
+            ),
+          )
           .toList(),
-      tasks: (json['tasks'] as List<dynamic>).map((e) => SyncTaskData.fromJson(e as Map<String, dynamic>)).toList(),
+      completions: (json['completions'] as List<dynamic>? ?? const [])
+          .map((e) => SyncTaskCompletionData.fromJson(e as Map<String, dynamic>, taskIdToUuid: taskIdToUuid))
+          .toList(),
+      sessions: (json['sessions'] as List<dynamic>? ?? const [])
+          .map((e) => SyncFocusSessionData.fromJson(e as Map<String, dynamic>, taskIdToUuid: taskIdToUuid))
+          .toList(),
+      settings: (json['settings'] as List<dynamic>? ?? const [])
+          .map((e) => SyncSettingData.fromJson(e as Map<String, dynamic>))
+          .where((s) => kSyncableSettingsKeys.contains(s.key))
+          .toList(),
     );
   }
 
   Map<String, dynamic> toJson() => {
+    'schemaVersion': schemaVersion,
     'syncTimestamp': syncTimestamp.toIso8601String(),
     'projects': projects.map((p) => p.toJson()).toList(),
+    'milestones': milestones.map((m) => m.toJson()).toList(),
+    'tags': tags.map((t) => t.toJson()).toList(),
     'tasks': tasks.map((t) => t.toJson()).toList(),
+    'taskTags': taskTags.map((t) => t.toJson()).toList(),
+    'completions': completions.map((c) => c.toJson()).toList(),
+    'sessions': sessions.map((s) => s.toJson()).toList(),
+    'settings': settings.map((s) => s.toJson()).toList(),
   };
 
   String toJsonString() => jsonEncode(toJson());
@@ -42,12 +143,51 @@ class SyncData {
     return SyncData.fromJson(jsonDecode(jsonString) as Map<String, dynamic>);
   }
 
-  static SyncData empty() => SyncData(syncTimestamp: DateTime.now(), projects: const [], tasks: const []);
+  static SyncData empty() => SyncData(syncTimestamp: DateTime.now());
+
+  SyncData copyWith({
+    int? schemaVersion,
+    DateTime? syncTimestamp,
+    List<SyncProjectData>? projects,
+    List<SyncMilestoneData>? milestones,
+    List<SyncTagData>? tags,
+    List<SyncTaskData>? tasks,
+    List<SyncTaskTagData>? taskTags,
+    List<SyncTaskCompletionData>? completions,
+    List<SyncFocusSessionData>? sessions,
+    List<SyncSettingData>? settings,
+  }) {
+    return SyncData(
+      schemaVersion: schemaVersion ?? this.schemaVersion,
+      syncTimestamp: syncTimestamp ?? this.syncTimestamp,
+      projects: projects ?? this.projects,
+      milestones: milestones ?? this.milestones,
+      tags: tags ?? this.tags,
+      tasks: tasks ?? this.tasks,
+      taskTags: taskTags ?? this.taskTags,
+      completions: completions ?? this.completions,
+      sessions: sessions ?? this.sessions,
+      settings: settings ?? this.settings,
+    );
+  }
 }
 
-/// Serializable project data for sync.
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+DateTime? _parseDate(dynamic value) => value != null ? DateTime.parse(value as String) : null;
+
+String _requireUuid(Map<String, dynamic> json, [String key = 'uuid']) {
+  final value = json[key] as String?;
+  return (value != null && value.isNotEmpty) ? value : generateUuid();
+}
+
+// ---------------------------------------------------------------------------
+// Entity payloads
+// ---------------------------------------------------------------------------
+
 class SyncProjectData {
-  final int id;
   final String uuid;
   final String title;
   final String? description;
@@ -59,8 +199,10 @@ class SyncProjectData {
   final DateTime updatedAt;
   final DateTime? deletedAt;
 
+  /// Legacy v1 int id — used only while migrating old payloads.
+  final int? legacyId;
+
   const SyncProjectData({
-    required this.id,
     required this.uuid,
     required this.title,
     this.description,
@@ -71,26 +213,26 @@ class SyncProjectData {
     required this.createdAt,
     required this.updatedAt,
     this.deletedAt,
+    this.legacyId,
   });
 
   factory SyncProjectData.fromJson(Map<String, dynamic> json) {
     return SyncProjectData(
-      id: json['id'] as int,
-      uuid: (json['uuid'] as String?) ?? generateUuid(),
+      uuid: _requireUuid(json),
       title: json['title'] as String,
       description: json['description'] as String?,
       statusIndex: (json['statusIndex'] as int?) ?? ProjectStatus.active.index,
       color: json['color'] as int?,
-      startDate: json['startDate'] != null ? DateTime.parse(json['startDate'] as String) : null,
-      deadline: json['deadline'] != null ? DateTime.parse(json['deadline'] as String) : null,
+      startDate: _parseDate(json['startDate']),
+      deadline: _parseDate(json['deadline']),
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
-      deletedAt: json['deletedAt'] != null ? DateTime.parse(json['deletedAt'] as String) : null,
+      deletedAt: _parseDate(json['deletedAt']),
+      legacyId: json['id'] as int?,
     );
   }
 
   Map<String, dynamic> toJson() => {
-    'id': id,
     'uuid': uuid,
     'title': title,
     'description': description,
@@ -102,46 +244,99 @@ class SyncProjectData {
     'updatedAt': updatedAt.toIso8601String(),
     'deletedAt': deletedAt?.toIso8601String(),
   };
+}
 
-  factory SyncProjectData.fromProject(Project project) {
-    return SyncProjectData(
-      id: project.id!,
-      uuid: project.uuid,
-      title: project.title,
-      description: project.description,
-      statusIndex: project.status.index,
-      color: project.color,
-      startDate: project.startDate,
-      deadline: project.deadline,
-      createdAt: project.createdAt,
-      updatedAt: project.updatedAt,
-      deletedAt: project.deletedAt,
+class SyncMilestoneData {
+  final String uuid;
+  final String projectUuid;
+  final String title;
+  final DateTime? targetDate;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? deletedAt;
+  final int? legacyId;
+
+  const SyncMilestoneData({
+    required this.uuid,
+    required this.projectUuid,
+    required this.title,
+    this.targetDate,
+    required this.createdAt,
+    required this.updatedAt,
+    this.deletedAt,
+    this.legacyId,
+  });
+
+  factory SyncMilestoneData.fromJson(Map<String, dynamic> json, {Map<int, String> projectIdToUuid = const {}}) {
+    final projectUuid = json['projectUuid'] as String? ?? projectIdToUuid[json['projectId'] as int?] ?? '';
+    return SyncMilestoneData(
+      uuid: _requireUuid(json),
+      projectUuid: projectUuid,
+      title: json['title'] as String,
+      targetDate: _parseDate(json['targetDate']),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      deletedAt: _parseDate(json['deletedAt']),
+      legacyId: json['id'] as int?,
     );
   }
 
-  Project toProject() => Project(
-    id: id,
-    uuid: uuid,
-    title: title,
-    description: description,
-    status: statusIndex >= 0 && statusIndex < ProjectStatus.values.length
-        ? ProjectStatus.values[statusIndex]
-        : ProjectStatus.active,
-    color: color,
-    startDate: startDate,
-    deadline: deadline,
-    createdAt: createdAt,
-    updatedAt: updatedAt,
-    deletedAt: deletedAt,
-  );
+  Map<String, dynamic> toJson() => {
+    'uuid': uuid,
+    'projectUuid': projectUuid,
+    'title': title,
+    'targetDate': targetDate?.toIso8601String(),
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+    'deletedAt': deletedAt?.toIso8601String(),
+  };
 }
 
-/// Serializable task data for sync.
-class SyncTaskData {
-  final int id;
+class SyncTagData {
   final String uuid;
-  final int projectId;
-  final int? parentTaskId;
+  final String name;
+  final int? color;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? deletedAt;
+  final int? legacyId;
+
+  const SyncTagData({
+    required this.uuid,
+    required this.name,
+    this.color,
+    required this.createdAt,
+    required this.updatedAt,
+    this.deletedAt,
+    this.legacyId,
+  });
+
+  factory SyncTagData.fromJson(Map<String, dynamic> json) {
+    return SyncTagData(
+      uuid: _requireUuid(json),
+      name: json['name'] as String,
+      color: json['color'] as int?,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      deletedAt: _parseDate(json['deletedAt']),
+      legacyId: json['id'] as int?,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'uuid': uuid,
+    'name': name,
+    'color': color,
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+    'deletedAt': deletedAt?.toIso8601String(),
+  };
+}
+
+class SyncTaskData {
+  final String uuid;
+  final String projectUuid;
+  final String? parentTaskUuid;
   final String title;
   final String? description;
   final int priorityIndex;
@@ -153,7 +348,7 @@ class SyncTaskData {
   final int depth;
   final int? estimatedMinutes;
   final double sortOrder;
-  final int? milestoneId;
+  final String? milestoneUuid;
   final String? recurrenceRuleJson;
   final DateTime? recurrenceAnchorDate;
   final bool isHabit;
@@ -161,12 +356,13 @@ class SyncTaskData {
   final DateTime createdAt;
   final DateTime updatedAt;
   final DateTime? deletedAt;
+  final int? legacyId;
+  final int? legacyParentTaskId;
 
   const SyncTaskData({
-    required this.id,
     required this.uuid,
-    required this.projectId,
-    this.parentTaskId,
+    required this.projectUuid,
+    this.parentTaskUuid,
     required this.title,
     this.description,
     required this.priorityIndex,
@@ -178,7 +374,7 @@ class SyncTaskData {
     required this.depth,
     this.estimatedMinutes,
     this.sortOrder = 0,
-    this.milestoneId,
+    this.milestoneUuid,
     this.recurrenceRuleJson,
     this.recurrenceAnchorDate,
     this.isHabit = false,
@@ -186,45 +382,52 @@ class SyncTaskData {
     required this.createdAt,
     required this.updatedAt,
     this.deletedAt,
+    this.legacyId,
+    this.legacyParentTaskId,
   });
 
-  factory SyncTaskData.fromJson(Map<String, dynamic> json) {
+  factory SyncTaskData.fromJson(
+    Map<String, dynamic> json, {
+    Map<int, String> projectIdToUuid = const {},
+    Map<int, String> milestoneIdToUuid = const {},
+  }) {
     final statusIndex = json['statusIndex'] as int?;
     final isCompleted = json['isCompleted'] as bool? ?? false;
+    final projectUuid = json['projectUuid'] as String? ?? projectIdToUuid[json['projectId'] as int?] ?? '';
+    final milestoneUuid = json['milestoneUuid'] as String? ?? milestoneIdToUuid[json['milestoneId'] as int?];
+
     return SyncTaskData(
-      id: json['id'] as int,
-      uuid: (json['uuid'] as String?) ?? generateUuid(),
-      projectId: json['projectId'] as int,
-      parentTaskId: json['parentTaskId'] as int?,
+      uuid: _requireUuid(json),
+      projectUuid: projectUuid,
+      parentTaskUuid: json['parentTaskUuid'] as String?,
       title: json['title'] as String,
       description: json['description'] as String?,
-      priorityIndex: json['priorityIndex'] as int,
+      priorityIndex: json['priorityIndex'] as int? ?? TaskPriority.medium.index,
       statusIndex: statusIndex ?? (isCompleted ? TaskStatus.done.index : TaskStatus.todo.index),
       reminderModeIndex: (json['reminderModeIndex'] as int?) ?? TaskReminderMode.smart.index,
       customReminderMinutesBefore: json['customReminderMinutesBefore'] as int?,
-      startDate: json['startDate'] != null ? DateTime.parse(json['startDate'] as String) : null,
-      endDate: json['endDate'] != null ? DateTime.parse(json['endDate'] as String) : null,
-      depth: json['depth'] as int,
+      startDate: _parseDate(json['startDate']),
+      endDate: _parseDate(json['endDate']),
+      depth: json['depth'] as int? ?? 0,
       estimatedMinutes: json['estimatedMinutes'] as int?,
       sortOrder: (json['sortOrder'] as num?)?.toDouble() ?? 0,
-      milestoneId: json['milestoneId'] as int?,
+      milestoneUuid: milestoneUuid,
       recurrenceRuleJson: json['recurrenceRuleJson'] as String?,
-      recurrenceAnchorDate: json['recurrenceAnchorDate'] != null
-          ? DateTime.parse(json['recurrenceAnchorDate'] as String)
-          : null,
+      recurrenceAnchorDate: _parseDate(json['recurrenceAnchorDate']),
       isHabit: json['isHabit'] as bool? ?? false,
       isCompleted: isCompleted,
       createdAt: DateTime.parse(json['createdAt'] as String),
       updatedAt: DateTime.parse(json['updatedAt'] as String),
-      deletedAt: json['deletedAt'] != null ? DateTime.parse(json['deletedAt'] as String) : null,
+      deletedAt: _parseDate(json['deletedAt']),
+      legacyId: json['id'] as int?,
+      legacyParentTaskId: json['parentTaskId'] as int?,
     );
   }
 
   Map<String, dynamic> toJson() => {
-    'id': id,
     'uuid': uuid,
-    'projectId': projectId,
-    'parentTaskId': parentTaskId,
+    'projectUuid': projectUuid,
+    'parentTaskUuid': parentTaskUuid,
     'title': title,
     'description': description,
     'priorityIndex': priorityIndex,
@@ -236,7 +439,7 @@ class SyncTaskData {
     'depth': depth,
     'estimatedMinutes': estimatedMinutes,
     'sortOrder': sortOrder,
-    'milestoneId': milestoneId,
+    'milestoneUuid': milestoneUuid,
     'recurrenceRuleJson': recurrenceRuleJson,
     'recurrenceAnchorDate': recurrenceAnchorDate?.toIso8601String(),
     'isHabit': isHabit,
@@ -246,63 +449,214 @@ class SyncTaskData {
     'deletedAt': deletedAt?.toIso8601String(),
   };
 
-  factory SyncTaskData.fromTask(Task task) {
+  SyncTaskData copyWith({String? parentTaskUuid}) {
     return SyncTaskData(
-      id: task.id!,
-      uuid: task.uuid,
-      projectId: task.projectId,
-      parentTaskId: task.parentTaskId,
-      title: task.title,
-      description: task.description,
-      priorityIndex: task.priority.index,
-      statusIndex: task.status.index,
-      reminderModeIndex: task.reminderMode.index,
-      customReminderMinutesBefore: task.customReminderMinutesBefore,
-      startDate: task.startDate,
-      endDate: task.endDate,
-      depth: task.depth,
-      estimatedMinutes: task.estimatedMinutes,
-      sortOrder: task.sortOrder,
-      milestoneId: task.milestoneId,
-      recurrenceRuleJson: task.recurrenceRule?.toJson(),
-      recurrenceAnchorDate: task.recurrenceAnchorDate,
-      isHabit: task.isHabit,
-      isCompleted: task.isCompleted,
-      createdAt: task.createdAt,
-      updatedAt: task.updatedAt,
-      deletedAt: task.deletedAt,
-    );
-  }
-
-  Task toTask() {
-    final resolvedStatus = statusIndex >= 0 && statusIndex < TaskStatus.values.length
-        ? TaskStatus.values[statusIndex]
-        : (isCompleted ? TaskStatus.done : TaskStatus.todo);
-    return Task(
-      id: id,
       uuid: uuid,
-      projectId: projectId,
-      parentTaskId: parentTaskId,
+      projectUuid: projectUuid,
+      parentTaskUuid: parentTaskUuid ?? this.parentTaskUuid,
       title: title,
       description: description,
-      priority: TaskPriority.values[priorityIndex],
-      status: resolvedStatus,
-      reminderMode: reminderModeIndex >= 0 && reminderModeIndex < TaskReminderMode.values.length
-          ? TaskReminderMode.values[reminderModeIndex]
-          : TaskReminderMode.smart,
+      priorityIndex: priorityIndex,
+      statusIndex: statusIndex,
+      reminderModeIndex: reminderModeIndex,
       customReminderMinutesBefore: customReminderMinutesBefore,
       startDate: startDate,
       endDate: endDate,
       depth: depth,
       estimatedMinutes: estimatedMinutes,
       sortOrder: sortOrder,
-      milestoneId: milestoneId,
-      recurrenceRule: RecurrenceRule.tryParseJson(recurrenceRuleJson),
+      milestoneUuid: milestoneUuid,
+      recurrenceRuleJson: recurrenceRuleJson,
       recurrenceAnchorDate: recurrenceAnchorDate,
       isHabit: isHabit,
+      isCompleted: isCompleted,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      deletedAt: deletedAt,
+      legacyId: legacyId,
+      legacyParentTaskId: legacyParentTaskId,
+    );
+  }
+
+  bool get isDone =>
+      (statusIndex >= 0 && statusIndex < TaskStatus.values.length ? TaskStatus.values[statusIndex] : null) ==
+          TaskStatus.done ||
+      isCompleted;
+
+  RecurrenceRule? get recurrenceRule => RecurrenceRule.tryParseJson(recurrenceRuleJson);
+}
+
+class SyncTaskTagData {
+  final String uuid;
+  final String taskUuid;
+  final String tagUuid;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? deletedAt;
+
+  const SyncTaskTagData({
+    required this.uuid,
+    required this.taskUuid,
+    required this.tagUuid,
+    required this.createdAt,
+    required this.updatedAt,
+    this.deletedAt,
+  });
+
+  factory SyncTaskTagData.fromJson(
+    Map<String, dynamic> json, {
+    Map<int, String> taskIdToUuid = const {},
+    Map<int, String> tagIdToUuid = const {},
+  }) {
+    final taskUuid = json['taskUuid'] as String? ?? taskIdToUuid[json['taskId'] as int?] ?? '';
+    final tagUuid = json['tagUuid'] as String? ?? tagIdToUuid[json['tagId'] as int?] ?? '';
+    final createdAt = _parseDate(json['createdAt']) ?? DateTime.fromMillisecondsSinceEpoch(0);
+    final updatedAt = _parseDate(json['updatedAt']) ?? createdAt;
+    return SyncTaskTagData(
+      uuid: _requireUuid(json),
+      taskUuid: taskUuid,
+      tagUuid: tagUuid,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+      deletedAt: _parseDate(json['deletedAt']),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'uuid': uuid,
+    'taskUuid': taskUuid,
+    'tagUuid': tagUuid,
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+    'deletedAt': deletedAt?.toIso8601String(),
+  };
+}
+
+class SyncTaskCompletionData {
+  final String uuid;
+  final String taskUuid;
+  final DateTime occurrenceDate;
+  final DateTime completedAt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? deletedAt;
+
+  const SyncTaskCompletionData({
+    required this.uuid,
+    required this.taskUuid,
+    required this.occurrenceDate,
+    required this.completedAt,
+    required this.createdAt,
+    required this.updatedAt,
+    this.deletedAt,
+  });
+
+  factory SyncTaskCompletionData.fromJson(Map<String, dynamic> json, {Map<int, String> taskIdToUuid = const {}}) {
+    return SyncTaskCompletionData(
+      uuid: _requireUuid(json),
+      taskUuid: json['taskUuid'] as String? ?? taskIdToUuid[json['taskId'] as int?] ?? '',
+      occurrenceDate: DateTime.parse(json['occurrenceDate'] as String),
+      completedAt: DateTime.parse(json['completedAt'] as String),
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      deletedAt: _parseDate(json['deletedAt']),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'uuid': uuid,
+    'taskUuid': taskUuid,
+    'occurrenceDate': occurrenceDate.toIso8601String(),
+    'completedAt': completedAt.toIso8601String(),
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+    'deletedAt': deletedAt?.toIso8601String(),
+  };
+}
+
+class SyncFocusSessionData {
+  final String uuid;
+  final String? taskUuid;
+  final int focusDurationMinutes;
+  final int breakDurationMinutes;
+  final DateTime startTime;
+  final DateTime? endTime;
+  final int stateIndex;
+  final int elapsedSeconds;
+  final int? focusPhaseEndedAt;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final DateTime? deletedAt;
+
+  const SyncFocusSessionData({
+    required this.uuid,
+    this.taskUuid,
+    required this.focusDurationMinutes,
+    required this.breakDurationMinutes,
+    required this.startTime,
+    this.endTime,
+    required this.stateIndex,
+    this.elapsedSeconds = 0,
+    this.focusPhaseEndedAt,
+    required this.createdAt,
+    required this.updatedAt,
+    this.deletedAt,
+  });
+
+  factory SyncFocusSessionData.fromJson(Map<String, dynamic> json, {Map<int, String> taskIdToUuid = const {}}) {
+    final startTime = DateTime.parse(json['startTime'] as String);
+    final endTime = _parseDate(json['endTime']);
+    final deletedAt = _parseDate(json['deletedAt']);
+    // Sessions historically lacked updatedAt; derive a stable clock for merge.
+    final updatedAt = _parseDate(json['updatedAt']) ?? deletedAt ?? endTime ?? startTime;
+    final createdAt = _parseDate(json['createdAt']) ?? startTime;
+
+    return SyncFocusSessionData(
+      uuid: _requireUuid(json),
+      taskUuid: json['taskUuid'] as String? ?? taskIdToUuid[json['taskId'] as int?],
+      focusDurationMinutes: json['focusDurationMinutes'] as int,
+      breakDurationMinutes: json['breakDurationMinutes'] as int,
+      startTime: startTime,
+      endTime: endTime,
+      stateIndex: json['stateIndex'] as int? ?? SessionState.completed.index,
+      elapsedSeconds: json['elapsedSeconds'] as int? ?? 0,
+      focusPhaseEndedAt: json['focusPhaseEndedAt'] as int?,
       createdAt: createdAt,
       updatedAt: updatedAt,
       deletedAt: deletedAt,
     );
   }
+
+  Map<String, dynamic> toJson() => {
+    'uuid': uuid,
+    'taskUuid': taskUuid,
+    'focusDurationMinutes': focusDurationMinutes,
+    'breakDurationMinutes': breakDurationMinutes,
+    'startTime': startTime.toIso8601String(),
+    'endTime': endTime?.toIso8601String(),
+    'stateIndex': stateIndex,
+    'elapsedSeconds': elapsedSeconds,
+    'focusPhaseEndedAt': focusPhaseEndedAt,
+    'createdAt': createdAt.toIso8601String(),
+    'updatedAt': updatedAt.toIso8601String(),
+    'deletedAt': deletedAt?.toIso8601String(),
+  };
+}
+
+class SyncSettingData {
+  final String key;
+  final String value;
+  final DateTime updatedAt;
+
+  const SyncSettingData({required this.key, required this.value, required this.updatedAt});
+
+  factory SyncSettingData.fromJson(Map<String, dynamic> json) {
+    return SyncSettingData(
+      key: json['key'] as String,
+      value: json['value'] as String,
+      updatedAt: _parseDate(json['updatedAt']) ?? DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {'key': key, 'value': value, 'updatedAt': updatedAt.toIso8601String()};
 }

--- a/lib/features/sync/domain/entities/sync_state.dart
+++ b/lib/features/sync/domain/entities/sync_state.dart
@@ -66,7 +66,9 @@ class SyncState extends Equatable {
 class SyncConflict extends Equatable {
   /// The unique identifier of the conflicting entity.
   final String entityType;
-  final int entityId;
+
+  /// Stable sync identity (`uuid` for rows, settings `key` for preferences).
+  final String entityId;
   final String entityTitle;
 
   /// When the local version was last updated.

--- a/lib/features/sync/domain/services/sync_auto_sync_service.dart
+++ b/lib/features/sync/domain/services/sync_auto_sync_service.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+import '../../../../core/services/data_change_bus.dart';
+import '../../../../core/services/log_service.dart';
+import '../../../../core/utils/result.dart';
+import '../entities/sync_state.dart';
+import 'i_cloud_storage_service.dart';
+import 'sync_engine.dart';
+
+final _log = LogService.instance;
+
+/// Drives automatic sync on app lifecycle events and debounced mutations.
+class SyncAutoSyncService with WidgetsBindingObserver {
+  SyncAutoSyncService({
+    required SyncEngine syncEngine,
+    required ICloudStorageService cloudService,
+    required DataChangeBus dataChangeBus,
+    this.mutationDebounce = const Duration(seconds: 8),
+  }) : _syncEngine = syncEngine,
+       _cloudService = cloudService,
+       _dataChangeBus = dataChangeBus;
+
+  final SyncEngine _syncEngine;
+  final ICloudStorageService _cloudService;
+  final DataChangeBus _dataChangeBus;
+  final Duration mutationDebounce;
+
+  Timer? _debounceTimer;
+  bool _syncInFlight = false;
+  bool _initialized = false;
+
+  /// Optional callback so UI notifiers can mirror sync results.
+  void Function(SyncState state)? onStateChanged;
+
+  void init() {
+    if (_initialized) return;
+    _initialized = true;
+    WidgetsBinding.instance.addObserver(this);
+    _dataChangeBus.addListener(scheduleDebouncedSync);
+    _log.info('Auto-sync service initialized', tag: 'SyncAutoSync');
+  }
+
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _dataChangeBus.removeListener(scheduleDebouncedSync);
+    _debounceTimer?.cancel();
+    _initialized = false;
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    switch (state) {
+      case AppLifecycleState.resumed:
+        unawaited(triggerSync(reason: 'foreground'));
+      case AppLifecycleState.paused:
+      case AppLifecycleState.hidden:
+        unawaited(triggerSync(reason: 'background'));
+      case AppLifecycleState.inactive:
+      case AppLifecycleState.detached:
+        break;
+    }
+  }
+
+  /// Debounce a sync after a local mutation batch.
+  void scheduleDebouncedSync() {
+    _debounceTimer?.cancel();
+    _debounceTimer = Timer(mutationDebounce, () {
+      unawaited(triggerSync(reason: 'mutation'));
+    });
+  }
+
+  /// Run an automatic sync when enabled + signed in.
+  Future<void> triggerSync({required String reason}) async {
+    if (_syncInFlight) return;
+    try {
+      if (!await _cloudService.isSignedIn()) return;
+      if (!await _syncEngine.isSyncEnabled()) return;
+
+      _syncInFlight = true;
+      _log.info('Auto-sync triggered ($reason)', tag: 'SyncAutoSync');
+      final result = await _syncEngine.performSync();
+      switch (result) {
+        case Success(:final value):
+          onStateChanged?.call(value);
+        case Failure(:final failure):
+          _log.warning('Auto-sync failed: ${failure.message}', tag: 'SyncAutoSync');
+          onStateChanged?.call(SyncState(status: SyncStatus.error, errorMessage: failure.message));
+      }
+    } catch (e, st) {
+      _log.error('Auto-sync crashed', tag: 'SyncAutoSync', error: e, stackTrace: st);
+    } finally {
+      _syncInFlight = false;
+    }
+  }
+}

--- a/lib/features/sync/domain/services/sync_backup_service.dart
+++ b/lib/features/sync/domain/services/sync_backup_service.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+
+import '../../../../core/services/log_service.dart';
+import '../../../../core/utils/result.dart';
+import '../entities/sync_data.dart';
+import 'sync_engine.dart';
+
+final _log = LogService.instance;
+
+/// Local JSON backup / restore using the SyncData envelope.
+class SyncBackupService {
+  SyncBackupService(this._syncEngine);
+
+  final SyncEngine _syncEngine;
+
+  /// Export full SyncData-shaped bundle to a user-chosen file.
+  Future<Result<String>> exportToFile() async {
+    try {
+      final data = await _syncEngine.exportLocalBackup();
+      final json = const JsonEncoder.withIndent('  ').convert(data.toJson());
+      final path = await FilePicker.saveFile(
+        dialogTitle: 'Export Focus backup',
+        fileName: 'focus_backup_${_timestamp()}.json',
+        type: FileType.custom,
+        allowedExtensions: const ['json'],
+        bytes: utf8.encode(json),
+      );
+      if (path == null) {
+        return const Failure(SyncFailure('Export cancelled'));
+      }
+      // Desktop saveFile may return a path without writing bytes on some platforms.
+      final file = File(path);
+      if (!await file.exists() || await file.length() == 0) {
+        await file.writeAsString(json);
+      }
+      _log.info('Backup exported to $path', tag: 'SyncBackup');
+      return Success(path);
+    } catch (e, st) {
+      _log.error('Backup export failed', tag: 'SyncBackup', error: e, stackTrace: st);
+      return Failure(SyncFailure('Failed to export backup', error: e, stackTrace: st));
+    }
+  }
+
+  /// Import a SyncData JSON file. Caller must confirm before invoking —
+  /// this **replaces** local sync-covered data.
+  Future<Result<void>> importFromFile() async {
+    try {
+      final result = await FilePicker.pickFiles(
+        dialogTitle: 'Import Focus backup',
+        type: FileType.custom,
+        allowedExtensions: const ['json'],
+        withData: true,
+      );
+      if (result == null || result.files.isEmpty) {
+        return const Failure(SyncFailure('Import cancelled'));
+      }
+      final file = result.files.single;
+      final bytes = file.bytes ?? (file.path != null ? await File(file.path!).readAsBytes() : null);
+      if (bytes == null) {
+        return const Failure(SyncFailure('Could not read backup file'));
+      }
+      final data = SyncData.fromJsonString(utf8.decode(bytes));
+      return _syncEngine.restoreFromBackup(data);
+    } catch (e, st) {
+      _log.error('Backup import failed', tag: 'SyncBackup', error: e, stackTrace: st);
+      return Failure(SyncFailure('Failed to import backup', error: e, stackTrace: st));
+    }
+  }
+
+  String _timestamp() {
+    final n = DateTime.now();
+    return '${n.year}${n.month.toString().padLeft(2, '0')}${n.day.toString().padLeft(2, '0')}_'
+        '${n.hour.toString().padLeft(2, '0')}${n.minute.toString().padLeft(2, '0')}';
+  }
+}

--- a/lib/features/sync/domain/services/sync_engine.dart
+++ b/lib/features/sync/domain/services/sync_engine.dart
@@ -1,11 +1,10 @@
 import '../../../../core/services/log_service.dart';
 import '../../../../core/utils/result.dart';
-import '../../../projects/domain/repositories/i_project_repository.dart';
-import '../../../tasks/domain/entities/task.dart';
-import '../../../tasks/domain/repositories/i_task_repository.dart';
-import '../../domain/entities/sync_data.dart';
-import '../../domain/entities/sync_state.dart';
-import '../../domain/services/i_cloud_storage_service.dart';
+import '../../data/datasources/sync_local_datasource.dart';
+import '../entities/sync_data.dart';
+import '../entities/sync_state.dart';
+import 'i_cloud_storage_service.dart';
+import 'sync_merge_engine.dart';
 import '../../../settings/domain/repositories/i_settings_repository.dart';
 
 final _log = LogService.instance;
@@ -16,74 +15,85 @@ abstract final class SyncSettingsKeys {
   static const String syncEnabled = 'sync_enabled';
 }
 
-/// The core sync engine that coordinates data synchronization between
-/// local storage and cloud storage.
+/// Coordinates local ↔ cloud synchronization.
 ///
-/// Handles:
-/// - Gathering all local projects and tasks
-/// - Comparing with remote data
-/// - Detecting conflicts (both sides changed since last sync)
-/// - Merging non-conflicting changes
-/// - Uploading the merged result
+/// Merge logic lives in [SyncMergeEngine] (pure / unit-tested). This class
+/// owns I/O: gather, download, upload, apply, and schema-version gating.
 class SyncEngine {
   final ICloudStorageService _cloudService;
-  final IProjectRepository _projectRepository;
-  final ITaskRepository _taskRepository;
+  final ISyncLocalDataSource _localDataSource;
   final ISettingsRepository _settingsRepository;
+  final SyncMergeEngine _mergeEngine;
 
-  SyncEngine(this._cloudService, this._projectRepository, this._taskRepository, this._settingsRepository);
+  SyncEngine(
+    this._cloudService,
+    this._localDataSource,
+    this._settingsRepository, {
+    SyncMergeEngine mergeEngine = const SyncMergeEngine(),
+  }) : _mergeEngine = mergeEngine;
 
-  /// Get the last sync timestamp from settings.
   Future<DateTime?> getLastSyncedAt() async {
     final value = await _settingsRepository.getValue(SyncSettingsKeys.lastSyncedAt);
     if (value == null) return null;
     return DateTime.tryParse(value);
   }
 
-  /// Save the last sync timestamp.
+  Future<bool> isSyncEnabled() async {
+    final value = await _settingsRepository.getValue(SyncSettingsKeys.syncEnabled);
+    // Default to enabled when connected so existing installs keep working.
+    if (value == null) return true;
+    return value == 'true';
+  }
+
+  Future<void> setSyncEnabled(bool enabled) async {
+    await _settingsRepository.setValue(SyncSettingsKeys.syncEnabled, enabled ? 'true' : 'false');
+  }
+
   Future<void> _saveLastSyncedAt(DateTime timestamp) async {
     await _settingsRepository.setValue(SyncSettingsKeys.lastSyncedAt, timestamp.toIso8601String());
   }
 
-  /// Gather all local data into a [SyncData] object.
-  Future<SyncData> _gatherLocalData() async {
-    final projects = await _projectRepository.getAllProjects();
-    final allTasks = <Task>[];
+  /// Export a SyncData-shaped bundle of the current local database.
+  Future<SyncData> exportLocalBackup() => _localDataSource.gatherLocalData();
 
-    for (final project in projects) {
-      if (project.id != null) {
-        final tasks = await _taskRepository.getTasksByProjectId(project.id!);
-        allTasks.addAll(tasks);
+  /// Replace local sync-covered data with [data] (after schema check).
+  Future<Result<void>> restoreFromBackup(SyncData data) async {
+    try {
+      if (data.schemaVersion > kSyncSchemaVersion) {
+        return Failure(
+          SyncFailure(
+            'Backup schema v${data.schemaVersion} is newer than this app (v$kSyncSchemaVersion). Upgrade Focus to restore.',
+          ),
+        );
       }
+      await _localDataSource.replaceAllWith(data.copyWith(schemaVersion: kSyncSchemaVersion));
+      return const Success(null);
+    } catch (e, st) {
+      _log.error('Restore failed', tag: 'SyncEngine', error: e, stackTrace: st);
+      return Failure(SyncFailure('Failed to restore backup', error: e, stackTrace: st));
     }
-
-    return SyncData(
-      syncTimestamp: DateTime.now(),
-      projects: projects.where((p) => p.id != null).map((p) => SyncProjectData.fromProject(p)).toList(),
-      tasks: allTasks.where((t) => t.id != null).map((t) => SyncTaskData.fromTask(t)).toList(),
-    );
   }
 
   /// Perform a full sync operation.
-  ///
-  /// Returns a [SyncState] with conflicts if any are detected.
-  /// The caller must resolve conflicts and call [applyResolutions] before
-  /// the sync is complete.
-  Future<Result<SyncState>> performSync() async {
+  Future<Result<SyncState>> performSync({bool force = false}) async {
     try {
+      if (!force && !await isSyncEnabled()) {
+        _log.info('Sync skipped — auto sync disabled', tag: 'SyncEngine');
+        final email = await _cloudService.getAccountEmail();
+        return Success(SyncState(status: SyncStatus.idle, lastSyncedAt: await getLastSyncedAt(), accountEmail: email));
+      }
+
       _log.info('Starting sync...', tag: 'SyncEngine');
 
-      // 1. Download remote data.
       final downloadResult = await _cloudService.downloadSyncData();
       switch (downloadResult) {
         case Failure(:final failure):
           return Failure(failure);
         case Success(:final value):
           final remoteData = value;
-          final localData = await _gatherLocalData();
+          final localData = await _localDataSource.gatherLocalData();
           final lastSyncedAt = await getLastSyncedAt();
 
-          // 2. If no remote data, just upload local.
           if (remoteData == null) {
             _log.info('No remote data found, uploading local data', tag: 'SyncEngine');
             final uploadResult = await _cloudService.uploadSyncData(localData);
@@ -103,10 +113,22 @@ class SyncEngine {
             }
           }
 
-          // 3. Detect conflicts and merge.
-          final mergeResult = _mergeData(localData, remoteData, lastSyncedAt);
+          if (remoteData.schemaVersion > kSyncSchemaVersion) {
+            return Failure(
+              SyncFailure(
+                'Remote sync schema v${remoteData.schemaVersion} is newer than this app '
+                '(v$kSyncSchemaVersion). Upgrade Focus to sync.',
+              ),
+            );
+          }
 
-          // 4. If conflicts exist, return them for resolution.
+          final SyncMergeResult mergeResult;
+          try {
+            mergeResult = _mergeEngine.merge(localData, remoteData, lastSyncedAt);
+          } on SyncSchemaTooNewException catch (e) {
+            return Failure(SyncFailure(e.toString()));
+          }
+
           if (mergeResult.conflicts.isNotEmpty) {
             _log.info('${mergeResult.conflicts.length} conflicts detected', tag: 'SyncEngine');
             return Success(
@@ -119,11 +141,9 @@ class SyncEngine {
             );
           }
 
-          // 5. Apply the merged data.
-          await _applyMergedData(mergeResult);
+          await _localDataSource.applyMergedData(mergeResult.merged);
 
-          // 6. Upload the final merged state.
-          final finalData = await _gatherLocalData();
+          final finalData = await _localDataSource.gatherLocalData();
           final uploadResult = await _cloudService.uploadSyncData(finalData);
           switch (uploadResult) {
             case Failure(:final failure):
@@ -159,47 +179,39 @@ class SyncEngine {
           if (remoteData == null) {
             return const Failure(SyncFailure('Remote data disappeared during conflict resolution'));
           }
-
-          final localData = await _gatherLocalData();
-          final lastSyncedAt = await getLastSyncedAt();
-          final mergeResult = _mergeData(localData, remoteData, lastSyncedAt);
-
-          // Apply non-conflicting changes first.
-          await _applyMergedData(mergeResult);
-
-          // Apply conflict resolutions.
-          for (final conflict in resolvedConflicts) {
-            if (conflict.resolution == null) continue;
-
-            if (conflict.resolution == ConflictResolution.keepRemote) {
-              // Apply the remote version.
-              if (conflict.entityType == 'project') {
-                final remoteProject = remoteData.projects.where((p) => p.id == conflict.entityId).firstOrNull;
-                if (remoteProject != null) {
-                  final existing = await _projectRepository.getProjectById(remoteProject.id);
-                  if (existing != null) {
-                    await _projectRepository.updateProject(remoteProject.toProject());
-                  } else {
-                    await _projectRepository.createProject(remoteProject.toProject());
-                  }
-                }
-              } else if (conflict.entityType == 'task') {
-                final remoteTask = remoteData.tasks.where((t) => t.id == conflict.entityId).firstOrNull;
-                if (remoteTask != null) {
-                  final existing = await _taskRepository.getTaskById(remoteTask.id);
-                  if (existing != null) {
-                    await _taskRepository.updateTask(remoteTask.toTask());
-                  } else {
-                    await _taskRepository.createTask(remoteTask.toTask());
-                  }
-                }
-              }
-            }
-            // keepLocal means we do nothing — local is already correct.
+          if (remoteData.schemaVersion > kSyncSchemaVersion) {
+            return Failure(
+              SyncFailure(
+                'Remote sync schema v${remoteData.schemaVersion} is newer than this app '
+                '(v$kSyncSchemaVersion). Upgrade Focus to sync.',
+              ),
+            );
           }
 
-          // Upload the final state.
-          final finalData = await _gatherLocalData();
+          final localData = await _localDataSource.gatherLocalData();
+          final lastSyncedAt = await getLastSyncedAt();
+
+          final SyncMergeResult mergeResult;
+          try {
+            mergeResult = _mergeEngine.merge(localData, remoteData, lastSyncedAt);
+          } on SyncSchemaTooNewException catch (e) {
+            return Failure(SyncFailure(e.toString()));
+          }
+
+          // Start from the non-conflicting merge, then overlay resolutions.
+          var resolved = mergeResult.merged;
+          final remoteByType = _indexRemote(remoteData);
+          final localByType = _indexLocal(localData);
+
+          for (final conflict in resolvedConflicts) {
+            if (conflict.resolution == null) continue;
+            final source = conflict.resolution == ConflictResolution.keepRemote ? remoteByType : localByType;
+            resolved = _applyConflictChoice(resolved, conflict, source);
+          }
+
+          await _localDataSource.applyMergedData(resolved);
+
+          final finalData = await _localDataSource.gatherLocalData();
           final uploadResult = await _cloudService.uploadSyncData(finalData);
           switch (uploadResult) {
             case Failure(:final failure):
@@ -223,153 +235,50 @@ class SyncEngine {
     }
   }
 
-  /// Merge local and remote data, detecting conflicts.
-  _MergeResult _mergeData(SyncData local, SyncData remote, DateTime? lastSyncedAt) {
-    final conflicts = <SyncConflict>[];
-    final projectsToCreate = <SyncProjectData>[];
-    final projectsToUpdate = <SyncProjectData>[];
-    final tasksToCreate = <SyncTaskData>[];
-    final tasksToUpdate = <SyncTaskData>[];
+  Map<String, Map<String, Object>> _indexRemote(SyncData data) => {
+    'project': {for (final e in data.projects) e.uuid: e},
+    'milestone': {for (final e in data.milestones) e.uuid: e},
+    'tag': {for (final e in data.tags) e.uuid: e},
+    'task': {for (final e in data.tasks) e.uuid: e},
+    'taskTag': {for (final e in data.taskTags) e.uuid: e},
+    'completion': {for (final e in data.completions) e.uuid: e},
+    'session': {for (final e in data.sessions) e.uuid: e},
+    'setting': {for (final e in data.settings) e.key: e},
+  };
 
-    final localProjectMap = {for (final p in local.projects) p.id: p};
-    final localTaskMap = {for (final t in local.tasks) t.id: t};
+  Map<String, Map<String, Object>> _indexLocal(SyncData data) => _indexRemote(data);
 
-    // --- Merge Projects ---
+  SyncData _applyConflictChoice(SyncData base, SyncConflict conflict, Map<String, Map<String, Object>> source) {
+    final entity = source[conflict.entityType]?[conflict.entityId];
+    if (entity == null) return base;
 
-    // Remote projects not in local → create locally.
-    for (final remoteProject in remote.projects) {
-      final localProject = localProjectMap[remoteProject.id];
-      if (localProject == null) {
-        projectsToCreate.add(remoteProject);
-        continue;
-      }
-
-      // Both exist — check for conflicts.
-      if (lastSyncedAt != null) {
-        final localChanged = localProject.updatedAt.isAfter(lastSyncedAt);
-        final remoteChanged = remoteProject.updatedAt.isAfter(lastSyncedAt);
-
-        if (localChanged && remoteChanged) {
-          // Both changed since last sync — CONFLICT.
-          conflicts.add(
-            SyncConflict(
-              entityType: 'project',
-              entityId: remoteProject.id,
-              entityTitle: remoteProject.title,
-              localUpdatedAt: localProject.updatedAt,
-              remoteUpdatedAt: remoteProject.updatedAt,
-            ),
-          );
-        } else if (remoteChanged && !localChanged) {
-          // Only remote changed — update local.
-          projectsToUpdate.add(remoteProject);
-        }
-        // Only local changed or neither changed → keep local (nothing to do).
-      } else {
-        // First sync ever — prefer whichever is newer.
-        if (remoteProject.updatedAt.isAfter(localProject.updatedAt)) {
-          projectsToUpdate.add(remoteProject);
-        }
-      }
-    }
-
-    // --- Merge Tasks ---
-
-    // Remote tasks not in local → create locally.
-    for (final remoteTask in remote.tasks) {
-      final localTask = localTaskMap[remoteTask.id];
-      if (localTask == null) {
-        tasksToCreate.add(remoteTask);
-        continue;
-      }
-
-      // Both exist — check for conflicts.
-      if (lastSyncedAt != null) {
-        final localChanged = localTask.updatedAt.isAfter(lastSyncedAt);
-        final remoteChanged = remoteTask.updatedAt.isAfter(lastSyncedAt);
-
-        if (localChanged && remoteChanged) {
-          conflicts.add(
-            SyncConflict(
-              entityType: 'task',
-              entityId: remoteTask.id,
-              entityTitle: remoteTask.title,
-              localUpdatedAt: localTask.updatedAt,
-              remoteUpdatedAt: remoteTask.updatedAt,
-            ),
-          );
-        } else if (remoteChanged && !localChanged) {
-          tasksToUpdate.add(remoteTask);
-        }
-      } else {
-        if (remoteTask.updatedAt.isAfter(localTask.updatedAt)) {
-          tasksToUpdate.add(remoteTask);
-        }
-      }
-    }
-
-    return _MergeResult(
-      conflicts: conflicts,
-      projectsToCreate: projectsToCreate,
-      projectsToUpdate: projectsToUpdate,
-      tasksToCreate: tasksToCreate,
-      tasksToUpdate: tasksToUpdate,
-    );
+    return switch (conflict.entityType) {
+      'project' => base.copyWith(projects: _replaceByUuid(base.projects, entity as SyncProjectData, (e) => e.uuid)),
+      'milestone' => base.copyWith(
+        milestones: _replaceByUuid(base.milestones, entity as SyncMilestoneData, (e) => e.uuid),
+      ),
+      'tag' => base.copyWith(tags: _replaceByUuid(base.tags, entity as SyncTagData, (e) => e.uuid)),
+      'task' => base.copyWith(tasks: _replaceByUuid(base.tasks, entity as SyncTaskData, (e) => e.uuid)),
+      'taskTag' => base.copyWith(taskTags: _replaceByUuid(base.taskTags, entity as SyncTaskTagData, (e) => e.uuid)),
+      'completion' => base.copyWith(
+        completions: _replaceByUuid(base.completions, entity as SyncTaskCompletionData, (e) => e.uuid),
+      ),
+      'session' => base.copyWith(
+        sessions: _replaceByUuid(base.sessions, entity as SyncFocusSessionData, (e) => e.uuid),
+      ),
+      'setting' => base.copyWith(settings: _replaceByKey(base.settings, entity as SyncSettingData)),
+      _ => base,
+    };
   }
 
-  /// Apply the non-conflicting merge results to the local database.
-  Future<void> _applyMergedData(_MergeResult mergeResult) async {
-    // Create new projects first (tasks depend on them).
-    for (final project in mergeResult.projectsToCreate) {
-      try {
-        await _projectRepository.createProject(project.toProject());
-      } catch (e, st) {
-        _log.warning('Failed to create synced project ${project.id}', tag: 'SyncEngine', error: e, stackTrace: st);
-      }
-    }
-
-    // Update existing projects.
-    for (final project in mergeResult.projectsToUpdate) {
-      try {
-        await _projectRepository.updateProject(project.toProject());
-      } catch (e, st) {
-        _log.warning('Failed to update synced project ${project.id}', tag: 'SyncEngine', error: e, stackTrace: st);
-      }
-    }
-
-    // Create new tasks.
-    for (final task in mergeResult.tasksToCreate) {
-      try {
-        await _taskRepository.createTask(task.toTask());
-      } catch (e, st) {
-        _log.warning('Failed to create synced task ${task.id}', tag: 'SyncEngine', error: e, stackTrace: st);
-      }
-    }
-
-    // Update existing tasks.
-    for (final task in mergeResult.tasksToUpdate) {
-      try {
-        await _taskRepository.updateTask(task.toTask());
-      } catch (e, st) {
-        _log.warning('Failed to update synced task ${task.id}', tag: 'SyncEngine', error: e, stackTrace: st);
-      }
-    }
+  List<T> _replaceByUuid<T>(List<T> list, T replacement, String Function(T) uuidOf) {
+    final uuid = uuidOf(replacement);
+    final without = list.where((e) => uuidOf(e) != uuid).toList();
+    return [...without, replacement];
   }
-}
 
-/// Internal result of the merge operation.
-class _MergeResult {
-  final List<SyncConflict> conflicts;
-  final List<SyncProjectData> projectsToCreate;
-  final List<SyncProjectData> projectsToUpdate;
-  final List<SyncTaskData> tasksToCreate;
-  final List<SyncTaskData> tasksToUpdate;
-
-  const _MergeResult({
-    required this.conflicts,
-    required this.projectsToCreate,
-    required this.projectsToUpdate,
-    required this.tasksToCreate,
-    required this.tasksToUpdate,
-  });
+  List<SyncSettingData> _replaceByKey(List<SyncSettingData> list, SyncSettingData replacement) {
+    final without = list.where((e) => e.key != replacement.key).toList();
+    return [...without, replacement];
+  }
 }

--- a/lib/features/sync/domain/services/sync_merge_engine.dart
+++ b/lib/features/sync/domain/services/sync_merge_engine.dart
@@ -1,0 +1,311 @@
+import '../entities/sync_data.dart';
+import '../entities/sync_state.dart';
+
+/// Pure last-write / conflict merge for [SyncData] envelopes.
+///
+/// Keys every entity by `uuid` (settings by `key`). Iterates the **union** of
+/// local and remote identities so local-only rows (including tombstones) are
+/// preserved for upload. Tombstones beat live rows when the tombstone's
+/// `updatedAt` is newer.
+class SyncMergeEngine {
+  const SyncMergeEngine();
+
+  /// Merge [local] and [remote] relative to [lastSyncedAt].
+  ///
+  /// Throws [SyncSchemaTooNewException] when [remote.schemaVersion] exceeds
+  /// [kSyncSchemaVersion].
+  SyncMergeResult merge(SyncData local, SyncData remote, DateTime? lastSyncedAt) {
+    if (remote.schemaVersion > kSyncSchemaVersion) {
+      throw SyncSchemaTooNewException(remote.schemaVersion, kSyncSchemaVersion);
+    }
+
+    final conflicts = <SyncConflict>[];
+
+    final projects = _mergeEntities<SyncProjectData>(
+      local: local.projects,
+      remote: remote.projects,
+      lastSyncedAt: lastSyncedAt,
+      uuidOf: (e) => e.uuid,
+      updatedAtOf: (e) => e.updatedAt,
+      deletedAtOf: (e) => e.deletedAt,
+      titleOf: (e) => e.title,
+      entityType: 'project',
+      conflicts: conflicts,
+    );
+
+    final milestones = _mergeEntities<SyncMilestoneData>(
+      local: local.milestones,
+      remote: remote.milestones,
+      lastSyncedAt: lastSyncedAt,
+      uuidOf: (e) => e.uuid,
+      updatedAtOf: (e) => e.updatedAt,
+      deletedAtOf: (e) => e.deletedAt,
+      titleOf: (e) => e.title,
+      entityType: 'milestone',
+      conflicts: conflicts,
+    );
+
+    final tags = _mergeEntities<SyncTagData>(
+      local: local.tags,
+      remote: remote.tags,
+      lastSyncedAt: lastSyncedAt,
+      uuidOf: (e) => e.uuid,
+      updatedAtOf: (e) => e.updatedAt,
+      deletedAtOf: (e) => e.deletedAt,
+      titleOf: (e) => e.name,
+      entityType: 'tag',
+      conflicts: conflicts,
+    );
+
+    final tasks = _mergeEntities<SyncTaskData>(
+      local: local.tasks,
+      remote: remote.tasks,
+      lastSyncedAt: lastSyncedAt,
+      uuidOf: (e) => e.uuid,
+      updatedAtOf: (e) => e.updatedAt,
+      deletedAtOf: (e) => e.deletedAt,
+      titleOf: (e) => e.title,
+      entityType: 'task',
+      conflicts: conflicts,
+    );
+
+    // Parents before children by depth for stable apply ordering.
+    tasks.sort((a, b) => a.depth.compareTo(b.depth));
+
+    final taskTags = _mergeEntities<SyncTaskTagData>(
+      local: local.taskTags,
+      remote: remote.taskTags,
+      lastSyncedAt: lastSyncedAt,
+      uuidOf: (e) => e.uuid,
+      updatedAtOf: (e) => e.updatedAt,
+      deletedAtOf: (e) => e.deletedAt,
+      titleOf: (e) => '${e.taskUuid}:${e.tagUuid}',
+      entityType: 'taskTag',
+      conflicts: conflicts,
+    );
+
+    final completions = _mergeEntities<SyncTaskCompletionData>(
+      local: local.completions,
+      remote: remote.completions,
+      lastSyncedAt: lastSyncedAt,
+      uuidOf: (e) => e.uuid,
+      updatedAtOf: (e) => e.updatedAt,
+      deletedAtOf: (e) => e.deletedAt,
+      titleOf: (e) => e.occurrenceDate.toIso8601String(),
+      entityType: 'completion',
+      conflicts: conflicts,
+    );
+
+    final sessions = _mergeEntities<SyncFocusSessionData>(
+      local: local.sessions,
+      remote: remote.sessions,
+      lastSyncedAt: lastSyncedAt,
+      uuidOf: (e) => e.uuid,
+      updatedAtOf: (e) => e.updatedAt,
+      deletedAtOf: (e) => e.deletedAt,
+      titleOf: (e) => e.startTime.toIso8601String(),
+      entityType: 'session',
+      conflicts: conflicts,
+    );
+
+    final settings = _mergeSettings(local.settings, remote.settings, lastSyncedAt, conflicts);
+
+    return SyncMergeResult(
+      conflicts: conflicts,
+      merged: SyncData(
+        schemaVersion: kSyncSchemaVersion,
+        syncTimestamp: DateTime.now(),
+        projects: projects,
+        milestones: milestones,
+        tags: tags,
+        tasks: tasks,
+        taskTags: taskTags,
+        completions: completions,
+        sessions: sessions,
+        settings: settings,
+      ),
+    );
+  }
+
+  List<T> _mergeEntities<T>({
+    required List<T> local,
+    required List<T> remote,
+    required DateTime? lastSyncedAt,
+    required String Function(T) uuidOf,
+    required DateTime Function(T) updatedAtOf,
+    required DateTime? Function(T) deletedAtOf,
+    required String Function(T) titleOf,
+    required String entityType,
+    required List<SyncConflict> conflicts,
+  }) {
+    final localMap = {for (final e in local) uuidOf(e): e};
+    final remoteMap = {for (final e in remote) uuidOf(e): e};
+    final allUuids = {...localMap.keys, ...remoteMap.keys};
+    final result = <T>[];
+
+    for (final uuid in allUuids) {
+      final localRow = localMap[uuid];
+      final remoteRow = remoteMap[uuid];
+
+      if (localRow == null && remoteRow != null) {
+        result.add(remoteRow);
+        continue;
+      }
+      if (remoteRow == null && localRow != null) {
+        result.add(localRow);
+        continue;
+      }
+      if (localRow == null || remoteRow == null) continue;
+
+      final winner = _pickWinner(
+        local: localRow,
+        remote: remoteRow,
+        lastSyncedAt: lastSyncedAt,
+        updatedAtOf: updatedAtOf,
+        deletedAtOf: deletedAtOf,
+        onConflict: () {
+          conflicts.add(
+            SyncConflict(
+              entityType: entityType,
+              entityId: uuid,
+              entityTitle: titleOf(localRow),
+              localUpdatedAt: updatedAtOf(localRow),
+              remoteUpdatedAt: updatedAtOf(remoteRow),
+            ),
+          );
+        },
+      );
+      if (winner != null) result.add(winner);
+    }
+
+    return result;
+  }
+
+  List<SyncSettingData> _mergeSettings(
+    List<SyncSettingData> local,
+    List<SyncSettingData> remote,
+    DateTime? lastSyncedAt,
+    List<SyncConflict> conflicts,
+  ) {
+    final localMap = {for (final s in local) s.key: s};
+    final remoteMap = {for (final s in remote) s.key: s};
+    final allKeys = {...localMap.keys, ...remoteMap.keys};
+    final result = <SyncSettingData>[];
+
+    for (final key in allKeys) {
+      if (!kSyncableSettingsKeys.contains(key)) continue;
+      final localRow = localMap[key];
+      final remoteRow = remoteMap[key];
+
+      if (localRow == null && remoteRow != null) {
+        result.add(remoteRow);
+        continue;
+      }
+      if (remoteRow == null && localRow != null) {
+        result.add(localRow);
+        continue;
+      }
+      if (localRow == null || remoteRow == null) continue;
+
+      if (localRow.value == remoteRow.value) {
+        result.add(localRow.updatedAt.isAfter(remoteRow.updatedAt) ? localRow : remoteRow);
+        continue;
+      }
+
+      final winner = _pickWinner(
+        local: localRow,
+        remote: remoteRow,
+        lastSyncedAt: lastSyncedAt,
+        updatedAtOf: (s) => s.updatedAt,
+        deletedAtOf: (_) => null,
+        onConflict: () {
+          conflicts.add(
+            SyncConflict(
+              entityType: 'setting',
+              entityId: key,
+              entityTitle: key,
+              localUpdatedAt: localRow.updatedAt,
+              remoteUpdatedAt: remoteRow.updatedAt,
+            ),
+          );
+        },
+      );
+      if (winner != null) result.add(winner);
+    }
+
+    return result;
+  }
+
+  /// Returns the row to keep, or `null` when a conflict is recorded and the
+  /// caller should leave the local DB untouched for that entity until the
+  /// user resolves it.
+  T? _pickWinner<T>({
+    required T local,
+    required T remote,
+    required DateTime? lastSyncedAt,
+    required DateTime Function(T) updatedAtOf,
+    required DateTime? Function(T) deletedAtOf,
+    required void Function() onConflict,
+  }) {
+    final localDeleted = deletedAtOf(local);
+    final remoteDeleted = deletedAtOf(remote);
+    final localUpdated = updatedAtOf(local);
+    final remoteUpdated = updatedAtOf(remote);
+
+    // Tombstone beats live when the tombstone clock is newer.
+    if (localDeleted != null && remoteDeleted == null) {
+      if (!localUpdated.isBefore(remoteUpdated)) return local;
+      // Remote live edit is newer than local tombstone — conflict or take remote.
+    }
+    if (remoteDeleted != null && localDeleted == null) {
+      if (!remoteUpdated.isBefore(localUpdated)) return remote;
+    }
+
+    if (lastSyncedAt != null) {
+      final localChanged = localUpdated.isAfter(lastSyncedAt);
+      final remoteChanged = remoteUpdated.isAfter(lastSyncedAt);
+
+      if (localChanged && remoteChanged) {
+        // Identical clocks / values are not conflicts — prefer newer.
+        if (localUpdated == remoteUpdated) {
+          return localDeleted != null
+              ? local
+              : remoteDeleted != null
+              ? remote
+              : local;
+        }
+        onConflict();
+        return null;
+      }
+      if (remoteChanged && !localChanged) return remote;
+      return local;
+    }
+
+    // First sync: newest wins; tombstone preferred on tie when present.
+    if (remoteUpdated.isAfter(localUpdated)) return remote;
+    if (localUpdated.isAfter(remoteUpdated)) return local;
+    if (remoteDeleted != null) return remote;
+    if (localDeleted != null) return local;
+    return local;
+  }
+}
+
+/// Raised when a remote payload was written by a newer app build.
+class SyncSchemaTooNewException implements Exception {
+  final int remoteVersion;
+  final int localVersion;
+
+  const SyncSchemaTooNewException(this.remoteVersion, this.localVersion);
+
+  @override
+  String toString() =>
+      'Remote sync schema v$remoteVersion is newer than this app (v$localVersion). Upgrade Focus to sync.';
+}
+
+/// Result of a pure merge pass.
+class SyncMergeResult {
+  final List<SyncConflict> conflicts;
+  final SyncData merged;
+
+  const SyncMergeResult({required this.conflicts, required this.merged});
+}

--- a/lib/features/sync/domain/services/sync_purge_service.dart
+++ b/lib/features/sync/domain/services/sync_purge_service.dart
@@ -31,6 +31,11 @@ class SyncPurgeService {
           _db.taskCompletionTable,
         )..where((t) => t.deletedAt.isNotNull() & t.deletedAt.isSmallerThanValue(cutoff))).go();
 
+        // Purge expired task↔tag link tombstones independently.
+        var taskTags = await (_db.delete(
+          _db.taskTagTable,
+        )..where((t) => t.deletedAt.isNotNull() & t.deletedAt.isSmallerThanValue(cutoff))).go();
+
         // Remove junction rows for tasks about to be purged.
         final expiredTaskIds =
             await (_db.selectOnly(_db.taskTable)
@@ -38,11 +43,10 @@ class SyncPurgeService {
                   ..where(_db.taskTable.deletedAt.isNotNull() & _db.taskTable.deletedAt.isSmallerThanValue(cutoff)))
                 .map((row) => row.read(_db.taskTable.id)!)
                 .get();
-        var taskTags = 0;
         if (expiredTaskIds.isNotEmpty) {
           // Also hard-delete any remaining completions for purged tasks.
           await (_db.delete(_db.taskCompletionTable)..where((t) => t.taskId.isIn(expiredTaskIds))).go();
-          taskTags = await (_db.delete(_db.taskTagTable)..where((t) => t.taskId.isIn(expiredTaskIds))).go();
+          taskTags += await (_db.delete(_db.taskTagTable)..where((t) => t.taskId.isIn(expiredTaskIds))).go();
         }
 
         final expiredTagIds =

--- a/lib/features/sync/presentation/providers/sync_provider.dart
+++ b/lib/features/sync/presentation/providers/sync_provider.dart
@@ -1,14 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../../../core/di/injection.dart';
 import '../../../../core/utils/result.dart';
 import '../../domain/entities/sync_state.dart';
 import '../../domain/services/i_cloud_storage_service.dart';
+import '../../domain/services/sync_auto_sync_service.dart';
 import '../../domain/services/sync_engine.dart';
 
 part 'sync_provider.g.dart';
 part 'cloud_storage_service_provider.part.dart';
 part 'sync_engine_provider.part.dart';
+
+/// Watches the persisted auto-sync toggle.
+final syncEnabledProvider = FutureProvider.autoDispose<bool>((ref) async {
+  return getIt<SyncEngine>().isSyncEnabled();
+});
 
 // ---------------------------------------------------------------------------
 // Sync state notifier
@@ -24,7 +31,13 @@ class SyncNotifier extends _$SyncNotifier {
     _syncEngine = ref.watch(syncEngineProvider);
     _cloudService = ref.watch(cloudStorageServiceProvider);
 
-    // Check initial sign-in state asynchronously.
+    // Bridge auto-sync results into this notifier when available.
+    final autoSync = getIt<SyncAutoSyncService>();
+    autoSync.onStateChanged = (next) {
+      if (!ref.mounted) return;
+      state = next;
+    };
+
     _initializeState();
 
     return const SyncState();
@@ -37,6 +50,11 @@ class SyncNotifier extends _$SyncNotifier {
       final lastSyncedAt = await _syncEngine.getLastSyncedAt();
       state = state.copyWith(status: SyncStatus.idle, accountEmail: email, lastSyncedAt: lastSyncedAt);
     }
+  }
+
+  Future<void> setSyncEnabled(bool enabled) async {
+    await _syncEngine.setSyncEnabled(enabled);
+    ref.invalidate(syncEnabledProvider);
   }
 
   /// Sign in to Google Drive and update state.
@@ -62,13 +80,13 @@ class SyncNotifier extends _$SyncNotifier {
     }
   }
 
-  /// Trigger a sync operation.
+  /// Trigger a manual sync (ignores auto-sync disabled).
   Future<void> sync() async {
     if (state.status == SyncStatus.syncing) return;
 
     state = state.copyWith(status: SyncStatus.syncing);
 
-    final result = await _syncEngine.performSync();
+    final result = await _syncEngine.performSync(force: true);
     switch (result) {
       case Success(:final value):
         state = value;

--- a/lib/features/sync/presentation/providers/sync_provider.g.dart
+++ b/lib/features/sync/presentation/providers/sync_provider.g.dart
@@ -37,7 +37,7 @@ final class SyncNotifierProvider extends $NotifierProvider<SyncNotifier, SyncSta
   }
 }
 
-String _$syncNotifierHash() => r'a83fdfd781fcf4a0a27c04c08381f8ca1faa8ddc';
+String _$syncNotifierHash() => r'5b891b6782d8cc866abe016ec162c9fa01c35f94';
 
 abstract class _$SyncNotifier extends $Notifier<SyncState> {
   SyncState build();

--- a/lib/features/sync/presentation/screens/sync_conflict_screen.dart
+++ b/lib/features/sync/presentation/screens/sync_conflict_screen.dart
@@ -113,7 +113,7 @@ class _ConflictCard extends StatelessWidget {
           Row(
             children: [
               Icon(
-                conflict.entityType == 'project' ? fu.FLucideIcons.folderOpen : fu.FLucideIcons.squareCheck,
+                _entityTypeIcon(conflict.entityType),
                 size: AppConstants.size.icon.regular,
                 color: context.colors.primary,
               ),
@@ -130,7 +130,7 @@ class _ConflictCard extends StatelessWidget {
                     ),
                     SizedBox(height: AppConstants.spacing.extraSmall),
                     Text(
-                      conflict.entityType == 'project' ? 'Project' : 'Task',
+                      _entityTypeLabel(conflict.entityType),
                       style: context.typography.xs.copyWith(color: context.colors.mutedForeground),
                     ),
                   ],
@@ -184,5 +184,31 @@ class _ConflictCard extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  IconData _entityTypeIcon(String type) {
+    return switch (type) {
+      'project' => fu.FLucideIcons.folderOpen,
+      'milestone' => fu.FLucideIcons.flag,
+      'tag' => fu.FLucideIcons.tag,
+      'taskTag' => fu.FLucideIcons.tags,
+      'completion' => fu.FLucideIcons.circleCheck,
+      'session' => fu.FLucideIcons.timer,
+      'setting' => fu.FLucideIcons.settings,
+      _ => fu.FLucideIcons.squareCheck,
+    };
+  }
+
+  String _entityTypeLabel(String type) {
+    return switch (type) {
+      'project' => 'Project',
+      'milestone' => 'Milestone',
+      'tag' => 'Tag',
+      'taskTag' => 'Task tag',
+      'completion' => 'Completion',
+      'session' => 'Focus session',
+      'setting' => 'Setting',
+      _ => 'Task',
+    };
   }
 }

--- a/lib/features/sync/presentation/widgets/sync_settings_card.dart
+++ b/lib/features/sync/presentation/widgets/sync_settings_card.dart
@@ -5,9 +5,12 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/config/theme/app_theme.dart';
 import '../../../../core/constants/app_constants.dart';
+import '../../../../core/di/injection.dart';
 import '../../../../core/routing/routes.dart';
 import '../../../../core/utils/datetime_formatter.dart';
+import '../../../../core/utils/result.dart';
 import '../../domain/entities/sync_state.dart';
+import '../../domain/services/sync_backup_service.dart';
 import '../providers/sync_provider.dart';
 
 /// Card widget shown in Settings that displays sync status and controls.
@@ -17,6 +20,7 @@ class SyncSettingsCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final syncState = ref.watch(syncProvider);
+    final syncEnabledAsync = ref.watch(syncEnabledProvider);
 
     return fu.FCard(
       child: Column(
@@ -61,6 +65,18 @@ class SyncSettingsCard extends ConsumerWidget {
               overflow: TextOverflow.ellipsis,
             ),
           ],
+          if (syncState.isConnected) ...[
+            SizedBox(height: AppConstants.spacing.regular),
+            Row(
+              children: [
+                Expanded(child: Text('Auto sync', style: context.typography.sm)),
+                fu.FSwitch(
+                  value: syncEnabledAsync.value ?? true,
+                  onChange: (enabled) => ref.read(syncProvider.notifier).setSyncEnabled(enabled),
+                ),
+              ],
+            ),
+          ],
           SizedBox(height: AppConstants.spacing.regular),
           if (!syncState.isConnected)
             SizedBox(
@@ -79,7 +95,6 @@ class SyncSettingsCard extends ConsumerWidget {
                         ? null
                         : () async {
                             await ref.read(syncProvider.notifier).sync();
-                            // If conflicts were detected, navigate to conflict screen.
                             final updatedState = ref.read(syncProvider);
                             if (updatedState.status == SyncStatus.conflictsDetected && context.mounted) {
                               context.push(AppRoutes.syncConflicts.path, extra: updatedState.conflicts);
@@ -98,9 +113,78 @@ class SyncSettingsCard extends ConsumerWidget {
                 ),
               ],
             ),
+          SizedBox(height: AppConstants.spacing.regular),
+          Text('Local backup', style: context.typography.sm.copyWith(fontWeight: FontWeight.w600)),
+          SizedBox(height: AppConstants.spacing.small),
+          Text(
+            'Export or replace all projects, tasks, sessions, and syncable settings as JSON.',
+            style: context.typography.xs.copyWith(color: context.colors.mutedForeground),
+          ),
+          SizedBox(height: AppConstants.spacing.regular),
+          Row(
+            children: [
+              Expanded(
+                child: fu.FButton(
+                  variant: .outline,
+                  onPress: () => _exportBackup(context),
+                  child: const Text('Export backup'),
+                ),
+              ),
+              SizedBox(width: AppConstants.spacing.regular),
+              Expanded(
+                child: fu.FButton(
+                  variant: .outline,
+                  onPress: () => _importBackup(context, ref),
+                  child: const Text('Restore backup'),
+                ),
+              ),
+            ],
+          ),
         ],
       ),
     );
+  }
+
+  Future<void> _exportBackup(BuildContext context) async {
+    final result = await getIt<SyncBackupService>().exportToFile();
+    if (!context.mounted) return;
+    switch (result) {
+      case Success(:final value):
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Backup saved: $value')));
+      case Failure(:final failure):
+        if (failure.message == 'Export cancelled') return;
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(failure.message)));
+    }
+  }
+
+  Future<void> _importBackup(BuildContext context, WidgetRef ref) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Replace local data?'),
+        content: const Text(
+          'Restoring a backup replaces projects, tasks, milestones, tags, '
+          'sessions, completions, and syncable settings on this device. '
+          'This cannot be undone.',
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.of(ctx).pop(true), child: const Text('Replace')),
+        ],
+      ),
+    );
+    if (confirmed != true || !context.mounted) return;
+
+    final result = await getIt<SyncBackupService>().importFromFile();
+    if (!context.mounted) return;
+    switch (result) {
+      case Success():
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Backup restored')));
+        ref.invalidate(syncProvider);
+      case Failure(:final failure):
+        if (failure.message == 'Import cancelled') return;
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(failure.message)));
+    }
   }
 
   String _statusText(SyncState state) {

--- a/lib/features/tags/data/datasources/tag_local_datasource.dart
+++ b/lib/features/tags/data/datasources/tag_local_datasource.dart
@@ -2,6 +2,7 @@ import 'package:drift/drift.dart';
 
 import '../../../../core/services/db_service.dart';
 import '../../../../core/services/log_service.dart';
+import '../../../../core/utils/id_utils.dart';
 
 abstract interface class ITagLocalDataSource {
   Future<List<TagTableData>> getAllTags();
@@ -44,7 +45,11 @@ class TagLocalDataSourceImpl implements ITagLocalDataSource {
   Future<List<TagTableData>> getTagsForTask(int taskId) async {
     final query =
         _db.select(_db.tagTable).join([innerJoin(_db.taskTagTable, _db.taskTagTable.tagId.equalsExp(_db.tagTable.id))])
-          ..where(_db.taskTagTable.taskId.equals(taskId) & _db.tagTable.deletedAt.isNull())
+          ..where(
+            _db.taskTagTable.taskId.equals(taskId) &
+                _db.taskTagTable.deletedAt.isNull() &
+                _db.tagTable.deletedAt.isNull(),
+          )
           ..orderBy([OrderingTerm.asc(_db.tagTable.name)]);
     return query.map((row) => row.readTable(_db.tagTable)).get();
   }
@@ -74,7 +79,9 @@ class TagLocalDataSourceImpl implements ITagLocalDataSource {
     try {
       await _db.transaction(() async {
         final now = DateTime.now();
-        await (_db.delete(_db.taskTagTable)..where((t) => t.tagId.equals(id))).go();
+        await (_db.update(_db.taskTagTable)..where((t) => t.tagId.equals(id) & t.deletedAt.isNull())).write(
+          TaskTagTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
+        );
         await (_db.update(_db.tagTable)..where((t) => t.id.equals(id) & t.deletedAt.isNull())).write(
           TagTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
         );
@@ -89,9 +96,39 @@ class TagLocalDataSourceImpl implements ITagLocalDataSource {
   Future<void> setTaskTags(int taskId, List<int> tagIds) async {
     try {
       await _db.transaction(() async {
-        await (_db.delete(_db.taskTagTable)..where((t) => t.taskId.equals(taskId))).go();
-        for (final tagId in tagIds) {
-          await _db.into(_db.taskTagTable).insert(TaskTagTableCompanion.insert(taskId: taskId, tagId: tagId));
+        final now = DateTime.now();
+        final desired = tagIds.toSet();
+
+        final existing = await (_db.select(_db.taskTagTable)..where((t) => t.taskId.equals(taskId))).get();
+        final existingByTag = {for (final row in existing) row.tagId: row};
+
+        // Tombstone links that are no longer desired.
+        for (final row in existing) {
+          if (!desired.contains(row.tagId) && row.deletedAt == null) {
+            await (_db.update(_db.taskTagTable)..where((t) => t.taskId.equals(taskId) & t.tagId.equals(row.tagId)))
+                .write(TaskTagTableCompanion(deletedAt: Value(now), updatedAt: Value(now)));
+          }
+        }
+
+        for (final tagId in desired) {
+          final current = existingByTag[tagId];
+          if (current == null) {
+            await _db
+                .into(_db.taskTagTable)
+                .insert(
+                  TaskTagTableCompanion.insert(
+                    taskId: taskId,
+                    tagId: tagId,
+                    uuid: generateUuid(),
+                    createdAt: now,
+                    updatedAt: now,
+                  ),
+                );
+          } else if (current.deletedAt != null) {
+            await (_db.update(_db.taskTagTable)..where((t) => t.taskId.equals(taskId) & t.tagId.equals(tagId))).write(
+              TaskTagTableCompanion(deletedAt: const Value(null), updatedAt: Value(now)),
+            );
+          }
         }
       });
     } catch (e, st) {

--- a/lib/features/tags/data/models/task_tag_model.dart
+++ b/lib/features/tags/data/models/task_tag_model.dart
@@ -4,10 +4,24 @@ import '../../../tasks/data/models/task_model.dart';
 import 'tag_model.dart';
 
 /// Many-to-many association between tasks and tags.
+///
+/// Soft-deleted via [deletedAt] so tombstones can sync across devices.
+/// Primary key remains `(taskId, tagId)`; re-linking revives the same row.
+@DataClassName('TaskTagData')
+@TableIndex(name: 'task_tag_uuid_idx', columns: {#uuid}, unique: true)
+@TableIndex(name: 'task_tag_deleted_at_idx', columns: {#deletedAt})
 class TaskTagTable extends Table {
   IntColumn get taskId => integer().references(TaskTable, #id, onDelete: KeyAction.cascade)();
 
   IntColumn get tagId => integer().references(TagTable, #id, onDelete: KeyAction.cascade)();
+
+  TextColumn get uuid => text().unique()();
+
+  DateTimeColumn get createdAt => dateTime()();
+
+  DateTimeColumn get updatedAt => dateTime()();
+
+  DateTimeColumn get deletedAt => dateTime().nullable()();
 
   @override
   Set<Column<Object>> get primaryKey => {taskId, tagId};

--- a/lib/features/tags/data/repositories/tag_repository_impl.dart
+++ b/lib/features/tags/data/repositories/tag_repository_impl.dart
@@ -1,3 +1,4 @@
+import '../../../../core/services/data_change_bus.dart';
 import '../../../../core/services/log_service.dart';
 import '../../domain/entities/tag.dart';
 import '../../domain/entities/tag_extensions.dart';
@@ -8,9 +9,12 @@ import '../mappers/tag_extensions.dart';
 final _log = LogService.instance;
 
 class TagRepositoryImpl implements ITagRepository {
-  TagRepositoryImpl(this._local);
+  TagRepositoryImpl(this._local, [this._dataChangeBus]);
 
   final ITagLocalDataSource _local;
+  final DataChangeBus? _dataChangeBus;
+
+  void _emitChange() => _dataChangeBus?.notify();
 
   @override
   Future<List<Tag>> getAllTags() async {
@@ -35,6 +39,7 @@ class TagRepositoryImpl implements ITagRepository {
     try {
       final id = await _local.createTag(tag.toCompanion());
       _log.debug('Tag created (id=$id)', tag: 'TagRepository');
+      _emitChange();
       return tag.copyWith(id: id);
     } catch (e, st) {
       _log.error('Failed to create tag', tag: 'TagRepository', error: e, stackTrace: st);
@@ -46,6 +51,7 @@ class TagRepositoryImpl implements ITagRepository {
   Future<void> updateTag(Tag tag) async {
     try {
       await _local.updateTag(tag.toCompanion());
+      _emitChange();
     } catch (e, st) {
       _log.error('Failed to update tag (id=${tag.id})', tag: 'TagRepository', error: e, stackTrace: st);
       rethrow;
@@ -56,6 +62,7 @@ class TagRepositoryImpl implements ITagRepository {
   Future<void> deleteTag(int id) async {
     try {
       await _local.deleteTag(id);
+      _emitChange();
     } catch (e, st) {
       _log.error('Failed to delete tag (id=$id)', tag: 'TagRepository', error: e, stackTrace: st);
       rethrow;
@@ -66,6 +73,7 @@ class TagRepositoryImpl implements ITagRepository {
   Future<void> setTaskTags(int taskId, List<int> tagIds) async {
     try {
       await _local.setTaskTags(taskId, tagIds);
+      _emitChange();
     } catch (e, st) {
       _log.error('Failed to set tags for task $taskId', tag: 'TagRepository', error: e, stackTrace: st);
       rethrow;

--- a/lib/features/tasks/data/datasources/task_local_datasource.dart
+++ b/lib/features/tasks/data/datasources/task_local_datasource.dart
@@ -142,7 +142,9 @@ class TaskLocalDataSourceImpl implements ITaskLocalDataSource {
         await (_db.update(_db.taskCompletionTable)..where((t) => t.taskId.isIn(idsToDelete) & t.deletedAt.isNull()))
             .write(TaskCompletionTableCompanion(deletedAt: Value(now), updatedAt: Value(now)));
 
-        await (_db.delete(_db.taskTagTable)..where((t) => t.taskId.isIn(idsToDelete))).go();
+        await (_db.update(_db.taskTagTable)..where((t) => t.taskId.isIn(idsToDelete) & t.deletedAt.isNull())).write(
+          TaskTagTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),
+        );
 
         await (_db.update(_db.taskTable)..where((t) => t.id.isIn(idsToDelete) & t.deletedAt.isNull())).write(
           TaskTableCompanion(deletedAt: Value(now), updatedAt: Value(now)),

--- a/lib/features/tasks/data/datasources/task_stats_local_datasource.dart
+++ b/lib/features/tasks/data/datasources/task_stats_local_datasource.dart
@@ -367,7 +367,7 @@ class TaskStatsLocalDataSourceImpl implements ITaskStatsLocalDataSource {
           'COALESCE(SUM(MIN(s.elapsed_seconds, s.focus_duration_minutes * 60)), 0) AS focus_seconds, '
           'tag.color AS color '
           'FROM tag_table tag '
-          'INNER JOIN task_tag_table tt ON tt.tag_id = tag.id '
+          'INNER JOIN task_tag_table tt ON tt.tag_id = tag.id AND tt.deleted_at IS NULL '
           'INNER JOIN focus_session_table s ON s.task_id = tt.task_id AND s.deleted_at IS NULL '
           "AND date(s.start_time, 'unixepoch', 'localtime') >= ? "
           "AND date(s.start_time, 'unixepoch', 'localtime') <= ? "

--- a/lib/features/tasks/data/repositories/task_repository_impl.dart
+++ b/lib/features/tasks/data/repositories/task_repository_impl.dart
@@ -9,14 +9,18 @@ import '../../domain/repositories/i_task_repository.dart';
 import '../datasources/task_local_datasource.dart';
 import '../mappers/task_completion_extensions.dart';
 import '../mappers/task_extensions.dart';
+import '../../../../core/services/data_change_bus.dart';
 import '../../../../core/services/log_service.dart';
 
 final _log = LogService.instance;
 
 class TaskRepositoryImpl implements ITaskRepository {
   final ITaskLocalDataSource _local;
+  final DataChangeBus? _dataChangeBus;
 
-  TaskRepositoryImpl(this._local);
+  TaskRepositoryImpl(this._local, [this._dataChangeBus]);
+
+  void _emitChange() => _dataChangeBus?.notify();
 
   @override
   Future<List<Task>> getTasksByProjectId(int projectId) async {
@@ -48,6 +52,7 @@ class TaskRepositoryImpl implements ITaskRepository {
       final companion = task.toCompanion();
       final id = await _local.createTask(companion);
       _log.debug('Task created (id=$id)', tag: 'TaskRepository');
+      _emitChange();
       return task.copyWith(id: id);
     } catch (e, st) {
       _log.error('Failed to create task', tag: 'TaskRepository', error: e, stackTrace: st);
@@ -60,6 +65,7 @@ class TaskRepositoryImpl implements ITaskRepository {
     try {
       final companion = task.toCompanion();
       await _local.updateTask(companion);
+      _emitChange();
     } catch (e, st) {
       _log.error('Failed to update task (id=${task.id})', tag: 'TaskRepository', error: e, stackTrace: st);
       rethrow;
@@ -70,6 +76,7 @@ class TaskRepositoryImpl implements ITaskRepository {
   Future<void> deleteTask(int id) async {
     try {
       await _local.deleteTask(id);
+      _emitChange();
     } catch (e, st) {
       _log.error('Failed to delete task (id=$id)', tag: 'TaskRepository', error: e, stackTrace: st);
       rethrow;
@@ -143,12 +150,14 @@ class TaskRepositoryImpl implements ITaskRepository {
   @override
   Future<TaskCompletion> upsertCompletion(TaskCompletion completion) async {
     final row = await _local.upsertCompletion(completion.toCompanion());
+    _emitChange();
     return row.toDomain();
   }
 
   @override
   Future<void> softDeleteCompletion(int id) async {
     await _local.softDeleteCompletion(id);
+    _emitChange();
   }
 
   @override

--- a/lib/features/tasks/presentation/providers/task_provider.g.dart
+++ b/lib/features/tasks/presentation/providers/task_provider.g.dart
@@ -135,7 +135,7 @@ final class TaskNotifierProvider extends $NotifierProvider<TaskNotifier, AsyncVa
   }
 }
 
-String _$taskNotifierHash() => r'2ae3787b3fa223fe0de554a7f355b1b4ffbb231b';
+String _$taskNotifierHash() => r'21e7549a43ba8c1c71a79a787464fd700ce54a0b';
 
 final class TaskNotifierFamily extends $Family
     with

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'core/services/desktop_lifecycle_service.dart';
 import 'core/utils/platform_utils.dart';
 import 'features/notifications/domain/services/notification_inbox_sync_service.dart';
 import 'features/settings/domain/services/settings_service.dart';
+import 'features/sync/domain/services/sync_auto_sync_service.dart';
 import 'features/sync/domain/services/sync_purge_service.dart';
 import 'features/tasks/domain/services/task_notification_service.dart';
 
@@ -41,6 +42,7 @@ void main(List<String> args) async {
   await getIt<SyncPurgeService>().purgeExpiredTombstones();
   await getIt<TaskNotificationService>().rescheduleAllReminders();
   await getIt<NotificationInboxSyncService>().init();
+  getIt<SyncAutoSyncService>().init();
 
   runApp(const ProviderScope(child: FocusApp()));
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import audio_service
 import audio_session
 import audioplayers_darwin
+import file_picker
 import flutter_local_notifications
 import google_sign_in_ios
 import screen_retriever_macos
@@ -19,6 +20,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioServicePlugin.register(with: registry.registrar(forPlugin: "AudioServicePlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -297,6 +297,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+4"
   crypto:
     dependency: transitive
     description:
@@ -401,6 +409,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "29cc1fdb20613876cc7afc529738c1c0f11a9ca159b010edad0c566ac330847e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.3"
   fixnum:
     dependency: transitive
     description:
@@ -483,6 +499,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.35"
   flutter_riverpod:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,7 @@ dependencies:
   extension_google_sign_in_as_googleapis_auth: ^3.0.0
   http: ^1.6.0
   uuid: ^4.6.0
+  file_picker: ^11.0.3
 
 dev_dependencies:
   flutter_test:

--- a/test/core/db/migration_harness_test.dart
+++ b/test/core/db/migration_harness_test.dart
@@ -5,18 +5,19 @@ import 'package:focus/features/tasks/domain/entities/task_status.dart';
 import 'package:focus/features/projects/domain/entities/project_status.dart';
 import 'package:sqlite3/sqlite3.dart';
 
-/// Phase 3 migration harness.
+/// Phase 7 migration harness.
 ///
-/// Captures the current (v8) schema via [AppDatabase.forTesting] and verifies
-/// that upgrading from a hand-built v1 schema reaches v8 without nested
-/// transaction statements, without losing rows, and with PM + recurrence columns.
+/// Captures the current (v9) schema via [AppDatabase.forTesting] and verifies
+/// that upgrading from a hand-built v1 schema reaches v9 without nested
+/// transaction statements, without losing rows, and with PM + recurrence +
+/// task-tag tombstone columns.
 void main() {
-  test('onCreate produces schema version 8 with expected tables', () async {
+  test('onCreate produces schema version 9 with expected tables', () async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 8);
+    expect(version.read<int>('user_version'), 9);
 
     final tables = await db.customSelect("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").get();
     final names = tables.map((row) => row.read<String>('name')).toSet();
@@ -73,6 +74,10 @@ void main() {
       containsAll({'uuid', 'task_id', 'occurrence_date', 'completed_at', 'created_at', 'updated_at', 'deleted_at'}),
     );
 
+    final taskTagCols = await db.customSelect('PRAGMA table_info(task_tag_table)').get();
+    final taskTagColNames = taskTagCols.map((r) => r.read<String>('name')).toSet();
+    expect(taskTagColNames, containsAll({'task_id', 'tag_id', 'uuid', 'created_at', 'updated_at', 'deleted_at'}));
+
     final indexes = await db
         .customSelect(
           "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'task_completion_task_occurrence_live_idx'",
@@ -109,7 +114,7 @@ void main() {
     });
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 8);
+    expect(version.read<int>('user_version'), 9);
 
     final tasks = await db.select(db.taskTable).get();
     expect(tasks, hasLength(1));
@@ -177,7 +182,7 @@ void main() {
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 8);
+    expect(version.read<int>('user_version'), 9);
 
     final project = (await db.select(db.projectTable).get()).single;
     expect(project.uuid, isNotEmpty);
@@ -224,7 +229,7 @@ void main() {
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 8);
+    expect(version.read<int>('user_version'), 9);
 
     final tasks = await db.select(db.taskTable).get();
     expect(tasks, hasLength(2));

--- a/test/domain/sync/sync_merge_engine_test.dart
+++ b/test/domain/sync/sync_merge_engine_test.dart
@@ -1,0 +1,237 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:focus/features/sync/domain/entities/sync_data.dart';
+import 'package:focus/features/sync/domain/entities/sync_state.dart';
+import 'package:focus/features/sync/domain/services/sync_merge_engine.dart';
+
+void main() {
+  const engine = SyncMergeEngine();
+  final base = DateTime.utc(2026, 1, 1, 12);
+  final lastSync = base;
+  final earlier = base.subtract(const Duration(hours: 1));
+  final later = base.add(const Duration(hours: 1));
+  final muchLater = base.add(const Duration(hours: 2));
+
+  SyncProjectData project({
+    required String uuid,
+    required String title,
+    required DateTime updatedAt,
+    DateTime? deletedAt,
+  }) {
+    return SyncProjectData(uuid: uuid, title: title, createdAt: earlier, updatedAt: updatedAt, deletedAt: deletedAt);
+  }
+
+  SyncTaskData task({
+    required String uuid,
+    required String title,
+    required DateTime updatedAt,
+    String projectUuid = 'proj-1',
+    String? parentTaskUuid,
+    int depth = 0,
+    DateTime? deletedAt,
+  }) {
+    return SyncTaskData(
+      uuid: uuid,
+      projectUuid: projectUuid,
+      parentTaskUuid: parentTaskUuid,
+      title: title,
+      priorityIndex: 1,
+      depth: depth,
+      isCompleted: false,
+      createdAt: earlier,
+      updatedAt: updatedAt,
+      deletedAt: deletedAt,
+    );
+  }
+
+  group('SyncMergeEngine', () {
+    test('refuses remote schema newer than local', () {
+      final local = SyncData(syncTimestamp: base, schemaVersion: kSyncSchemaVersion);
+      final remote = SyncData(syncTimestamp: base, schemaVersion: kSyncSchemaVersion + 1);
+      expect(() => engine.merge(local, remote, lastSync), throwsA(isA<SyncSchemaTooNewException>()));
+    });
+
+    test('concurrent create: union keeps both local-only and remote-only rows', () {
+      final local = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'a', title: 'Local Only', updatedAt: later)],
+      );
+      final remote = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'b', title: 'Remote Only', updatedAt: later)],
+      );
+
+      final result = engine.merge(local, remote, lastSync);
+      expect(result.conflicts, isEmpty);
+      expect(result.merged.projects.map((p) => p.uuid).toSet(), {'a', 'b'});
+    });
+
+    test('concurrent edit of same uuid yields conflict', () {
+      final local = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'shared', title: 'Local Edit', updatedAt: later)],
+      );
+      final remote = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'shared', title: 'Remote Edit', updatedAt: muchLater)],
+      );
+
+      final result = engine.merge(local, remote, lastSync);
+      expect(result.conflicts, hasLength(1));
+      expect(result.conflicts.single.entityId, 'shared');
+      expect(result.conflicts.single.entityType, 'project');
+      expect(result.merged.projects.where((p) => p.uuid == 'shared'), isEmpty);
+    });
+
+    test('delete-versus-edit: newer tombstone wins over older live edit', () {
+      final local = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'p1', title: 'Gone', updatedAt: muchLater, deletedAt: muchLater)],
+      );
+      final remote = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'p1', title: 'Edited remotely', updatedAt: later)],
+      );
+
+      final result = engine.merge(local, remote, lastSync);
+      expect(result.conflicts, isEmpty);
+      expect(result.merged.projects.single.deletedAt, isNotNull);
+      expect(result.merged.projects.single.title, 'Gone');
+    });
+
+    test('delete-versus-edit: both changed since last sync yields conflict when live is newer', () {
+      final local = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'p1', title: 'Deleted locally', updatedAt: later, deletedAt: later)],
+      );
+      final remote = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'p1', title: 'Revived remotely', updatedAt: muchLater)],
+      );
+
+      final result = engine.merge(local, remote, lastSync);
+      // Both changed since last sync → conflict (delete vs edit).
+      expect(result.conflicts, hasLength(1));
+      expect(result.conflicts.single.entityId, 'p1');
+    });
+
+    test('remote-only change updates local without conflict', () {
+      final local = SyncData(
+        syncTimestamp: earlier,
+        projects: [project(uuid: 'p1', title: 'Old', updatedAt: earlier)],
+      );
+      final remote = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'p1', title: 'New', updatedAt: later)],
+      );
+
+      final result = engine.merge(local, remote, lastSync);
+      expect(result.conflicts, isEmpty);
+      expect(result.merged.projects.single.title, 'New');
+    });
+
+    test('local-only tombstone is retained for upload (union of uuids)', () {
+      final local = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'dead', title: 'Tombstone', updatedAt: later, deletedAt: later)],
+      );
+      final remote = SyncData(syncTimestamp: earlier, projects: const []);
+
+      final result = engine.merge(local, remote, lastSync);
+      expect(result.merged.projects, hasLength(1));
+      expect(result.merged.projects.single.deletedAt, isNotNull);
+    });
+
+    test('tasks are ordered parents-before-children by depth', () {
+      final local = SyncData(
+        syncTimestamp: later,
+        tasks: [
+          task(uuid: 'child', title: 'Child', updatedAt: later, parentTaskUuid: 'parent', depth: 1),
+          task(uuid: 'parent', title: 'Parent', updatedAt: later, depth: 0),
+        ],
+      );
+      final remote = SyncData(syncTimestamp: earlier);
+
+      final result = engine.merge(local, remote, lastSync);
+      expect(result.merged.tasks.map((t) => t.uuid).toList(), ['parent', 'child']);
+    });
+
+    test('three-device convergence: A create, B edit, C tombstone → newest tombstone', () {
+      // Device A created, B edited, C deleted last — C's tombstone should win.
+      final deviceA = SyncData(
+        syncTimestamp: earlier,
+        projects: [project(uuid: 'conv', title: 'Created A', updatedAt: earlier)],
+      );
+      final deviceB = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'conv', title: 'Edited B', updatedAt: later)],
+      );
+      final deviceC = SyncData(
+        syncTimestamp: muchLater,
+        projects: [project(uuid: 'conv', title: 'Edited B', updatedAt: muchLater, deletedAt: muchLater)],
+      );
+
+      final ab = engine.merge(deviceA, deviceB, null);
+      expect(ab.conflicts, isEmpty);
+      expect(ab.merged.projects.single.title, 'Edited B');
+      final abc = engine.merge(ab.merged, deviceC, earlier);
+      expect(abc.conflicts, isEmpty);
+      expect(abc.merged.projects.single.deletedAt, isNotNull);
+    });
+
+    test('three-device convergence: concurrent edits on B and C after shared base conflict', () {
+      final shared = SyncData(
+        syncTimestamp: earlier,
+        projects: [project(uuid: 'conv', title: 'Base', updatedAt: earlier)],
+      );
+      final deviceB = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'conv', title: 'B', updatedAt: later)],
+      );
+      final deviceC = SyncData(
+        syncTimestamp: later,
+        projects: [project(uuid: 'conv', title: 'C', updatedAt: later.add(const Duration(minutes: 1)))],
+      );
+
+      final fromB = engine.merge(shared, deviceB, earlier);
+      expect(fromB.conflicts, isEmpty);
+      final fromC = engine.merge(fromB.merged, deviceC, earlier);
+      expect(fromC.conflicts, hasLength(1));
+      expect(fromC.conflicts.single.entityId, 'conv');
+    });
+
+    test('settings merge by key and ignore non-whitelisted keys', () {
+      final local = SyncData(
+        syncTimestamp: later,
+        settings: [
+          SyncSettingData(key: 'focus_duration_minutes', value: '25', updatedAt: earlier),
+          SyncSettingData(key: 'device_id', value: 'local-device', updatedAt: later),
+        ],
+      );
+      final remote = SyncData(
+        syncTimestamp: later,
+        settings: [
+          SyncSettingData(key: 'focus_duration_minutes', value: '30', updatedAt: later),
+          SyncSettingData(key: 'device_id', value: 'remote-device', updatedAt: later),
+        ],
+      );
+
+      final result = engine.merge(local, remote, lastSync);
+      expect(result.conflicts, isEmpty);
+      expect(result.merged.settings.single.key, 'focus_duration_minutes');
+      expect(result.merged.settings.single.value, '30');
+    });
+
+    test('SyncConflict.entityId is a String uuid', () {
+      final conflict = SyncConflict(
+        entityType: 'task',
+        entityId: 'uuid-abc',
+        entityTitle: 'T',
+        localUpdatedAt: later,
+        remoteUpdatedAt: muchLater,
+      );
+      expect(conflict.entityId, isA<String>());
+      expect(conflict.entityId, 'uuid-abc');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch feat/phase-7-sync-rewrite into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
cdf9d77 feat(sync): rewrite sync on UUID identity with tombstones

### Files
- .agents/docs/architecture.md
- .agents/docs/audit_results.md
- .agents/docs/feature_plans.md
- .agents/docs/patterns.md
- lib/core/di/injection.dart
- lib/core/services/data_change_bus.dart
- lib/core/services/db_service.dart
- lib/core/services/db_service.g.dart
- lib/features/milestones/data/repositories/milestone_repository_impl.dart
- lib/features/projects/data/datasources/project_local_datasource.dart
- lib/features/projects/data/repositories/project_repository_impl.dart
- lib/features/session/data/repositories/focus_session_repository_impl.dart
- lib/features/settings/data/repositories/settings_repository_impl.dart
- lib/features/settings/domain/entities/setting.dart
- lib/features/sync/data/datasources/sync_local_datasource.dart
- lib/features/sync/domain/entities/sync_data.dart
- lib/features/sync/domain/entities/sync_state.dart
- lib/features/sync/domain/services/sync_auto_sync_service.dart
- lib/features/sync/domain/services/sync_backup_service.dart
- lib/features/sync/domain/services/sync_engine.dart
- lib/features/sync/domain/services/sync_merge_engine.dart
- lib/features/sync/domain/services/sync_purge_service.dart
- lib/features/sync/presentation/providers/sync_provider.dart
- lib/features/sync/presentation/providers/sync_provider.g.dart
- lib/features/sync/presentation/screens/sync_conflict_screen.dart
- lib/features/sync/presentation/widgets/sync_settings_card.dart
- lib/features/tags/data/datasources/tag_local_datasource.dart
- lib/features/tags/data/models/task_tag_model.dart
- lib/features/tags/data/repositories/tag_repository_impl.dart
- lib/features/tasks/data/datasources/task_local_datasource.dart
- lib/features/tasks/data/datasources/task_stats_local_datasource.dart
- lib/features/tasks/data/repositories/task_repository_impl.dart
- lib/features/tasks/presentation/providers/task_provider.g.dart
- lib/main.dart
- macos/Flutter/GeneratedPluginRegistrant.swift
- pubspec.lock
- pubspec.yaml
- test/core/db/migration_harness_test.dart
- test/domain/sync/sync_merge_engine_test.dart

### Diffstat
 .agents/docs/architecture.md                       |  16 +-
 .agents/docs/audit_results.md                      |  20 +
 .agents/docs/feature_plans.md                      |  12 +-
 .agents/docs/patterns.md                           |  36 ++
 lib/core/di/injection.dart                         |  43 +-
 lib/core/services/data_change_bus.dart             |  17 +
 lib/core/services/db_service.dart                  |  42 +-
 lib/core/services/db_service.g.dart                | 348 ++++++++++--
 .../repositories/milestone_repository_impl.dart    |   9 +-
 .../data/datasources/project_local_datasource.dart |   4 +-
 .../data/repositories/project_repository_impl.dart |   9 +-
 .../focus_session_repository_impl.dart             |   9 +-
 .../repositories/settings_repository_impl.dart     |  10 +-
 lib/features/settings/domain/entities/setting.dart |  15 +
 .../data/datasources/sync_local_datasource.dart    | 603 +++++++++++++++++++++
 lib/features/sync/domain/entities/sync_data.dart   | 586 ++++++++++++++++----
 lib/features/sync/domain/entities/sync_state.dart  |   4 +-
 .../domain/services/sync_auto_sync_service.dart    |  97 ++++
 .../sync/domain/services/sync_backup_service.dart  |  78 +++
 lib/features/sync/domain/services/sync_engine.dart | 361 +++++-------
 .../sync/domain/services/sync_merge_engine.dart    | 311 +++++++++++
 .../sync/domain/services/sync_purge_service.dart   |   8 +-
 .../sync/presentation/providers/sync_provider.dart |  24 +-
 .../presentation/providers/sync_provider.g.dart    |   2 +-
 .../presentation/screens/sync_conflict_screen.dart |  30 +-
 .../presentation/widgets/sync_settings_card.dart   |  86 ++-
 .../data/datasources/tag_local_datasource.dart     |  47 +-
 lib/features/tags/data/models/task_tag_model.dart  |  14 +
 .../data/repositories/tag_repository_impl.dart     |  10 +-
 .../data/datasources/task_local_datasource.dart    |   4 +-
 .../datasources/task_stats_local_datasource.dart   |   2 +-
 .../data/repositories/task_repository_impl.dart    |  11 +-
 .../presentation/providers/task_provider.g.dart    |   2 +-
 lib/main.dart                                      |   2 +
 macos/Flutter/GeneratedPluginRegistrant.swift      |   2 +
 pubspec.lock                                       |  24 +
 pubspec.yaml                                       |   1 +
 test/core/db/migration_harness_test.dart           |  23 +-
 test/domain/sync/sync_merge_engine_test.dart       | 237 ++++++++
 39 files changed, 2725 insertions(+), 434 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
