### PR TITLE
feat(projects): Phase 8 templates shortcuts and docs

### DIFF
--- a/.agents/docs/architecture.md
+++ b/.agents/docs/architecture.md
@@ -160,7 +160,7 @@ Rules for schema changes:
 4. Regenerate code.
 5. Verify migration behavior with existing user data.
 
-Current sync-ready schema (v9) includes on `project_table`, `task_table`, and `focus_session_table`:
+Current sync-ready schema (v10) includes on `project_table`, `task_table`, and `focus_session_table`:
 - `uuid` (TEXT, unique) — stable sync identity, generated on create and backfilled on migration
 - `deleted_at` (nullable DateTime) — soft-delete tombstone; all reads filter `deletedAt IS NULL`
 
@@ -188,6 +188,14 @@ Sync rewrite (v9) adds:
 - Auto-sync via `SyncAutoSyncService` (foreground/background + debounced `DataChangeBus` mutations) gated by `sync_enabled`
 - Local JSON backup/restore reuses `SyncData` serialization (`SyncBackupService`)
 
+Project templates (v10) adds:
+- `project_template_table` — `uuid`, `name`, `description`, `is_builtin`, `payload_json`, timestamps
+- Payload JSON (`ProjectTemplatePayload`) captures tasks, milestones, tags, and recurrence with relative
+  date offsets; apply remaps stable template keys to new entity IDs
+- Three built-in templates seeded idempotently on `onCreate` / v10 upgrade (`BuiltInTemplates`)
+- Save-as-template from project action menu; template picker on create-project flow
+- Templates are local-only (not included in cloud sync envelope)
+
 Deletes are soft deletes. `ON DELETE CASCADE` no longer fires for app-level deletes, so project/task
 deletion must cascade soft-deletes to dependents inside a transaction (including milestones,
 completions, and soft-deleted `task_tag` associations). `SyncPurgeService` hard-deletes tombstones older
@@ -209,6 +217,9 @@ Current task schema also includes reminder configuration fields:
   (`SettingsKeys.tasksViewMode`).
 - Board columns map 1:1 to `TaskStatus`; ordering uses sparse `sortOrder` (`SparseSortOrder`).
 - Project detail uses a local segmented tab: Overview / Tasks / Board / Milestones / Timeline.
+- Desktop keyboard shortcuts: global (`AppKeyboardShortcuts` — ⌘/Ctrl+N/P, Space, Esc); board
+  (←/→ columns, 1–4 status); calendar (←/→ period, T=today, 1–3 scope).
+- Empty surfaces use shared `AppEmptyState` (board, agenda, timeline, milestones).
 
 ## Notifications Architecture
 

--- a/.agents/docs/audit_results.md
+++ b/.agents/docs/audit_results.md
@@ -1,20 +1,28 @@
 # Focus Audit Snapshot
 
-Last updated: Phase 7 sync rewrite (`feat/phase-7-sync-rewrite`).
+Last updated: Phase 8 templates + polish (`feat/phase-8-templates-docs`).
 
 ## Current Risk Profile
 
 | Area | Risk | Notes |
 |------|------|-------|
+| Template apply orchestration | Medium | Multi-step create (project → milestones → tags → tasks); partial failure can leave orphan project |
+| Template payload schema | Low | Pure JSON capture/round-trip unit-tested; version field present for future bumps |
+| Schema migration v9→v10 | Low | `createTable` + idempotent built-in seed by UUID; migration harness covers onCreate + legacy upgrades |
 | Sync merge conflicts | Medium | Pure merge is unit-tested; apply/upsert path is integration-sensitive across UUID→id maps |
-| Schema migration v8→v9 | Low | Idempotent task_tag column add; migration harness covers onCreate + legacy upgrades |
 | Auto-sync debounce | Low | 8s debounce; skips when unsigned-in or `sync_enabled=false`; manual Sync Now forces |
-| Backup restore | Medium | Destructive replace of sync-covered tables — gated by confirmation dialog |
+| Backup restore | Medium | Destructive replace of sync-covered tables — gated by confirmation dialog; templates not in envelope |
 | Focus session clocks | Low | Sessions lack DB `updatedAt`; merge uses `deletedAt ?? endTime ?? startTime` |
+| Soft-delete cascades | Medium | Project/task delete must soft-cascade dependents; regression covered partially by datasource tests |
+| Sparse board rebalance | Low | Gap collapse rewrites column orders; pure `SparseSortOrder` unit-tested |
+| Recurrence expansion | Low | Pure domain; reminder window advance after occurrence complete is the main integration risk |
 
 ## Known Gaps / Follow-ups
 
 - No end-to-end Google Drive integration test (mocked cloud service recommended).
+- No integration test for full `ProjectTemplateService.applyTemplate` against a real DB.
 - Settings LWW depends on `${key}__updated_at` side-car keys written by `SettingsRepositoryImpl`.
 - Concurrent delete-vs-edit (both changed since last sync) still surfaces as a user conflict.
 - macOS file picker may require User Selected File entitlements for backup export/import.
+- Project templates are local-only; syncing them needs an explicit SyncData schema bump.
+- Template apply does not roll back the created project if a later milestone/task insert fails.

--- a/.agents/docs/feature_plans.md
+++ b/.agents/docs/feature_plans.md
@@ -8,6 +8,17 @@ This document tracks implementation priorities and planning guidance for coding 
 - Keep architecture boundaries intact while adding capability.
 - Persist user-facing preference state when users expect continuity across restarts.
 
+## Completed — PM & Sync Overhaul (Phases 1–8)
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| 1–3 Schema / soft-delete / UUID / PM model | Done | Soft-delete, tags, milestones, status, estimates |
+| 4 Board / calendar / timeline | Done | Sparse sort, shared calendar widgets, project tabs |
+| 5 Home today agenda + habits | Done | `TodayAgendaBuilder`, habits strip |
+| 6 Reports insights + CSV | Done | Window-scoped SQL aggregates + export |
+| 7 Sync rewrite | Done | UUID envelope v2, merge engine, auto-sync, backup |
+| 8 Templates + polish | Done | `project_template_table` v10, shortcuts, empty states, docs |
+
 ## Near-Term Priorities
 
 ### 1. Testing Foundation (High)
@@ -19,6 +30,7 @@ Suggested scope:
 - Domain services for tasks/projects/session
 - Provider behavior for key mutation paths
 - Notification scheduling fallback behavior
+- Template apply integration (beyond pure payload serialization)
 
 ### 2. Session Reliability Improvements (High)
 
@@ -40,36 +52,11 @@ Suggested scope:
 - Improve reminder controls and statuses
 - Add stronger validation and user feedback for invalid task inputs
 
-### 4. Reporting and Insights (Medium)
-
-Goal:
-- Expand reporting value while keeping UI responsive and readable.
-
-Suggested scope:
-- Additional insight visualizations with persisted window modes
-- Better empty states and no-data messaging
-- Evaluate caching/aggregation improvements for heavier stats views
-
-Status (Phase 6):
-- Habit consistency, estimate accuracy, time-by-project/tag, throughput, and CSV export
-  are implemented on `ReportsScreen` via window-scoped SQL aggregates in
-  `task_stats_local_datasource.dart` and `ReportInsightsCalculator`.
-
-### 5. Sync Rewrite (Phase 7 — High)
-
-Goal:
-- UUID-keyed multi-device sync with tombstones, extended entity coverage, auto-sync, and backup.
-
-Status (Phase 7):
-- `SyncData` schema v2 references peers by UUID; refuses newer remote schemas.
-- Pure `SyncMergeEngine` + `SyncEngine`/`SyncLocalDataSource` bulk gather/apply.
-- Auto-sync (`sync_enabled`, lifecycle, mutation debounce) and local JSON backup/restore.
-- DB schema v9 adds soft-delete fields on `task_tag_table`.
-
 ## Backlog Candidates
 
-- Extended keyboard and desktop productivity shortcuts
+- Sync project templates across devices (needs SyncData schema bump)
 - Advanced session analytics and trend surfacing
+- Additional desktop productivity shortcuts (global command palette)
 
 ## Implementation Template
 

--- a/.agents/docs/patterns.md
+++ b/.agents/docs/patterns.md
@@ -461,6 +461,46 @@ Gotchas:
 - Focus sessions derive merge clocks from `deletedAt ?? endTime ?? startTime` (no DB `updatedAt`).
 - Task↔tag links soft-delete (do not hard-delete) so tombstones can propagate.
 
+## Project Templates
+
+Templates live under `lib/features/projects/` (not a separate feature root).
+
+```dart
+final payload = ProjectTemplatePayload.capture(
+  project: project,
+  tasks: tasks,
+  milestones: milestones,
+  tagsByTaskId: tagsByTaskId,
+);
+
+final result = await templateService.applyTemplate(
+  template: template,
+  title: title,
+  startDate: startDate,
+);
+```
+
+Payload rules:
+- Stable string keys (`m0`, `t0`, `g0`) link milestones/tasks/tags inside the JSON.
+- Dates are relative offsets from project start (or earliest dated item / today).
+- Apply creates project → milestones → tags (reuse by name) → tasks (depth/parent order) → task tags.
+- Built-ins use fixed UUIDs (`BuiltInTemplateIds`) and are seeded idempotently in migration v10 / `onCreate`.
+- Templates are local-only; do not add them to the sync envelope without an explicit schema bump.
+
+UI hooks:
+- `ActionMenuButton.onSaveAsTemplate` on project detail.
+- `ProjectTemplatePicker` on `CreateProjectScreen`.
+
+## Desktop Keyboard Shortcuts + Empty States
+
+```dart
+// Global (desktop shell): ⌘/Ctrl+N task, ⌘/Ctrl+P project, Space session, Esc pop
+// Board: ←/→ column, 1–4 status; Calendar: ←/→ period, T today, 1–3 scope
+```
+
+Use `AppEmptyState` for board/calendar agenda/timeline/milestones empty surfaces.
+Home may keep `EmptySection` or migrate to `AppEmptyState` — prefer the core widget for new views.
+
 ## Mandatory Follow-Up
 
 When a new pattern is introduced in production code, add it here with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,11 +167,14 @@ Commit titles should default to Conventional Commit types (`feat`, `fix`, `refac
 | File | Purpose |
 |------|---------|
 | `lib/core/di/injection.dart` | DI registration |
-| `lib/core/services/db_service.dart` | Drift database and migrations |
+| `lib/core/services/db_service.dart` | Drift database and migrations (current schema v10) |
 | `lib/core/services/log_service.dart` | Centralized logging |
 | `lib/core/utils/result.dart` | `Result<T>` and failure types |
 | `lib/core/routing/app_router.dart` | go_router config |
 | `lib/core/routing/routes.dart` | Route constants/helpers |
+| `lib/core/widgets/app_empty_state.dart` | Shared empty-state UI |
+| `lib/core/widgets/keyboard_shortcuts.dart` | Global desktop shortcuts |
+| `lib/features/projects/domain/services/project_template_service.dart` | Save/apply project templates |
 | `lib/features/notifications/presentation/screens/notifications_screen.dart` | Notifications inbox UI |
 | `lib/features/tasks/domain/services/task_reminder_planner.dart` | Task reminder scheduling logic |
 | `lib/core/constants/app_constants.dart` | Shared spacing/sizing constants |

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -1,9 +1,13 @@
 import 'package:get_it/get_it.dart';
 
 import '../../features/projects/data/datasources/project_local_datasource.dart';
+import '../../features/projects/data/datasources/project_template_local_datasource.dart';
 import '../../features/projects/data/repositories/project_repository_impl.dart';
+import '../../features/projects/data/repositories/project_template_repository_impl.dart';
 import '../../features/projects/domain/repositories/i_project_repository.dart';
+import '../../features/projects/domain/repositories/i_project_template_repository.dart';
 import '../../features/projects/domain/services/project_service.dart';
+import '../../features/projects/domain/services/project_template_service.dart';
 import '../../features/milestones/data/datasources/milestone_local_datasource.dart';
 import '../../features/milestones/data/repositories/milestone_repository_impl.dart';
 import '../../features/milestones/domain/repositories/i_milestone_repository.dart';
@@ -105,7 +109,23 @@ void _initProjectsDi() {
     ..registerLazySingleton<IProjectRepository>(
       () => ProjectRepositoryImpl(getIt<IProjectLocalDataSource>(), getIt<DataChangeBus>()),
     )
-    ..registerLazySingleton<ProjectService>(() => ProjectService(getIt<IProjectRepository>()));
+    ..registerLazySingleton<ProjectService>(() => ProjectService(getIt<IProjectRepository>()))
+    ..registerLazySingleton<IProjectTemplateLocalDataSource>(
+      () => ProjectTemplateLocalDataSourceImpl(getIt<AppDatabase>()),
+    )
+    ..registerLazySingleton<IProjectTemplateRepository>(
+      () => ProjectTemplateRepositoryImpl(getIt<IProjectTemplateLocalDataSource>(), getIt<DataChangeBus>()),
+    )
+    ..registerLazySingleton<ProjectTemplateService>(
+      () => ProjectTemplateService(
+        getIt<IProjectTemplateRepository>(),
+        getIt<IProjectRepository>(),
+        getIt<ProjectService>(),
+        getIt<TaskService>(),
+        getIt<MilestoneService>(),
+        getIt<TagService>(),
+      ),
+    );
 }
 
 void _initMilestonesDi() {

--- a/lib/core/services/db_service.dart
+++ b/lib/core/services/db_service.dart
@@ -10,6 +10,8 @@ import 'package:focus/features/tags/data/models/task_tag_model.dart';
 import 'package:focus/features/milestones/data/models/milestone_model.dart';
 
 import '../../features/projects/data/models/project_model.dart';
+import '../../features/projects/data/models/project_template_model.dart';
+import '../../features/projects/domain/entities/built_in_templates.dart';
 import '../../features/session/data/models/focus_session_model.dart';
 import '../../features/session/domain/entities/session_state.dart';
 import '../../features/notifications/domain/entities/notification_inbox_item.dart';
@@ -34,6 +36,7 @@ part 'db_service.g.dart';
     TaskTagTable,
     MilestoneTable,
     TaskCompletionTable,
+    ProjectTemplateTable,
   ],
 )
 class AppDatabase extends _$AppDatabase {
@@ -43,7 +46,7 @@ class AppDatabase extends _$AppDatabase {
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 9;
+  int get schemaVersion => 10;
 
   /// Recalculates the [dailySessionStatsTable] row for the given
   /// local calendar [dateKey] (format `YYYY-MM-DD`).
@@ -83,6 +86,7 @@ class AppDatabase extends _$AppDatabase {
         'CREATE UNIQUE INDEX IF NOT EXISTS task_completion_task_occurrence_live_idx '
         'ON task_completion_table(task_id, occurrence_date) WHERE deleted_at IS NULL',
       );
+      await _seedBuiltInTemplates();
     },
     onUpgrade: (m, from, to) async {
       if (from < 2) {
@@ -318,6 +322,18 @@ class AppDatabase extends _$AppDatabase {
         await customStatement('CREATE UNIQUE INDEX IF NOT EXISTS task_tag_uuid_idx ON task_tag_table(uuid)');
         await customStatement('CREATE INDEX IF NOT EXISTS task_tag_deleted_at_idx ON task_tag_table(deleted_at)');
       }
+
+      // v9 → v10: Project templates with JSON payload + built-in seeds.
+      if (from < 10) {
+        await m.createTable(projectTemplateTable);
+        await customStatement(
+          'CREATE UNIQUE INDEX IF NOT EXISTS project_template_uuid_idx ON project_template_table(uuid)',
+        );
+        await customStatement(
+          'CREATE INDEX IF NOT EXISTS project_template_builtin_idx ON project_template_table(is_builtin)',
+        );
+        await _seedBuiltInTemplates();
+      }
     },
     beforeOpen: (details) async {
       // SQLite requires this pragma to be enabled per connection.
@@ -332,6 +348,27 @@ class AppDatabase extends _$AppDatabase {
     for (final row in rows) {
       final id = row.read<int>('id');
       await customStatement('UPDATE $tableName SET uuid = ? WHERE id = ?', [generateUuid(), id]);
+    }
+  }
+
+  /// Inserts shipped built-in templates when missing (idempotent by uuid).
+  Future<void> _seedBuiltInTemplates() async {
+    for (final template in BuiltInTemplates.all()) {
+      final existing = await (select(
+        projectTemplateTable,
+      )..where((t) => t.uuid.equals(template.uuid))).getSingleOrNull();
+      if (existing != null) continue;
+      await into(projectTemplateTable).insert(
+        ProjectTemplateTableCompanion.insert(
+          uuid: template.uuid,
+          name: template.name,
+          description: Value(template.description),
+          isBuiltin: const Value(true),
+          payloadJson: template.payload.toJsonString(),
+          createdAt: template.createdAt,
+          updatedAt: template.updatedAt,
+        ),
+      );
     }
   }
 }

--- a/lib/core/services/db_service.g.dart
+++ b/lib/core/services/db_service.g.dart
@@ -4827,6 +4827,424 @@ class TaskCompletionTableCompanion extends UpdateCompanion<TaskCompletionTableDa
   }
 }
 
+class $ProjectTemplateTableTable extends ProjectTemplateTable
+    with TableInfo<$ProjectTemplateTableTable, ProjectTemplateTableData> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $ProjectTemplateTableTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'),
+  );
+  static const VerificationMeta _uuidMeta = const VerificationMeta('uuid');
+  @override
+  late final GeneratedColumn<String> uuid = GeneratedColumn<String>(
+    'uuid',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _descriptionMeta = const VerificationMeta('description');
+  @override
+  late final GeneratedColumn<String> description = GeneratedColumn<String>(
+    'description',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _isBuiltinMeta = const VerificationMeta('isBuiltin');
+  @override
+  late final GeneratedColumn<bool> isBuiltin = GeneratedColumn<bool>(
+    'is_builtin',
+    aliasedName,
+    false,
+    type: DriftSqlType.bool,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways('CHECK ("is_builtin" IN (0, 1))'),
+    defaultValue: const Constant(false),
+  );
+  static const VerificationMeta _payloadJsonMeta = const VerificationMeta('payloadJson');
+  @override
+  late final GeneratedColumn<String> payloadJson = GeneratedColumn<String>(
+    'payload_json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _createdAtMeta = const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+    'created_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.dateTime,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, uuid, name, description, isBuiltin, payloadJson, createdAt, updatedAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'project_template_table';
+  @override
+  VerificationContext validateIntegrity(Insertable<ProjectTemplateTableData> instance, {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('uuid')) {
+      context.handle(_uuidMeta, uuid.isAcceptableOrUnknown(data['uuid']!, _uuidMeta));
+    } else if (isInserting) {
+      context.missing(_uuidMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(_nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('description')) {
+      context.handle(_descriptionMeta, description.isAcceptableOrUnknown(data['description']!, _descriptionMeta));
+    }
+    if (data.containsKey('is_builtin')) {
+      context.handle(_isBuiltinMeta, isBuiltin.isAcceptableOrUnknown(data['is_builtin']!, _isBuiltinMeta));
+    }
+    if (data.containsKey('payload_json')) {
+      context.handle(_payloadJsonMeta, payloadJson.isAcceptableOrUnknown(data['payload_json']!, _payloadJsonMeta));
+    } else if (isInserting) {
+      context.missing(_payloadJsonMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta, createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    } else if (isInserting) {
+      context.missing(_createdAtMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta, updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  ProjectTemplateTableData map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return ProjectTemplateTableData(
+      id: attachedDatabase.typeMapping.read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      uuid: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}uuid'])!,
+      name: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      description: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}description']),
+      isBuiltin: attachedDatabase.typeMapping.read(DriftSqlType.bool, data['${effectivePrefix}is_builtin'])!,
+      payloadJson: attachedDatabase.typeMapping.read(DriftSqlType.string, data['${effectivePrefix}payload_json'])!,
+      createdAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping.read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at'])!,
+    );
+  }
+
+  @override
+  $ProjectTemplateTableTable createAlias(String alias) {
+    return $ProjectTemplateTableTable(attachedDatabase, alias);
+  }
+}
+
+class ProjectTemplateTableData extends DataClass implements Insertable<ProjectTemplateTableData> {
+  final int id;
+  final String uuid;
+  final String name;
+  final String? description;
+  final bool isBuiltin;
+
+  /// JSON [ProjectTemplatePayload] blob.
+  final String payloadJson;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  const ProjectTemplateTableData({
+    required this.id,
+    required this.uuid,
+    required this.name,
+    this.description,
+    required this.isBuiltin,
+    required this.payloadJson,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['uuid'] = Variable<String>(uuid);
+    map['name'] = Variable<String>(name);
+    if (!nullToAbsent || description != null) {
+      map['description'] = Variable<String>(description);
+    }
+    map['is_builtin'] = Variable<bool>(isBuiltin);
+    map['payload_json'] = Variable<String>(payloadJson);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    return map;
+  }
+
+  ProjectTemplateTableCompanion toCompanion(bool nullToAbsent) {
+    return ProjectTemplateTableCompanion(
+      id: Value(id),
+      uuid: Value(uuid),
+      name: Value(name),
+      description: description == null && nullToAbsent ? const Value.absent() : Value(description),
+      isBuiltin: Value(isBuiltin),
+      payloadJson: Value(payloadJson),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+    );
+  }
+
+  factory ProjectTemplateTableData.fromJson(Map<String, dynamic> json, {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return ProjectTemplateTableData(
+      id: serializer.fromJson<int>(json['id']),
+      uuid: serializer.fromJson<String>(json['uuid']),
+      name: serializer.fromJson<String>(json['name']),
+      description: serializer.fromJson<String?>(json['description']),
+      isBuiltin: serializer.fromJson<bool>(json['isBuiltin']),
+      payloadJson: serializer.fromJson<String>(json['payloadJson']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'uuid': serializer.toJson<String>(uuid),
+      'name': serializer.toJson<String>(name),
+      'description': serializer.toJson<String?>(description),
+      'isBuiltin': serializer.toJson<bool>(isBuiltin),
+      'payloadJson': serializer.toJson<String>(payloadJson),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+    };
+  }
+
+  ProjectTemplateTableData copyWith({
+    int? id,
+    String? uuid,
+    String? name,
+    Value<String?> description = const Value.absent(),
+    bool? isBuiltin,
+    String? payloadJson,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) => ProjectTemplateTableData(
+    id: id ?? this.id,
+    uuid: uuid ?? this.uuid,
+    name: name ?? this.name,
+    description: description.present ? description.value : this.description,
+    isBuiltin: isBuiltin ?? this.isBuiltin,
+    payloadJson: payloadJson ?? this.payloadJson,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+  ProjectTemplateTableData copyWithCompanion(ProjectTemplateTableCompanion data) {
+    return ProjectTemplateTableData(
+      id: data.id.present ? data.id.value : this.id,
+      uuid: data.uuid.present ? data.uuid.value : this.uuid,
+      name: data.name.present ? data.name.value : this.name,
+      description: data.description.present ? data.description.value : this.description,
+      isBuiltin: data.isBuiltin.present ? data.isBuiltin.value : this.isBuiltin,
+      payloadJson: data.payloadJson.present ? data.payloadJson.value : this.payloadJson,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ProjectTemplateTableData(')
+          ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
+          ..write('name: $name, ')
+          ..write('description: $description, ')
+          ..write('isBuiltin: $isBuiltin, ')
+          ..write('payloadJson: $payloadJson, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, uuid, name, description, isBuiltin, payloadJson, createdAt, updatedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is ProjectTemplateTableData &&
+          other.id == this.id &&
+          other.uuid == this.uuid &&
+          other.name == this.name &&
+          other.description == this.description &&
+          other.isBuiltin == this.isBuiltin &&
+          other.payloadJson == this.payloadJson &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt);
+}
+
+class ProjectTemplateTableCompanion extends UpdateCompanion<ProjectTemplateTableData> {
+  final Value<int> id;
+  final Value<String> uuid;
+  final Value<String> name;
+  final Value<String?> description;
+  final Value<bool> isBuiltin;
+  final Value<String> payloadJson;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  const ProjectTemplateTableCompanion({
+    this.id = const Value.absent(),
+    this.uuid = const Value.absent(),
+    this.name = const Value.absent(),
+    this.description = const Value.absent(),
+    this.isBuiltin = const Value.absent(),
+    this.payloadJson = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+  });
+  ProjectTemplateTableCompanion.insert({
+    this.id = const Value.absent(),
+    required String uuid,
+    required String name,
+    this.description = const Value.absent(),
+    this.isBuiltin = const Value.absent(),
+    required String payloadJson,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) : uuid = Value(uuid),
+       name = Value(name),
+       payloadJson = Value(payloadJson),
+       createdAt = Value(createdAt),
+       updatedAt = Value(updatedAt);
+  static Insertable<ProjectTemplateTableData> custom({
+    Expression<int>? id,
+    Expression<String>? uuid,
+    Expression<String>? name,
+    Expression<String>? description,
+    Expression<bool>? isBuiltin,
+    Expression<String>? payloadJson,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (uuid != null) 'uuid': uuid,
+      if (name != null) 'name': name,
+      if (description != null) 'description': description,
+      if (isBuiltin != null) 'is_builtin': isBuiltin,
+      if (payloadJson != null) 'payload_json': payloadJson,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+    });
+  }
+
+  ProjectTemplateTableCompanion copyWith({
+    Value<int>? id,
+    Value<String>? uuid,
+    Value<String>? name,
+    Value<String?>? description,
+    Value<bool>? isBuiltin,
+    Value<String>? payloadJson,
+    Value<DateTime>? createdAt,
+    Value<DateTime>? updatedAt,
+  }) {
+    return ProjectTemplateTableCompanion(
+      id: id ?? this.id,
+      uuid: uuid ?? this.uuid,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      isBuiltin: isBuiltin ?? this.isBuiltin,
+      payloadJson: payloadJson ?? this.payloadJson,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (uuid.present) {
+      map['uuid'] = Variable<String>(uuid.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (description.present) {
+      map['description'] = Variable<String>(description.value);
+    }
+    if (isBuiltin.present) {
+      map['is_builtin'] = Variable<bool>(isBuiltin.value);
+    }
+    if (payloadJson.present) {
+      map['payload_json'] = Variable<String>(payloadJson.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('ProjectTemplateTableCompanion(')
+          ..write('id: $id, ')
+          ..write('uuid: $uuid, ')
+          ..write('name: $name, ')
+          ..write('description: $description, ')
+          ..write('isBuiltin: $isBuiltin, ')
+          ..write('payloadJson: $payloadJson, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
@@ -4840,6 +5258,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $TagTableTable tagTable = $TagTableTable(this);
   late final $TaskTagTableTable taskTagTable = $TaskTagTableTable(this);
   late final $TaskCompletionTableTable taskCompletionTable = $TaskCompletionTableTable(this);
+  late final $ProjectTemplateTableTable projectTemplateTable = $ProjectTemplateTableTable(this);
   late final Index projectCreatedAtIdx = Index(
     'project_created_at_idx',
     'CREATE INDEX project_created_at_idx ON project_table (created_at)',
@@ -4972,6 +5391,14 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     'task_completion_deleted_at_idx',
     'CREATE INDEX task_completion_deleted_at_idx ON task_completion_table (deleted_at)',
   );
+  late final Index projectTemplateUuidIdx = Index(
+    'project_template_uuid_idx',
+    'CREATE UNIQUE INDEX project_template_uuid_idx ON project_template_table (uuid)',
+  );
+  late final Index projectTemplateBuiltinIdx = Index(
+    'project_template_builtin_idx',
+    'CREATE INDEX project_template_builtin_idx ON project_template_table (is_builtin)',
+  );
   @override
   Iterable<TableInfo<Table, Object?>> get allTables => allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
@@ -4986,6 +5413,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     tagTable,
     taskTagTable,
     taskCompletionTable,
+    projectTemplateTable,
     projectCreatedAtIdx,
     projectUpdatedAtIdx,
     projectUuidIdx,
@@ -5022,6 +5450,8 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     taskCompletionTaskIdIdx,
     taskCompletionOccurrenceDateIdx,
     taskCompletionDeletedAtIdx,
+    projectTemplateUuidIdx,
+    projectTemplateBuiltinIdx,
   ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules([
@@ -8387,6 +8817,204 @@ typedef $$TaskCompletionTableTableProcessedTableManager =
       TaskCompletionTableData,
       PrefetchHooks Function({bool taskId})
     >;
+typedef $$ProjectTemplateTableTableCreateCompanionBuilder =
+    ProjectTemplateTableCompanion Function({
+      Value<int> id,
+      required String uuid,
+      required String name,
+      Value<String?> description,
+      Value<bool> isBuiltin,
+      required String payloadJson,
+      required DateTime createdAt,
+      required DateTime updatedAt,
+    });
+typedef $$ProjectTemplateTableTableUpdateCompanionBuilder =
+    ProjectTemplateTableCompanion Function({
+      Value<int> id,
+      Value<String> uuid,
+      Value<String> name,
+      Value<String?> description,
+      Value<bool> isBuiltin,
+      Value<String> payloadJson,
+      Value<DateTime> createdAt,
+      Value<DateTime> updatedAt,
+    });
+
+class $$ProjectTemplateTableTableFilterComposer extends Composer<_$AppDatabase, $ProjectTemplateTableTable> {
+  $$ProjectTemplateTableTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(column: $table.id, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get uuid => $composableBuilder(column: $table.uuid, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get name => $composableBuilder(column: $table.name, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get description =>
+      $composableBuilder(column: $table.description, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<bool> get isBuiltin =>
+      $composableBuilder(column: $table.isBuiltin, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get payloadJson =>
+      $composableBuilder(column: $table.payloadJson, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+}
+
+class $$ProjectTemplateTableTableOrderingComposer extends Composer<_$AppDatabase, $ProjectTemplateTableTable> {
+  $$ProjectTemplateTableTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(column: $table.id, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get uuid =>
+      $composableBuilder(column: $table.uuid, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get description =>
+      $composableBuilder(column: $table.description, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<bool> get isBuiltin =>
+      $composableBuilder(column: $table.isBuiltin, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get payloadJson =>
+      $composableBuilder(column: $table.payloadJson, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+}
+
+class $$ProjectTemplateTableTableAnnotationComposer extends Composer<_$AppDatabase, $ProjectTemplateTableTable> {
+  $$ProjectTemplateTableTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id => $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get uuid => $composableBuilder(column: $table.uuid, builder: (column) => column);
+
+  GeneratedColumn<String> get name => $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<String> get description =>
+      $composableBuilder(column: $table.description, builder: (column) => column);
+
+  GeneratedColumn<bool> get isBuiltin => $composableBuilder(column: $table.isBuiltin, builder: (column) => column);
+
+  GeneratedColumn<String> get payloadJson =>
+      $composableBuilder(column: $table.payloadJson, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt => $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt => $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+}
+
+class $$ProjectTemplateTableTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $ProjectTemplateTableTable,
+          ProjectTemplateTableData,
+          $$ProjectTemplateTableTableFilterComposer,
+          $$ProjectTemplateTableTableOrderingComposer,
+          $$ProjectTemplateTableTableAnnotationComposer,
+          $$ProjectTemplateTableTableCreateCompanionBuilder,
+          $$ProjectTemplateTableTableUpdateCompanionBuilder,
+          (
+            ProjectTemplateTableData,
+            BaseReferences<_$AppDatabase, $ProjectTemplateTableTable, ProjectTemplateTableData>,
+          ),
+          ProjectTemplateTableData,
+          PrefetchHooks Function()
+        > {
+  $$ProjectTemplateTableTableTableManager(_$AppDatabase db, $ProjectTemplateTableTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () => $$ProjectTemplateTableTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () => $$ProjectTemplateTableTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () => $$ProjectTemplateTableTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> uuid = const Value.absent(),
+                Value<String> name = const Value.absent(),
+                Value<String?> description = const Value.absent(),
+                Value<bool> isBuiltin = const Value.absent(),
+                Value<String> payloadJson = const Value.absent(),
+                Value<DateTime> createdAt = const Value.absent(),
+                Value<DateTime> updatedAt = const Value.absent(),
+              }) => ProjectTemplateTableCompanion(
+                id: id,
+                uuid: uuid,
+                name: name,
+                description: description,
+                isBuiltin: isBuiltin,
+                payloadJson: payloadJson,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String uuid,
+                required String name,
+                Value<String?> description = const Value.absent(),
+                Value<bool> isBuiltin = const Value.absent(),
+                required String payloadJson,
+                required DateTime createdAt,
+                required DateTime updatedAt,
+              }) => ProjectTemplateTableCompanion.insert(
+                id: id,
+                uuid: uuid,
+                name: name,
+                description: description,
+                isBuiltin: isBuiltin,
+                payloadJson: payloadJson,
+                createdAt: createdAt,
+                updatedAt: updatedAt,
+              ),
+          withReferenceMapper: (p0) => p0.map((e) => (e.readTable(table), BaseReferences(db, table, e))).toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$ProjectTemplateTableTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $ProjectTemplateTableTable,
+      ProjectTemplateTableData,
+      $$ProjectTemplateTableTableFilterComposer,
+      $$ProjectTemplateTableTableOrderingComposer,
+      $$ProjectTemplateTableTableAnnotationComposer,
+      $$ProjectTemplateTableTableCreateCompanionBuilder,
+      $$ProjectTemplateTableTableUpdateCompanionBuilder,
+      (ProjectTemplateTableData, BaseReferences<_$AppDatabase, $ProjectTemplateTableTable, ProjectTemplateTableData>),
+      ProjectTemplateTableData,
+      PrefetchHooks Function()
+    >;
 
 class $AppDatabaseManager {
   final _$AppDatabase _db;
@@ -8405,4 +9033,6 @@ class $AppDatabaseManager {
   $$TaskTagTableTableTableManager get taskTagTable => $$TaskTagTableTableTableManager(_db, _db.taskTagTable);
   $$TaskCompletionTableTableTableManager get taskCompletionTable =>
       $$TaskCompletionTableTableTableManager(_db, _db.taskCompletionTable);
+  $$ProjectTemplateTableTableTableManager get projectTemplateTable =>
+      $$ProjectTemplateTableTableTableManager(_db, _db.projectTemplateTable);
 }

--- a/lib/core/widgets/action_menu_button.dart
+++ b/lib/core/widgets/action_menu_button.dart
@@ -3,11 +3,14 @@ import 'package:forui/forui.dart' as fu;
 
 import '../config/theme/app_theme.dart';
 
+/// Overflow menu with optional Edit / Save as template / Delete actions.
 class ActionMenuButton extends StatelessWidget {
   final VoidCallback? onEdit;
   final VoidCallback? onDelete;
+  final VoidCallback? onSaveAsTemplate;
   final String editLabel;
   final String deleteLabel;
+  final String saveAsTemplateLabel;
   final IconData icon;
   final double iconSize;
   final Color? iconColor;
@@ -17,8 +20,10 @@ class ActionMenuButton extends StatelessWidget {
     super.key,
     this.onEdit,
     this.onDelete,
+    this.onSaveAsTemplate,
     this.editLabel = 'Edit',
     this.deleteLabel = 'Delete',
+    this.saveAsTemplateLabel = 'Save as template',
     this.icon = fu.FLucideIcons.ellipsisVertical,
     this.iconSize = 16,
     this.iconColor,
@@ -27,10 +32,9 @@ class ActionMenuButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (onEdit == null && onDelete == null) {
+    if (onEdit == null && onDelete == null && onSaveAsTemplate == null) {
       return const SizedBox.shrink();
     }
-
     return fu.FPopoverMenu(
       autofocus: true,
       menuAnchor: Alignment.topRight,
@@ -38,16 +42,24 @@ class ActionMenuButton extends StatelessWidget {
       menu: [
         fu.FItemGroup(
           children: [
-            fu.FItem(
-              prefix: const Icon(fu.FLucideIcons.pencil),
-              title: const Text('Edit'),
-              onPress: () => onEdit?.call(),
-            ),
-            fu.FItem(
-              prefix: Icon(fu.FLucideIcons.trash, color: context.colors.destructive),
-              title: Text('Delete', style: context.typography.md.copyWith(color: context.colors.destructive)),
-              onPress: () => onDelete?.call(),
-            ),
+            if (onEdit != null)
+              fu.FItem(
+                prefix: const Icon(fu.FLucideIcons.pencil),
+                title: Text(editLabel),
+                onPress: () => onEdit?.call(),
+              ),
+            if (onSaveAsTemplate != null)
+              fu.FItem(
+                prefix: const Icon(fu.FLucideIcons.layoutTemplate),
+                title: Text(saveAsTemplateLabel),
+                onPress: () => onSaveAsTemplate?.call(),
+              ),
+            if (onDelete != null)
+              fu.FItem(
+                prefix: Icon(fu.FLucideIcons.trash, color: context.colors.destructive),
+                title: Text(deleteLabel, style: context.typography.md.copyWith(color: context.colors.destructive)),
+                onPress: () => onDelete?.call(),
+              ),
           ],
         ),
       ],

--- a/lib/core/widgets/app_empty_state.dart
+++ b/lib/core/widgets/app_empty_state.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:focus/core/config/theme/app_theme.dart';
+import 'package:focus/core/constants/app_constants.dart';
+
+/// Lightweight empty-state block used across list/board/calendar surfaces.
+class AppEmptyState extends StatelessWidget {
+  final IconData icon;
+  final String message;
+  final String? detail;
+
+  const AppEmptyState({super.key, required this.icon, required this.message, this.detail});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.extraLarge2, vertical: AppConstants.spacing.large),
+      child: Center(
+        child: Column(
+          mainAxisSize: .min,
+          children: [
+            Icon(
+              icon,
+              size: AppConstants.size.icon.large * 4 / 3,
+              color: context.colors.mutedForeground.withValues(alpha: 0.4),
+            ),
+            SizedBox(height: AppConstants.spacing.regular),
+            Text(
+              message,
+              textAlign: .center,
+              style: context.typography.sm.copyWith(color: context.colors.mutedForeground),
+            ),
+            if (detail != null) ...[
+              SizedBox(height: AppConstants.spacing.extraSmall),
+              Text(
+                detail!,
+                textAlign: .center,
+                style: context.typography.xs.copyWith(color: context.colors.mutedForeground.withValues(alpha: 0.8)),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/keyboard_shortcuts.dart
+++ b/lib/core/widgets/keyboard_shortcuts.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 
 import '../routing/routes.dart';
+import '../utils/platform_utils.dart';
 
 class AppKeyboardShortcuts extends StatelessWidget {
   final Widget child;
@@ -11,12 +12,13 @@ class AppKeyboardShortcuts extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final meta = PlatformUtils.isDesktop;
     return CallbackShortcuts(
       bindings: {
-        const SingleActivator(LogicalKeyboardKey.keyN, control: true): () {
+        SingleActivator(LogicalKeyboardKey.keyN, control: !meta, meta: meta): () {
           context.push(AppRoutes.createTaskWithProject.path);
         },
-        const SingleActivator(LogicalKeyboardKey.keyP, control: true): () {
+        SingleActivator(LogicalKeyboardKey.keyP, control: !meta, meta: meta): () {
           context.push(AppRoutes.createProject.path);
         },
         const SingleActivator(LogicalKeyboardKey.space): () {

--- a/lib/features/projects/data/datasources/project_template_local_datasource.dart
+++ b/lib/features/projects/data/datasources/project_template_local_datasource.dart
@@ -1,0 +1,91 @@
+import 'package:drift/drift.dart';
+
+import '../../../../core/services/db_service.dart';
+import '../../../../core/services/log_service.dart';
+import '../mappers/project_template_extensions.dart';
+import '../../domain/entities/project_template.dart';
+
+final _log = LogService.instance;
+
+abstract class IProjectTemplateLocalDataSource {
+  Future<List<ProjectTemplateTableData>> getAllTemplates();
+
+  Future<ProjectTemplateTableData?> getTemplateById(int id);
+
+  Future<ProjectTemplateTableData?> getTemplateByUuid(String uuid);
+
+  Stream<List<ProjectTemplateTableData>> watchAllTemplates();
+
+  Future<int> createTemplate(ProjectTemplateTableCompanion companion);
+
+  Future<void> updateTemplate(ProjectTemplateTableCompanion companion);
+
+  Future<void> deleteTemplate(int id);
+
+  Future<void> ensureBuiltInTemplates(List<ProjectTemplate> builtIns);
+}
+
+class ProjectTemplateLocalDataSourceImpl implements IProjectTemplateLocalDataSource {
+  ProjectTemplateLocalDataSourceImpl(this._db);
+
+  final AppDatabase _db;
+
+  @override
+  Future<List<ProjectTemplateTableData>> getAllTemplates() {
+    return (_db.select(_db.projectTemplateTable)..orderBy([(t) => OrderingTerm.asc(t.name)])).get();
+  }
+
+  @override
+  Future<ProjectTemplateTableData?> getTemplateById(int id) {
+    return (_db.select(_db.projectTemplateTable)..where((t) => t.id.equals(id))).getSingleOrNull();
+  }
+
+  @override
+  Future<ProjectTemplateTableData?> getTemplateByUuid(String uuid) {
+    return (_db.select(_db.projectTemplateTable)..where((t) => t.uuid.equals(uuid))).getSingleOrNull();
+  }
+
+  @override
+  Stream<List<ProjectTemplateTableData>> watchAllTemplates() {
+    return (_db.select(_db.projectTemplateTable)..orderBy([(t) => OrderingTerm.asc(t.name)])).watch();
+  }
+
+  @override
+  Future<int> createTemplate(ProjectTemplateTableCompanion companion) async {
+    try {
+      return await _db.into(_db.projectTemplateTable).insert(companion);
+    } catch (e, st) {
+      _log.error('createTemplate failed', tag: 'ProjectTemplateLocalDS', error: e, stackTrace: st);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> updateTemplate(ProjectTemplateTableCompanion companion) async {
+    try {
+      await (_db.update(_db.projectTemplateTable)..where((t) => t.id.equals(companion.id.value))).write(companion);
+    } catch (e, st) {
+      _log.error('updateTemplate failed', tag: 'ProjectTemplateLocalDS', error: e, stackTrace: st);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> deleteTemplate(int id) async {
+    try {
+      await (_db.delete(_db.projectTemplateTable)..where((t) => t.id.equals(id))).go();
+    } catch (e, st) {
+      _log.error('deleteTemplate failed', tag: 'ProjectTemplateLocalDS', error: e, stackTrace: st);
+      rethrow;
+    }
+  }
+
+  @override
+  Future<void> ensureBuiltInTemplates(List<ProjectTemplate> builtIns) async {
+    for (final template in builtIns) {
+      final existing = await getTemplateByUuid(template.uuid);
+      if (existing != null) continue;
+      await createTemplate(template.toCompanion());
+    }
+  }
+}

--- a/lib/features/projects/data/mappers/project_template_extensions.dart
+++ b/lib/features/projects/data/mappers/project_template_extensions.dart
@@ -1,0 +1,44 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:focus/core/services/db_service.dart';
+
+import '../../domain/entities/project_template.dart';
+import '../../domain/entities/project_template_payload.dart';
+
+extension DbProjectTemplateToDomain on ProjectTemplateTableData {
+  ProjectTemplate toDomain() => ProjectTemplate(
+    id: id,
+    uuid: uuid,
+    name: name,
+    description: description,
+    isBuiltin: isBuiltin,
+    payload: ProjectTemplatePayload.fromJsonString(payloadJson),
+    createdAt: createdAt,
+    updatedAt: updatedAt,
+  );
+}
+
+extension DomainProjectTemplateToCompanion on ProjectTemplate {
+  ProjectTemplateTableCompanion toCompanion() {
+    if (id != null) {
+      return ProjectTemplateTableCompanion(
+        id: Value(id!),
+        uuid: Value(uuid),
+        name: Value(name),
+        description: Value(description),
+        isBuiltin: Value(isBuiltin),
+        payloadJson: Value(payload.toJsonString()),
+        createdAt: Value(createdAt),
+        updatedAt: Value(updatedAt),
+      );
+    }
+    return ProjectTemplateTableCompanion.insert(
+      uuid: uuid,
+      name: name,
+      description: Value<String?>(description),
+      isBuiltin: Value(isBuiltin),
+      payloadJson: payload.toJsonString(),
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    );
+  }
+}

--- a/lib/features/projects/data/models/project_template_model.dart
+++ b/lib/features/projects/data/models/project_template_model.dart
@@ -1,0 +1,22 @@
+import 'package:drift/drift.dart';
+
+@TableIndex(name: 'project_template_uuid_idx', columns: {#uuid}, unique: true)
+@TableIndex(name: 'project_template_builtin_idx', columns: {#isBuiltin})
+class ProjectTemplateTable extends Table {
+  IntColumn get id => integer().autoIncrement()();
+
+  TextColumn get uuid => text().unique()();
+
+  TextColumn get name => text()();
+
+  TextColumn get description => text().nullable()();
+
+  BoolColumn get isBuiltin => boolean().withDefault(const Constant(false))();
+
+  /// JSON [ProjectTemplatePayload] blob.
+  TextColumn get payloadJson => text()();
+
+  DateTimeColumn get createdAt => dateTime()();
+
+  DateTimeColumn get updatedAt => dateTime()();
+}

--- a/lib/features/projects/data/repositories/project_template_repository_impl.dart
+++ b/lib/features/projects/data/repositories/project_template_repository_impl.dart
@@ -1,0 +1,60 @@
+import '../../../../core/services/data_change_bus.dart';
+import '../../domain/entities/project_template.dart';
+import '../../domain/repositories/i_project_template_repository.dart';
+import '../datasources/project_template_local_datasource.dart';
+import '../mappers/project_template_extensions.dart';
+
+class ProjectTemplateRepositoryImpl implements IProjectTemplateRepository {
+  ProjectTemplateRepositoryImpl(this._local, this._bus);
+
+  final IProjectTemplateLocalDataSource _local;
+  final DataChangeBus _bus;
+
+  @override
+  Future<List<ProjectTemplate>> getAllTemplates() async {
+    final rows = await _local.getAllTemplates();
+    return rows.map((r) => r.toDomain()).toList();
+  }
+
+  @override
+  Future<ProjectTemplate?> getTemplateById(int id) async {
+    final row = await _local.getTemplateById(id);
+    return row?.toDomain();
+  }
+
+  @override
+  Future<ProjectTemplate?> getTemplateByUuid(String uuid) async {
+    final row = await _local.getTemplateByUuid(uuid);
+    return row?.toDomain();
+  }
+
+  @override
+  Stream<List<ProjectTemplate>> watchAllTemplates() {
+    return _local.watchAllTemplates().map((rows) => rows.map((r) => r.toDomain()).toList());
+  }
+
+  @override
+  Future<ProjectTemplate> createTemplate(ProjectTemplate template) async {
+    final id = await _local.createTemplate(template.toCompanion());
+    _bus.notify();
+    final created = await _local.getTemplateById(id);
+    return created!.toDomain();
+  }
+
+  @override
+  Future<void> updateTemplate(ProjectTemplate template) async {
+    await _local.updateTemplate(template.toCompanion());
+    _bus.notify();
+  }
+
+  @override
+  Future<void> deleteTemplate(int id) async {
+    await _local.deleteTemplate(id);
+    _bus.notify();
+  }
+
+  @override
+  Future<void> ensureBuiltInTemplates(List<ProjectTemplate> builtIns) {
+    return _local.ensureBuiltInTemplates(builtIns);
+  }
+}

--- a/lib/features/projects/domain/entities/built_in_templates.dart
+++ b/lib/features/projects/domain/entities/built_in_templates.dart
@@ -1,0 +1,232 @@
+import '../../../../core/utils/id_utils.dart';
+import 'project_template.dart';
+import 'project_template_payload.dart';
+
+/// Stable seed UUIDs for built-in templates (idempotent migration inserts).
+abstract final class BuiltInTemplateIds {
+  static const productLaunch = 'tpl-builtin-product-launch-0001';
+  static const contentSprint = 'tpl-builtin-content-sprint-0002';
+  static const studyPlan = 'tpl-builtin-study-plan-0003';
+}
+
+/// Factory for the shipped built-in project templates.
+abstract final class BuiltInTemplates {
+  static List<ProjectTemplate> all({DateTime? now}) {
+    final stamp = now ?? DateTime.fromMillisecondsSinceEpoch(0, isUtc: true);
+    return [_productLaunch(stamp), _contentSprint(stamp), _studyPlan(stamp)];
+  }
+
+  static ProjectTemplate _productLaunch(DateTime stamp) {
+    return ProjectTemplate(
+      uuid: BuiltInTemplateIds.productLaunch,
+      name: 'Product Launch',
+      description: 'Milestones and tasks for shipping a product release.',
+      isBuiltin: true,
+      payload: const ProjectTemplatePayload(
+        defaultTitle: 'Product Launch',
+        defaultDescription: 'Plan, build, and ship a release.',
+        milestones: [
+          TemplateMilestoneSpec(key: 'm0', title: 'Kickoff', targetOffsetDays: 0),
+          TemplateMilestoneSpec(key: 'm1', title: 'Beta', targetOffsetDays: 21),
+          TemplateMilestoneSpec(key: 'm2', title: 'Launch', targetOffsetDays: 35),
+        ],
+        tags: [
+          TemplateTagSpec(key: 'g0', name: 'launch'),
+          TemplateTagSpec(key: 'g1', name: 'marketing'),
+        ],
+        tasks: [
+          TemplateTaskSpec(
+            key: 't0',
+            title: 'Define goals & success metrics',
+            priorityIndex: 1,
+            estimatedMinutes: 90,
+            sortOrder: 0,
+            endOffsetDays: 3,
+            tagKeys: ['g0'],
+            milestoneKey: 'm0',
+          ),
+          TemplateTaskSpec(
+            key: 't1',
+            title: 'Build MVP features',
+            priorityIndex: 0,
+            estimatedMinutes: 480,
+            sortOrder: 1000,
+            startOffsetDays: 3,
+            endOffsetDays: 21,
+            tagKeys: ['g0'],
+            milestoneKey: 'm1',
+          ),
+          TemplateTaskSpec(
+            key: 't2',
+            title: 'Draft launch announcement',
+            priorityIndex: 2,
+            estimatedMinutes: 120,
+            sortOrder: 2000,
+            startOffsetDays: 14,
+            endOffsetDays: 28,
+            tagKeys: ['g1'],
+            milestoneKey: 'm2',
+          ),
+          TemplateTaskSpec(
+            key: 't3',
+            title: 'QA & polish pass',
+            priorityIndex: 1,
+            estimatedMinutes: 240,
+            sortOrder: 3000,
+            startOffsetDays: 21,
+            endOffsetDays: 32,
+            tagKeys: ['g0'],
+            milestoneKey: 'm2',
+          ),
+        ],
+      ),
+      createdAt: stamp,
+      updatedAt: stamp,
+    );
+  }
+
+  static ProjectTemplate _contentSprint(DateTime stamp) {
+    return ProjectTemplate(
+      uuid: BuiltInTemplateIds.contentSprint,
+      name: 'Content Sprint',
+      description: 'Two-week content production board with a weekly habit.',
+      isBuiltin: true,
+      payload: ProjectTemplatePayload(
+        defaultTitle: 'Content Sprint',
+        defaultDescription: 'Plan, produce, and publish content in two weeks.',
+        milestones: const [
+          TemplateMilestoneSpec(key: 'm0', title: 'Outline complete', targetOffsetDays: 3),
+          TemplateMilestoneSpec(key: 'm1', title: 'Publish', targetOffsetDays: 14),
+        ],
+        tags: const [
+          TemplateTagSpec(key: 'g0', name: 'content'),
+          TemplateTagSpec(key: 'g1', name: 'writing'),
+        ],
+        tasks: [
+          const TemplateTaskSpec(
+            key: 't0',
+            title: 'Topic research',
+            priorityIndex: 1,
+            estimatedMinutes: 120,
+            sortOrder: 0,
+            endOffsetDays: 2,
+            tagKeys: ['g0'],
+            milestoneKey: 'm0',
+          ),
+          const TemplateTaskSpec(
+            key: 't1',
+            title: 'Write first draft',
+            priorityIndex: 1,
+            estimatedMinutes: 180,
+            sortOrder: 1000,
+            startOffsetDays: 2,
+            endOffsetDays: 7,
+            tagKeys: ['g1'],
+          ),
+          const TemplateTaskSpec(
+            key: 't2',
+            title: 'Edit & design assets',
+            priorityIndex: 2,
+            estimatedMinutes: 150,
+            sortOrder: 2000,
+            startOffsetDays: 7,
+            endOffsetDays: 12,
+            tagKeys: ['g0'],
+            milestoneKey: 'm1',
+          ),
+          TemplateTaskSpec(
+            key: 't3',
+            title: 'Daily writing habit',
+            priorityIndex: 2,
+            estimatedMinutes: 30,
+            sortOrder: 3000,
+            startOffsetDays: 0,
+            endOffsetDays: 14,
+            tagKeys: const ['g1'],
+            isHabit: true,
+            recurrenceRuleJson: const {'frequency': 'daily', 'interval': 1},
+          ),
+        ],
+      ),
+      createdAt: stamp,
+      updatedAt: stamp,
+    );
+  }
+
+  static ProjectTemplate _studyPlan(DateTime stamp) {
+    return ProjectTemplate(
+      uuid: BuiltInTemplateIds.studyPlan,
+      name: 'Study Plan',
+      description: 'Exam prep with weekly review habits and milestones.',
+      isBuiltin: true,
+      payload: ProjectTemplatePayload(
+        defaultTitle: 'Study Plan',
+        defaultDescription: 'Structured study toward an exam or certification.',
+        milestones: const [
+          TemplateMilestoneSpec(key: 'm0', title: 'Syllabus mapped', targetOffsetDays: 7),
+          TemplateMilestoneSpec(key: 'm1', title: 'Practice exam', targetOffsetDays: 28),
+          TemplateMilestoneSpec(key: 'm2', title: 'Exam day', targetOffsetDays: 42),
+        ],
+        tags: const [
+          TemplateTagSpec(key: 'g0', name: 'study'),
+          TemplateTagSpec(key: 'g1', name: 'exam'),
+        ],
+        tasks: [
+          const TemplateTaskSpec(
+            key: 't0',
+            title: 'Map syllabus & resources',
+            priorityIndex: 1,
+            estimatedMinutes: 90,
+            sortOrder: 0,
+            endOffsetDays: 5,
+            tagKeys: ['g0'],
+            milestoneKey: 'm0',
+          ),
+          TemplateTaskSpec(
+            key: 't1',
+            title: 'Weekly review session',
+            priorityIndex: 1,
+            estimatedMinutes: 60,
+            sortOrder: 1000,
+            startOffsetDays: 0,
+            endOffsetDays: 42,
+            tagKeys: const ['g0'],
+            isHabit: true,
+            recurrenceRuleJson: {
+              'frequency': 'weekly',
+              'interval': 1,
+              'byWeekday': [6],
+            },
+          ),
+          const TemplateTaskSpec(
+            key: 't2',
+            title: 'Complete practice exam',
+            priorityIndex: 0,
+            estimatedMinutes: 180,
+            sortOrder: 2000,
+            startOffsetDays: 21,
+            endOffsetDays: 28,
+            tagKeys: ['g1'],
+            milestoneKey: 'm1',
+          ),
+          const TemplateTaskSpec(
+            key: 't3',
+            title: 'Final review & rest',
+            priorityIndex: 2,
+            estimatedMinutes: 120,
+            sortOrder: 3000,
+            startOffsetDays: 35,
+            endOffsetDays: 41,
+            tagKeys: ['g1'],
+            milestoneKey: 'm2',
+          ),
+        ],
+      ),
+      createdAt: stamp,
+      updatedAt: stamp,
+    );
+  }
+
+  /// Ensures built-in UUIDs are valid for storage (no generateUuid needed).
+  static String ensureUuid(String id) => id.isEmpty ? generateUuid() : id;
+}

--- a/lib/features/projects/domain/entities/project_template.dart
+++ b/lib/features/projects/domain/entities/project_template.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+import 'project_template_payload.dart';
+
+/// Stored project template (built-in or user-saved).
+@immutable
+class ProjectTemplate extends Equatable {
+  final int? id;
+  final String uuid;
+  final String name;
+  final String? description;
+  final bool isBuiltin;
+  final ProjectTemplatePayload payload;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  const ProjectTemplate({
+    this.id,
+    required this.uuid,
+    required this.name,
+    this.description,
+    this.isBuiltin = false,
+    required this.payload,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  @override
+  List<Object?> get props => [id, uuid, name, description, isBuiltin, payload, createdAt, updatedAt];
+}

--- a/lib/features/projects/domain/entities/project_template_extensions.dart
+++ b/lib/features/projects/domain/entities/project_template_extensions.dart
@@ -1,0 +1,26 @@
+import 'project_template.dart';
+import 'project_template_payload.dart';
+
+extension ProjectTemplateCopyWith on ProjectTemplate {
+  ProjectTemplate copyWith({
+    int? id,
+    String? uuid,
+    String? name,
+    String? description,
+    bool? isBuiltin,
+    ProjectTemplatePayload? payload,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return ProjectTemplate(
+      id: id ?? this.id,
+      uuid: uuid ?? this.uuid,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      isBuiltin: isBuiltin ?? this.isBuiltin,
+      payload: payload ?? this.payload,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}

--- a/lib/features/projects/domain/entities/project_template_payload.dart
+++ b/lib/features/projects/domain/entities/project_template_payload.dart
@@ -1,0 +1,333 @@
+import 'dart:convert';
+
+import 'package:equatable/equatable.dart';
+import 'package:meta/meta.dart';
+
+import '../../../milestones/domain/entities/milestone.dart';
+import '../../../tags/domain/entities/tag.dart';
+import '../../../tasks/domain/entities/recurrence_rule.dart';
+import '../../../tasks/domain/entities/task.dart';
+import '../../../tasks/domain/entities/task_priority.dart';
+import '../../../tasks/domain/entities/task_status.dart';
+import 'project.dart';
+
+/// JSON schema version for [ProjectTemplatePayload].
+const int kProjectTemplatePayloadVersion = 1;
+
+/// Serializable blueprint of a project's structure (tasks, milestones, tags,
+/// recurrence) with relative date offsets so it can be reapplied later.
+@immutable
+class ProjectTemplatePayload extends Equatable {
+  final int version;
+  final String? defaultTitle;
+  final String? defaultDescription;
+  final int? color;
+  final List<TemplateMilestoneSpec> milestones;
+  final List<TemplateTagSpec> tags;
+  final List<TemplateTaskSpec> tasks;
+
+  const ProjectTemplatePayload({
+    this.version = kProjectTemplatePayloadVersion,
+    this.defaultTitle,
+    this.defaultDescription,
+    this.color,
+    this.milestones = const [],
+    this.tags = const [],
+    this.tasks = const [],
+  });
+
+  factory ProjectTemplatePayload.fromJson(Map<String, dynamic> json) {
+    return ProjectTemplatePayload(
+      version: (json['version'] as int?) ?? kProjectTemplatePayloadVersion,
+      defaultTitle: json['defaultTitle'] as String?,
+      defaultDescription: json['defaultDescription'] as String?,
+      color: json['color'] as int?,
+      milestones: (json['milestones'] as List<dynamic>? ?? const [])
+          .map((e) => TemplateMilestoneSpec.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      tags: (json['tags'] as List<dynamic>? ?? const [])
+          .map((e) => TemplateTagSpec.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      tasks: (json['tasks'] as List<dynamic>? ?? const [])
+          .map((e) => TemplateTaskSpec.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  factory ProjectTemplatePayload.fromJsonString(String raw) {
+    return ProjectTemplatePayload.fromJson(jsonDecode(raw) as Map<String, dynamic>);
+  }
+
+  Map<String, dynamic> toJson() => {
+    'version': version,
+    'defaultTitle': defaultTitle,
+    'defaultDescription': defaultDescription,
+    'color': color,
+    'milestones': milestones.map((m) => m.toJson()).toList(),
+    'tags': tags.map((t) => t.toJson()).toList(),
+    'tasks': tasks.map((t) => t.toJson()).toList(),
+  };
+
+  String toJsonString() => jsonEncode(toJson());
+
+  /// Captures a live project into a reusable template payload.
+  ///
+  /// Dates become offsets from [anchor] (project start, else earliest dated
+  /// task/milestone, else [fallbackNow]).
+  static ProjectTemplatePayload capture({
+    required Project project,
+    required List<Task> tasks,
+    required List<Milestone> milestones,
+    required Map<int, List<Tag>> tagsByTaskId,
+    DateTime? fallbackNow,
+  }) {
+    final now = fallbackNow ?? DateTime.now();
+    final liveTasks = tasks.where((t) => t.deletedAt == null).toList();
+    final liveMilestones = milestones.where((m) => m.deletedAt == null).toList();
+    final anchor = _resolveAnchor(
+      projectStart: project.startDate,
+      tasks: liveTasks,
+      milestones: liveMilestones,
+      fallback: now,
+    );
+    final milestoneKeyById = <int, String>{
+      for (var i = 0; i < liveMilestones.length; i++)
+        if (liveMilestones[i].id != null) liveMilestones[i].id!: 'm$i',
+    };
+    final taskKeyById = <int, String>{
+      for (var i = 0; i < liveTasks.length; i++)
+        if (liveTasks[i].id != null) liveTasks[i].id!: 't$i',
+    };
+    final tagByUuid = <String, Tag>{};
+    for (final list in tagsByTaskId.values) {
+      for (final tag in list) {
+        if (tag.deletedAt == null) tagByUuid[tag.uuid] = tag;
+      }
+    }
+    final tags = tagByUuid.values.toList();
+    final tagKeyByUuid = <String, String>{for (var i = 0; i < tags.length; i++) tags[i].uuid: 'g$i'};
+    return ProjectTemplatePayload(
+      defaultTitle: project.title,
+      defaultDescription: project.description,
+      color: project.color,
+      milestones: [
+        for (final m in liveMilestones)
+          if (m.id != null)
+            TemplateMilestoneSpec(
+              key: milestoneKeyById[m.id]!,
+              title: m.title,
+              targetOffsetDays: m.targetDate == null ? null : _offsetDays(anchor, m.targetDate!),
+            ),
+      ],
+      tags: [for (final tag in tags) TemplateTagSpec(key: tagKeyByUuid[tag.uuid]!, name: tag.name, color: tag.color)],
+      tasks: [
+        for (final task in liveTasks)
+          if (task.id != null)
+            TemplateTaskSpec(
+              key: taskKeyById[task.id]!,
+              title: task.title,
+              description: task.description,
+              priorityIndex: task.priority.index,
+              statusIndex: TaskStatus.todo.index,
+              estimatedMinutes: task.estimatedMinutes,
+              sortOrder: task.sortOrder,
+              depth: task.depth,
+              parentKey: task.parentTaskId == null ? null : taskKeyById[task.parentTaskId],
+              milestoneKey: task.milestoneId == null ? null : milestoneKeyById[task.milestoneId],
+              tagKeys: [
+                for (final tag in tagsByTaskId[task.id] ?? const <Tag>[])
+                  if (tag.deletedAt == null) tagKeyByUuid[tag.uuid]!,
+              ],
+              startOffsetDays: task.startDate == null ? null : _offsetDays(anchor, task.startDate!),
+              endOffsetDays: task.endDate == null ? null : _offsetDays(anchor, task.endDate!),
+              recurrenceRuleJson: task.recurrenceRule?.toMap(),
+              isHabit: task.isHabit,
+            ),
+      ],
+    );
+  }
+
+  static DateTime _resolveAnchor({
+    required DateTime? projectStart,
+    required List<Task> tasks,
+    required List<Milestone> milestones,
+    required DateTime fallback,
+  }) {
+    if (projectStart != null) return DateTime(projectStart.year, projectStart.month, projectStart.day);
+    final dates = <DateTime>[
+      for (final t in tasks) ...[if (t.startDate != null) t.startDate!, if (t.endDate != null) t.endDate!],
+      for (final m in milestones)
+        if (m.targetDate != null) m.targetDate!,
+    ];
+    if (dates.isEmpty) return DateTime(fallback.year, fallback.month, fallback.day);
+    dates.sort();
+    final first = dates.first;
+    return DateTime(first.year, first.month, first.day);
+  }
+
+  static int _offsetDays(DateTime anchor, DateTime date) {
+    final a = DateTime(anchor.year, anchor.month, anchor.day);
+    final d = DateTime(date.year, date.month, date.day);
+    return d.difference(a).inDays;
+  }
+
+  @override
+  List<Object?> get props => [version, defaultTitle, defaultDescription, color, milestones, tags, tasks];
+}
+
+@immutable
+class TemplateMilestoneSpec extends Equatable {
+  final String key;
+  final String title;
+  final int? targetOffsetDays;
+
+  const TemplateMilestoneSpec({required this.key, required this.title, this.targetOffsetDays});
+
+  factory TemplateMilestoneSpec.fromJson(Map<String, dynamic> json) => TemplateMilestoneSpec(
+    key: json['key'] as String,
+    title: json['title'] as String,
+    targetOffsetDays: json['targetOffsetDays'] as int?,
+  );
+
+  Map<String, dynamic> toJson() => {'key': key, 'title': title, 'targetOffsetDays': targetOffsetDays};
+
+  DateTime? resolveDate(DateTime anchor) {
+    if (targetOffsetDays == null) return null;
+    return DateTime(anchor.year, anchor.month, anchor.day).add(Duration(days: targetOffsetDays!));
+  }
+
+  @override
+  List<Object?> get props => [key, title, targetOffsetDays];
+}
+
+@immutable
+class TemplateTagSpec extends Equatable {
+  final String key;
+  final String name;
+  final int? color;
+
+  const TemplateTagSpec({required this.key, required this.name, this.color});
+
+  factory TemplateTagSpec.fromJson(Map<String, dynamic> json) =>
+      TemplateTagSpec(key: json['key'] as String, name: json['name'] as String, color: json['color'] as int?);
+
+  Map<String, dynamic> toJson() => {'key': key, 'name': name, 'color': color};
+
+  @override
+  List<Object?> get props => [key, name, color];
+}
+
+@immutable
+class TemplateTaskSpec extends Equatable {
+  final String key;
+  final String title;
+  final String? description;
+  final int priorityIndex;
+  final int statusIndex;
+  final int? estimatedMinutes;
+  final double sortOrder;
+  final int depth;
+  final String? parentKey;
+  final String? milestoneKey;
+  final List<String> tagKeys;
+  final int? startOffsetDays;
+  final int? endOffsetDays;
+  final Map<String, dynamic>? recurrenceRuleJson;
+  final bool isHabit;
+
+  const TemplateTaskSpec({
+    required this.key,
+    required this.title,
+    this.description,
+    this.priorityIndex = 2,
+    this.statusIndex = 0,
+    this.estimatedMinutes,
+    this.sortOrder = 0,
+    this.depth = 0,
+    this.parentKey,
+    this.milestoneKey,
+    this.tagKeys = const [],
+    this.startOffsetDays,
+    this.endOffsetDays,
+    this.recurrenceRuleJson,
+    this.isHabit = false,
+  });
+
+  factory TemplateTaskSpec.fromJson(Map<String, dynamic> json) => TemplateTaskSpec(
+    key: json['key'] as String,
+    title: json['title'] as String,
+    description: json['description'] as String?,
+    priorityIndex: (json['priorityIndex'] as int?) ?? TaskPriority.medium.index,
+    statusIndex: (json['statusIndex'] as int?) ?? TaskStatus.todo.index,
+    estimatedMinutes: json['estimatedMinutes'] as int?,
+    sortOrder: (json['sortOrder'] as num?)?.toDouble() ?? 0,
+    depth: (json['depth'] as int?) ?? 0,
+    parentKey: json['parentKey'] as String?,
+    milestoneKey: json['milestoneKey'] as String?,
+    tagKeys: (json['tagKeys'] as List<dynamic>? ?? const []).cast<String>(),
+    startOffsetDays: json['startOffsetDays'] as int?,
+    endOffsetDays: json['endOffsetDays'] as int?,
+    recurrenceRuleJson: json['recurrenceRule'] as Map<String, dynamic>?,
+    isHabit: (json['isHabit'] as bool?) ?? false,
+  );
+
+  Map<String, dynamic> toJson() => {
+    'key': key,
+    'title': title,
+    'description': description,
+    'priorityIndex': priorityIndex,
+    'statusIndex': statusIndex,
+    'estimatedMinutes': estimatedMinutes,
+    'sortOrder': sortOrder,
+    'depth': depth,
+    'parentKey': parentKey,
+    'milestoneKey': milestoneKey,
+    'tagKeys': tagKeys,
+    'startOffsetDays': startOffsetDays,
+    'endOffsetDays': endOffsetDays,
+    'recurrenceRule': recurrenceRuleJson,
+    'isHabit': isHabit,
+  };
+
+  TaskPriority get priority {
+    final values = TaskPriority.values;
+    if (priorityIndex < 0 || priorityIndex >= values.length) return TaskPriority.medium;
+    return values[priorityIndex];
+  }
+
+  TaskStatus get status {
+    final values = TaskStatus.values;
+    if (statusIndex < 0 || statusIndex >= values.length) return TaskStatus.todo;
+    return values[statusIndex];
+  }
+
+  RecurrenceRule? get recurrenceRule => RecurrenceRule.tryParse(recurrenceRuleJson);
+
+  DateTime? resolveStart(DateTime anchor) => _offsetToDate(anchor, startOffsetDays);
+
+  DateTime? resolveEnd(DateTime anchor) => _offsetToDate(anchor, endOffsetDays);
+
+  static DateTime? _offsetToDate(DateTime anchor, int? offsetDays) {
+    if (offsetDays == null) return null;
+    return DateTime(anchor.year, anchor.month, anchor.day).add(Duration(days: offsetDays));
+  }
+
+  @override
+  List<Object?> get props => [
+    key,
+    title,
+    description,
+    priorityIndex,
+    statusIndex,
+    estimatedMinutes,
+    sortOrder,
+    depth,
+    parentKey,
+    milestoneKey,
+    tagKeys,
+    startOffsetDays,
+    endOffsetDays,
+    recurrenceRuleJson,
+    isHabit,
+  ];
+}

--- a/lib/features/projects/domain/repositories/i_project_template_repository.dart
+++ b/lib/features/projects/domain/repositories/i_project_template_repository.dart
@@ -1,0 +1,20 @@
+import '../entities/project_template.dart';
+
+abstract class IProjectTemplateRepository {
+  Future<List<ProjectTemplate>> getAllTemplates();
+
+  Future<ProjectTemplate?> getTemplateById(int id);
+
+  Future<ProjectTemplate?> getTemplateByUuid(String uuid);
+
+  Stream<List<ProjectTemplate>> watchAllTemplates();
+
+  Future<ProjectTemplate> createTemplate(ProjectTemplate template);
+
+  Future<void> updateTemplate(ProjectTemplate template);
+
+  Future<void> deleteTemplate(int id);
+
+  /// Inserts built-in templates that are missing by UUID (idempotent).
+  Future<void> ensureBuiltInTemplates(List<ProjectTemplate> builtIns);
+}

--- a/lib/features/projects/domain/services/project_template_service.dart
+++ b/lib/features/projects/domain/services/project_template_service.dart
@@ -1,0 +1,232 @@
+import '../../../../core/services/log_service.dart';
+import '../../../../core/utils/id_utils.dart';
+import '../../../../core/utils/result.dart';
+import '../../../milestones/domain/services/milestone_service.dart';
+import '../../../tags/domain/entities/tag.dart';
+import '../../../tags/domain/services/tag_service.dart';
+import '../../../tasks/domain/entities/task.dart';
+import '../../../tasks/domain/services/task_service.dart';
+import '../entities/built_in_templates.dart';
+import '../entities/project.dart';
+import '../entities/project_template.dart';
+import '../entities/project_template_payload.dart';
+import '../repositories/i_project_repository.dart';
+import '../repositories/i_project_template_repository.dart';
+import 'project_service.dart';
+
+final _log = LogService.instance;
+
+/// Orchestrates saving projects as templates and applying templates to new projects.
+class ProjectTemplateService {
+  ProjectTemplateService(
+    this._templates,
+    this._projects,
+    this._projectService,
+    this._tasks,
+    this._milestones,
+    this._tags,
+  );
+
+  final IProjectTemplateRepository _templates;
+  final IProjectRepository _projects;
+  final ProjectService _projectService;
+  final TaskService _tasks;
+  final MilestoneService _milestones;
+  final TagService _tags;
+
+  Future<List<ProjectTemplate>> getAllTemplates() => _templates.getAllTemplates();
+
+  Stream<List<ProjectTemplate>> watchAllTemplates() => _templates.watchAllTemplates();
+
+  Future<ProjectTemplate?> getTemplateById(int id) => _templates.getTemplateById(id);
+
+  /// Seeds built-in templates if missing (safe to call on startup).
+  Future<void> ensureBuiltIns() => _templates.ensureBuiltInTemplates(BuiltInTemplates.all());
+
+  Future<Result<ProjectTemplate>> saveProjectAsTemplate({
+    required int projectId,
+    required String name,
+    String? description,
+  }) async {
+    try {
+      final project = await _projects.getProjectById(projectId);
+      if (project == null) {
+        return const Failure(NotFoundFailure('Project not found'));
+      }
+      final tasks = await _tasks.getTasksByProjectId(projectId);
+      final milestones = await _milestones.getMilestonesByProjectId(projectId);
+      final tagsByTaskId = <int, List<Tag>>{};
+      for (final task in tasks) {
+        if (task.id == null) continue;
+        tagsByTaskId[task.id!] = await _tags.getTagsForTask(task.id!);
+      }
+      final payload = ProjectTemplatePayload.capture(
+        project: project,
+        tasks: tasks,
+        milestones: milestones,
+        tagsByTaskId: tagsByTaskId,
+      );
+      final now = DateTime.now();
+      final template = ProjectTemplate(
+        uuid: generateUuid(),
+        name: name.trim().isEmpty ? project.title : name.trim(),
+        description: description?.trim().isEmpty == true ? null : description?.trim(),
+        isBuiltin: false,
+        payload: payload,
+        createdAt: now,
+        updatedAt: now,
+      );
+      final created = await _templates.createTemplate(template);
+      _log.info('Saved project $projectId as template "${created.name}"', tag: 'ProjectTemplateService');
+      return Success(created);
+    } catch (e, st) {
+      _log.error(
+        'Failed to save project $projectId as template',
+        tag: 'ProjectTemplateService',
+        error: e,
+        stackTrace: st,
+      );
+      return Failure(DatabaseFailure('Failed to save template', error: e, stackTrace: st));
+    }
+  }
+
+  /// Creates a project from [template], materializing milestones, tags, and tasks.
+  Future<Result<Project>> applyTemplate({
+    required ProjectTemplate template,
+    required String title,
+    String? description,
+    DateTime? startDate,
+    DateTime? deadline,
+  }) async {
+    try {
+      final payload = template.payload;
+      final projectResult = await _projectService.createProject(
+        title: title,
+        description: description ?? payload.defaultDescription,
+        color: payload.color,
+        startDate: startDate,
+        deadline: deadline,
+      );
+      late final Project project;
+      switch (projectResult) {
+        case Success(:final value):
+          project = value;
+        case Failure(:final failure):
+          return Failure(failure);
+      }
+      final projectId = project.id;
+      if (projectId == null) {
+        return const Failure(DatabaseFailure('Created project missing id'));
+      }
+      final anchor = startDate != null
+          ? DateTime(startDate.year, startDate.month, startDate.day)
+          : DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
+      final milestoneIdByKey = <String, int>{};
+      for (final spec in payload.milestones) {
+        final result = await _milestones.createMilestone(
+          projectId: projectId,
+          title: spec.title,
+          targetDate: spec.resolveDate(anchor),
+        );
+        switch (result) {
+          case Success(:final value):
+            if (value.id != null) milestoneIdByKey[spec.key] = value.id!;
+          case Failure(:final failure):
+            return Failure(failure);
+        }
+      }
+      final tagIdByKey = <String, int>{};
+      final existingTags = await _tags.getAllTags();
+      final existingByName = <String, Tag>{for (final t in existingTags) t.name.toLowerCase(): t};
+      for (final spec in payload.tags) {
+        final existing = existingByName[spec.name.toLowerCase()];
+        if (existing?.id != null) {
+          tagIdByKey[spec.key] = existing!.id!;
+          continue;
+        }
+        final result = await _tags.createTag(name: spec.name, color: spec.color);
+        switch (result) {
+          case Success(:final value):
+            if (value.id != null) {
+              tagIdByKey[spec.key] = value.id!;
+              existingByName[spec.name.toLowerCase()] = value;
+            }
+          case Failure(:final failure):
+            return Failure(failure);
+        }
+      }
+      final sortedTasks = [...payload.tasks]
+        ..sort((a, b) {
+          final depthCmp = a.depth.compareTo(b.depth);
+          if (depthCmp != 0) return depthCmp;
+          return a.sortOrder.compareTo(b.sortOrder);
+        });
+      final taskIdByKey = <String, int>{};
+      for (final spec in sortedTasks) {
+        final parentId = spec.parentKey == null ? null : taskIdByKey[spec.parentKey];
+        final milestoneId = spec.milestoneKey == null ? null : milestoneIdByKey[spec.milestoneKey];
+        final start = spec.resolveStart(anchor);
+        final end = spec.resolveEnd(anchor);
+        final result = await _tasks.createTask(
+          projectId: projectId,
+          parentTaskId: parentId,
+          title: spec.title,
+          description: spec.description,
+          priority: spec.priority,
+          status: spec.status,
+          startDate: start,
+          endDate: end,
+          estimatedMinutes: spec.estimatedMinutes,
+          sortOrder: spec.sortOrder,
+          milestoneId: milestoneId,
+          recurrenceRule: spec.recurrenceRule,
+          recurrenceAnchorDate: spec.recurrenceRule == null ? null : (start ?? anchor),
+          isHabit: spec.isHabit,
+          depth: spec.depth,
+        );
+        late final Task created;
+        switch (result) {
+          case Success(:final value):
+            created = value;
+          case Failure(:final failure):
+            return Failure(failure);
+        }
+        if (created.id != null) {
+          taskIdByKey[spec.key] = created.id!;
+          final tagIds = [
+            for (final key in spec.tagKeys)
+              if (tagIdByKey.containsKey(key)) tagIdByKey[key]!,
+          ];
+          if (tagIds.isNotEmpty) {
+            final tagResult = await _tags.setTaskTags(created.id!, tagIds);
+            if (tagResult case Failure(:final failure)) return Failure(failure);
+          }
+        }
+      }
+      _log.info(
+        'Applied template "${template.name}" → project $projectId '
+        '(${payload.tasks.length} tasks, ${payload.milestones.length} milestones)',
+        tag: 'ProjectTemplateService',
+      );
+      return Success(project);
+    } catch (e, st) {
+      _log.error('Failed to apply template ${template.uuid}', tag: 'ProjectTemplateService', error: e, stackTrace: st);
+      return Failure(DatabaseFailure('Failed to apply template', error: e, stackTrace: st));
+    }
+  }
+
+  Future<Result<void>> deleteTemplate(int id) async {
+    try {
+      final existing = await _templates.getTemplateById(id);
+      if (existing == null) return const Failure(NotFoundFailure('Template not found'));
+      if (existing.isBuiltin) {
+        return const Failure(UnexpectedFailure('Built-in templates cannot be deleted'));
+      }
+      await _templates.deleteTemplate(id);
+      return const Success(null);
+    } catch (e, st) {
+      _log.error('Failed to delete template $id', tag: 'ProjectTemplateService', error: e, stackTrace: st);
+      return Failure(DatabaseFailure('Failed to delete template', error: e, stackTrace: st));
+    }
+  }
+}

--- a/lib/features/projects/presentation/commands/project_commands.dart
+++ b/lib/features/projects/presentation/commands/project_commands.dart
@@ -3,8 +3,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:focus/core/widgets/confirmation_dialog.dart';
 import 'package:focus/core/routing/routes.dart';
+import 'package:focus/core/utils/result.dart';
 import 'package:focus/features/projects/domain/entities/project.dart';
 import 'package:focus/features/projects/presentation/providers/project_provider.dart';
+import 'package:focus/features/projects/presentation/providers/project_template_provider.dart';
 
 class ProjectCommands {
   static void create(BuildContext context) {
@@ -18,7 +20,6 @@ class ProjectCommands {
 
   static Future<void> delete(BuildContext context, WidgetRef ref, Project project, {VoidCallback? onDeleted}) async {
     if (project.id == null) return;
-
     await ConfirmationDialog.show(
       context,
       title: 'Delete Project',
@@ -28,5 +29,37 @@ class ProjectCommands {
         onDeleted?.call();
       },
     );
+  }
+
+  static Future<void> saveAsTemplate(BuildContext context, WidgetRef ref, Project project) async {
+    if (project.id == null) return;
+    final controller = TextEditingController(text: '${project.title} Template');
+    final name = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Save as template'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          decoration: const InputDecoration(hintText: 'Template name'),
+          onSubmitted: (value) => Navigator.of(context).pop(value.trim()),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(context).pop(), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.of(context).pop(controller.text.trim()), child: const Text('Save')),
+        ],
+      ),
+    );
+    if (name == null || name.isEmpty) return;
+    final result = await ref
+        .read(projectTemplateServiceProvider)
+        .saveProjectAsTemplate(projectId: project.id!, name: name);
+    if (!context.mounted) return;
+    switch (result) {
+      case Success(:final value):
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Saved template "${value.name}"')));
+      case Failure(:final failure):
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(failure.message)));
+    }
   }
 }

--- a/lib/features/projects/presentation/providers/project_notifier_provider.part.dart
+++ b/lib/features/projects/presentation/providers/project_notifier_provider.part.dart
@@ -62,4 +62,6 @@ class ProjectNotifier extends _$ProjectNotifier {
         state = AsyncValue.error(failure, StackTrace.current);
     }
   }
+
+  Future<void> reload() => _loadProjects();
 }

--- a/lib/features/projects/presentation/providers/project_provider.g.dart
+++ b/lib/features/projects/presentation/providers/project_provider.g.dart
@@ -85,7 +85,7 @@ final class ProjectNotifierProvider extends $NotifierProvider<ProjectNotifier, A
   }
 }
 
-String _$projectNotifierHash() => r'cc1fe02046a9f7eb31e97dca48dd73976787ac57';
+String _$projectNotifierHash() => r'1a713bde5e2a44511ae06d96d68744f558898af2';
 
 abstract class _$ProjectNotifier extends $Notifier<AsyncValue<List<Project>>> {
   AsyncValue<List<Project>> build();

--- a/lib/features/projects/presentation/providers/project_template_provider.dart
+++ b/lib/features/projects/presentation/providers/project_template_provider.dart
@@ -1,0 +1,17 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../../../core/di/injection.dart';
+import '../../domain/entities/project_template.dart';
+import '../../domain/services/project_template_service.dart';
+
+part 'project_template_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+ProjectTemplateService projectTemplateService(Ref ref) {
+  return getIt<ProjectTemplateService>();
+}
+
+@Riverpod(keepAlive: true)
+Stream<List<ProjectTemplate>> projectTemplates(Ref ref) {
+  return ref.watch(projectTemplateServiceProvider).watchAllTemplates();
+}

--- a/lib/features/projects/presentation/providers/project_template_provider.g.dart
+++ b/lib/features/projects/presentation/providers/project_template_provider.g.dart
@@ -1,0 +1,80 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'project_template_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(projectTemplateService)
+final projectTemplateServiceProvider = ProjectTemplateServiceProvider._();
+
+final class ProjectTemplateServiceProvider
+    extends $FunctionalProvider<ProjectTemplateService, ProjectTemplateService, ProjectTemplateService>
+    with $Provider<ProjectTemplateService> {
+  ProjectTemplateServiceProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'projectTemplateServiceProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$projectTemplateServiceHash();
+
+  @$internal
+  @override
+  $ProviderElement<ProjectTemplateService> $createElement($ProviderPointer pointer) => $ProviderElement(pointer);
+
+  @override
+  ProjectTemplateService create(Ref ref) {
+    return projectTemplateService(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(ProjectTemplateService value) {
+    return $ProviderOverride(origin: this, providerOverride: $SyncValueProvider<ProjectTemplateService>(value));
+  }
+}
+
+String _$projectTemplateServiceHash() => r'126b97ad48dcd11f69321ca6c64380a8e6b1cde3';
+
+@ProviderFor(projectTemplates)
+final projectTemplatesProvider = ProjectTemplatesProvider._();
+
+final class ProjectTemplatesProvider
+    extends $FunctionalProvider<AsyncValue<List<ProjectTemplate>>, List<ProjectTemplate>, Stream<List<ProjectTemplate>>>
+    with $FutureModifier<List<ProjectTemplate>>, $StreamProvider<List<ProjectTemplate>> {
+  ProjectTemplatesProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'projectTemplatesProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$projectTemplatesHash();
+
+  @$internal
+  @override
+  $StreamProviderElement<List<ProjectTemplate>> $createElement($ProviderPointer pointer) =>
+      $StreamProviderElement(pointer);
+
+  @override
+  Stream<List<ProjectTemplate>> create(Ref ref) {
+    return projectTemplates(ref);
+  }
+}
+
+String _$projectTemplatesHash() => r'0cc0f792506d5ff00dfca7ed6e70285e45a18315';

--- a/lib/features/projects/presentation/screens/create_project_screen.dart
+++ b/lib/features/projects/presentation/screens/create_project_screen.dart
@@ -4,10 +4,14 @@ import 'package:forui/forui.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/utils/form_validators.dart';
+import '../../../../core/utils/result.dart';
 import '../../../../core/widgets/base_form_screen.dart';
 import '../../../../core/widgets/time_field.dart';
 import '../../../../core/routing/routes.dart';
+import '../../domain/entities/project_template.dart';
 import '../providers/project_provider.dart';
+import '../providers/project_template_provider.dart';
+import '../widgets/project_template_picker.dart';
 
 class CreateProjectScreen extends ConsumerStatefulWidget {
   const CreateProjectScreen({super.key});
@@ -21,6 +25,8 @@ class _CreateProjectScreenState extends ConsumerState<CreateProjectScreen> {
   final _descriptionController = TextEditingController();
   DateTime? _startDate;
   DateTime? _deadline;
+  ProjectTemplate? _selectedTemplate;
+  bool _titleTouched = false;
 
   @override
   void dispose() {
@@ -29,15 +35,29 @@ class _CreateProjectScreenState extends ConsumerState<CreateProjectScreen> {
     super.dispose();
   }
 
+  void _onTemplateChanged(ProjectTemplate? template) {
+    setState(() {
+      _selectedTemplate = template;
+      if (template == null) return;
+      if (!_titleTouched || _titleController.text.trim().isEmpty) {
+        _titleController.text = template.payload.defaultTitle ?? template.name;
+      }
+      if (_descriptionController.text.trim().isEmpty && template.payload.defaultDescription != null) {
+        _descriptionController.text = template.payload.defaultDescription!;
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return BaseFormScreen(
       title: 'New Project',
-      submitButtonText: 'Create Project',
+      submitButtonText: _selectedTemplate == null ? 'Create Project' : 'Create from Template',
       onSubmit: _submit,
       fields: [
+        ProjectTemplatePicker(selected: _selectedTemplate, onChanged: _onTemplateChanged),
         FTextFormField(
-          control: FTextFieldControl.managed(controller: _titleController),
+          control: FTextFieldControl.managed(controller: _titleController, onChange: (_) => _titleTouched = true),
           hint: 'Project Title',
           label: const Text('Title'),
           validator: (value) => AppFormValidator.isNotEmpty(value),
@@ -78,18 +98,36 @@ class _CreateProjectScreenState extends ConsumerState<CreateProjectScreen> {
   Future<void> _submit() async {
     final title = _titleController.text.trim();
     if (title.isEmpty) return;
-
+    final description = _descriptionController.text.trim().isEmpty ? null : _descriptionController.text.trim();
+    final template = _selectedTemplate;
+    if (template != null) {
+      final result = await ref
+          .read(projectTemplateServiceProvider)
+          .applyTemplate(
+            template: template,
+            title: title,
+            description: description,
+            startDate: _startDate,
+            deadline: _deadline,
+          );
+      if (!mounted) return;
+      switch (result) {
+        case Success(:final value):
+          await ref.read(projectProvider.notifier).reload();
+          if (!mounted) return;
+          if (value.id != null) {
+            context.pop();
+            context.push(AppRoutes.projectDetailPath(value.id!));
+          }
+        case Failure(:final failure):
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(failure.message)));
+      }
+      return;
+    }
     final project = await ref
         .read(projectProvider.notifier)
-        .createProject(
-          title: title,
-          description: _descriptionController.text.trim().isEmpty ? null : _descriptionController.text.trim(),
-          startDate: _startDate,
-          deadline: _deadline,
-        );
-
+        .createProject(title: title, description: description, startDate: _startDate, deadline: _deadline);
     if (mounted && project.id != null) {
-      // Pop this screen and navigate to the new project's detail page.
       context.pop();
       context.push(AppRoutes.projectDetailPath(project.id!));
     }

--- a/lib/features/projects/presentation/screens/project_detail_screen.dart
+++ b/lib/features/projects/presentation/screens/project_detail_screen.dart
@@ -240,6 +240,7 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
                     if (project == null) return const SizedBox.shrink();
                     return ActionMenuButton(
                       onEdit: () => ProjectCommands.edit(context, project),
+                      onSaveAsTemplate: () => ProjectCommands.saveAsTemplate(context, ref, project),
                       onDelete: () => ProjectCommands.delete(context, ref, project),
                     );
                   },
@@ -276,6 +277,7 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
               if (project == null) return const SizedBox.shrink();
               return ActionMenuButton(
                 onEdit: () => ProjectCommands.edit(context, project),
+                onSaveAsTemplate: () => ProjectCommands.saveAsTemplate(context, ref, project),
                 onDelete: () => ProjectCommands.delete(context, ref, project, onDeleted: () => context.pop()),
               );
             },

--- a/lib/features/projects/presentation/widgets/project_milestones_panel.dart
+++ b/lib/features/projects/presentation/widgets/project_milestones_panel.dart
@@ -6,6 +6,7 @@ import '../../../../core/config/theme/app_theme.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/utils/datetime_formatter.dart';
 import '../../../../core/utils/result.dart';
+import '../../../../core/widgets/app_empty_state.dart';
 import '../../../milestones/domain/entities/milestone.dart';
 import '../providers/project_milestones_provider.dart';
 
@@ -66,11 +67,10 @@ class ProjectMilestonesPanel extends ConsumerWidget {
             error: (err, _) => Center(child: Text('Error: $err')),
             data: (milestones) {
               if (milestones.isEmpty) {
-                return Center(
-                  child: Text(
-                    'No milestones yet',
-                    style: context.typography.sm.copyWith(color: context.colors.mutedForeground),
-                  ),
+                return const AppEmptyState(
+                  icon: fu.FLucideIcons.flag,
+                  message: 'No milestones yet',
+                  detail: 'Add a milestone to group tasks toward a target date.',
                 );
               }
 

--- a/lib/features/projects/presentation/widgets/project_template_picker.dart
+++ b/lib/features/projects/presentation/widgets/project_template_picker.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart' as fu;
+
+import '../../../../core/config/theme/app_theme.dart';
+import '../../../../core/constants/app_constants.dart';
+import '../../domain/entities/project_template.dart';
+import '../providers/project_template_provider.dart';
+
+/// Compact picker for built-in and user templates on the create-project form.
+class ProjectTemplatePicker extends ConsumerWidget {
+  final ProjectTemplate? selected;
+  final ValueChanged<ProjectTemplate?> onChanged;
+
+  const ProjectTemplatePicker({super.key, required this.selected, required this.onChanged});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final async = ref.watch(projectTemplatesProvider);
+    return async.when(
+      loading: () => const SizedBox.shrink(),
+      error: (_, _) => const SizedBox.shrink(),
+      data: (templates) {
+        if (templates.isEmpty) return const SizedBox.shrink();
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('Template', style: context.typography.sm.copyWith(fontWeight: FontWeight.w600)),
+            SizedBox(height: AppConstants.spacing.small),
+            Wrap(
+              spacing: AppConstants.spacing.small,
+              runSpacing: AppConstants.spacing.small,
+              children: [
+                _Chip(label: 'Blank', selected: selected == null, onPress: () => onChanged(null)),
+                for (final template in templates)
+                  _Chip(
+                    label: template.name,
+                    selected: selected?.uuid == template.uuid,
+                    builtin: template.isBuiltin,
+                    onPress: () => onChanged(template),
+                  ),
+              ],
+            ),
+            if (selected?.description != null) ...[
+              SizedBox(height: AppConstants.spacing.small),
+              Text(
+                selected!.description!,
+                style: context.typography.xs.copyWith(color: context.colors.mutedForeground),
+              ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _Chip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final bool builtin;
+  final VoidCallback onPress;
+
+  const _Chip({required this.label, required this.selected, required this.onPress, this.builtin = false});
+
+  @override
+  Widget build(BuildContext context) {
+    return fu.FButton(
+      size: .sm,
+      mainAxisSize: .min,
+      variant: selected ? .secondary : .outline,
+      onPress: onPress,
+      child: Text(builtin ? '$label · built-in' : label, style: context.typography.xs),
+    );
+  }
+}

--- a/lib/features/projects/presentation/widgets/project_timeline_view.dart
+++ b/lib/features/projects/presentation/widgets/project_timeline_view.dart
@@ -7,6 +7,7 @@ import 'package:forui/forui.dart' as fu;
 import '../../../../core/config/theme/app_theme.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/utils/date_time_utils.dart';
+import '../../../../core/widgets/app_empty_state.dart';
 import '../../../milestones/domain/entities/milestone.dart';
 import '../../../tasks/domain/entities/task.dart';
 import '../providers/project_milestones_provider.dart';
@@ -31,11 +32,10 @@ class ProjectTimelineView extends ConsumerWidget {
         .toList();
 
     if (datedTasks.isEmpty && deadlineOnly.isEmpty && milestones.isEmpty) {
-      return Center(
-        child: Text(
-          'No dated tasks or milestones',
-          style: context.typography.sm.copyWith(color: context.colors.mutedForeground),
-        ),
+      return const AppEmptyState(
+        icon: fu.FLucideIcons.chartBar,
+        message: 'No dated tasks or milestones',
+        detail: 'Add start/end dates or milestones to see the timeline.',
       );
     }
 

--- a/lib/features/tasks/presentation/widgets/tasks_board_view.dart
+++ b/lib/features/tasks/presentation/widgets/tasks_board_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:forui/forui.dart' as fu;
 import 'package:go_router/go_router.dart';
@@ -8,6 +9,7 @@ import '../../../../core/constants/app_constants.dart';
 import '../../../../core/routing/routes.dart';
 import '../../../../core/utils/platform_utils.dart';
 import '../../../../core/widgets/app_card.dart';
+import '../../../../core/widgets/app_empty_state.dart';
 import '../../domain/entities/task.dart';
 import '../../domain/entities/task_extensions.dart';
 import '../../domain/entities/task_status.dart';
@@ -105,82 +107,113 @@ class _TasksBoardViewState extends ConsumerState<TasksBoardView> {
     context.push(AppRoutes.taskDetailPath(task.id!), extra: {'projectId': task.projectId});
   }
 
+  void _goToColumn(int index) {
+    final clamped = index.clamp(0, TaskStatus.values.length - 1);
+    if (clamped == _compactPage) return;
+    setState(() => _compactPage = clamped);
+    if (_pageController.hasClients) {
+      _pageController.animateToPage(clamped, duration: const Duration(milliseconds: 250), curve: Curves.easeOut);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final columns = _columns();
-
-    if (context.isCompact) {
-      return Column(
-        children: [
-          Row(
-            children: [
-              IconButton(
-                onPressed: _compactPage > 0
-                    ? () => _pageController.previousPage(
-                        duration: const Duration(milliseconds: 250),
-                        curve: Curves.easeOut,
-                      )
-                    : null,
-                icon: const Icon(fu.FLucideIcons.chevronLeft),
-              ),
-              Expanded(
-                child: Text(
-                  TaskStatus.values[_compactPage].label,
-                  textAlign: TextAlign.center,
-                  style: context.typography.sm.copyWith(fontWeight: FontWeight.w700),
-                ),
-              ),
-              IconButton(
-                onPressed: _compactPage < TaskStatus.values.length - 1
-                    ? () => _pageController.nextPage(duration: const Duration(milliseconds: 250), curve: Curves.easeOut)
-                    : null,
-                icon: const Icon(fu.FLucideIcons.chevronRight),
-              ),
-            ],
-          ),
-          Expanded(
-            child: PageView.builder(
-              controller: _pageController,
-              itemCount: TaskStatus.values.length,
-              onPageChanged: (index) => setState(() => _compactPage = index),
-              itemBuilder: (context, index) {
-                final status = TaskStatus.values[index];
-                return _BoardColumn(
-                  status: status,
-                  tasks: columns[status]!,
-                  selectedTaskId: widget.selectedTaskId,
-                  onOpenTask: _openTask,
-                  onDrop: (task, insertIndex) => _moveTask(
-                    task: task,
-                    targetStatus: status,
-                    insertIndex: insertIndex,
-                    targetColumn: columns[status]!,
-                  ),
-                );
-              },
-            ),
-          ),
-        ],
+    if (widget.tasks.isEmpty) {
+      return const AppEmptyState(
+        icon: fu.FLucideIcons.kanban,
+        message: 'No tasks on this board yet',
+        detail: 'Create a task to start organizing by status.',
       );
     }
-
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        for (final status in TaskStatus.values) ...[
-          if (status != TaskStatus.values.first) SizedBox(width: AppConstants.spacing.small),
-          Expanded(
-            child: _BoardColumn(
-              status: status,
-              tasks: columns[status]!,
-              selectedTaskId: widget.selectedTaskId,
-              onOpenTask: _openTask,
-              onDrop: (task, insertIndex) =>
-                  _moveTask(task: task, targetStatus: status, insertIndex: insertIndex, targetColumn: columns[status]!),
-            ),
-          ),
-        ],
-      ],
+    final board = context.isCompact
+        ? Column(
+            children: [
+              Row(
+                children: [
+                  IconButton(
+                    onPressed: _compactPage > 0
+                        ? () => _pageController.previousPage(
+                            duration: const Duration(milliseconds: 250),
+                            curve: Curves.easeOut,
+                          )
+                        : null,
+                    icon: const Icon(fu.FLucideIcons.chevronLeft),
+                  ),
+                  Expanded(
+                    child: Text(
+                      TaskStatus.values[_compactPage].label,
+                      textAlign: TextAlign.center,
+                      style: context.typography.sm.copyWith(fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: _compactPage < TaskStatus.values.length - 1
+                        ? () => _pageController.nextPage(
+                            duration: const Duration(milliseconds: 250),
+                            curve: Curves.easeOut,
+                          )
+                        : null,
+                    icon: const Icon(fu.FLucideIcons.chevronRight),
+                  ),
+                ],
+              ),
+              Expanded(
+                child: PageView.builder(
+                  controller: _pageController,
+                  itemCount: TaskStatus.values.length,
+                  onPageChanged: (index) => setState(() => _compactPage = index),
+                  itemBuilder: (context, index) {
+                    final status = TaskStatus.values[index];
+                    return _BoardColumn(
+                      status: status,
+                      tasks: columns[status]!,
+                      selectedTaskId: widget.selectedTaskId,
+                      onOpenTask: _openTask,
+                      onDrop: (task, insertIndex) => _moveTask(
+                        task: task,
+                        targetStatus: status,
+                        insertIndex: insertIndex,
+                        targetColumn: columns[status]!,
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ],
+          )
+        : Row(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              for (final status in TaskStatus.values) ...[
+                if (status != TaskStatus.values.first) SizedBox(width: AppConstants.spacing.small),
+                Expanded(
+                  child: _BoardColumn(
+                    status: status,
+                    tasks: columns[status]!,
+                    selectedTaskId: widget.selectedTaskId,
+                    onOpenTask: _openTask,
+                    onDrop: (task, insertIndex) => _moveTask(
+                      task: task,
+                      targetStatus: status,
+                      insertIndex: insertIndex,
+                      targetColumn: columns[status]!,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          );
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.arrowLeft): () => _goToColumn(_compactPage - 1),
+        const SingleActivator(LogicalKeyboardKey.arrowRight): () => _goToColumn(_compactPage + 1),
+        const SingleActivator(LogicalKeyboardKey.digit1): () => _goToColumn(0),
+        const SingleActivator(LogicalKeyboardKey.digit2): () => _goToColumn(1),
+        const SingleActivator(LogicalKeyboardKey.digit3): () => _goToColumn(2),
+        const SingleActivator(LogicalKeyboardKey.digit4): () => _goToColumn(3),
+      },
+      child: Focus(autofocus: PlatformUtils.isDesktop, child: board),
     );
   }
 }

--- a/lib/features/tasks/presentation/widgets/tasks_calendar_view.dart
+++ b/lib/features/tasks/presentation/widgets/tasks_calendar_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:forui/forui.dart' as fu;
 import 'package:go_router/go_router.dart';
@@ -9,6 +10,8 @@ import '../../../../core/constants/date_time_constants.dart';
 import '../../../../core/routing/routes.dart';
 import '../../../../core/utils/date_time_utils.dart';
 import '../../../../core/utils/datetime_formatter.dart';
+import '../../../../core/utils/platform_utils.dart';
+import '../../../../core/widgets/app_empty_state.dart';
 import '../../../../core/widgets/calendar/calendar_agenda_view.dart';
 import '../../../../core/widgets/calendar/calendar_day_info.dart';
 import '../../../../core/widgets/calendar/calendar_month_grid.dart';
@@ -136,6 +139,14 @@ class _TasksCalendarViewState extends ConsumerState<TasksCalendarView> {
     };
   }
 
+  void _goToday() {
+    final today = DateTimeUtils.dateOnly(DateTimeUtils.now());
+    setState(() {
+      _selectedDay = today;
+      _anchor = DateTime(today.year, today.month);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final now = DateTimeUtils.dateOnly(DateTimeUtils.now());
@@ -152,7 +163,7 @@ class _TasksCalendarViewState extends ConsumerState<TasksCalendarView> {
     final selectedTasks = tasksByDate[_selectedDay] ?? const <Task>[];
     final selectedInfo = dayInfo[_selectedDay] ?? const CalendarDayInfo();
 
-    return Column(
+    final content = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Row(
@@ -241,6 +252,11 @@ class _TasksCalendarViewState extends ConsumerState<TasksCalendarView> {
                 selectedDay: _selectedDay,
                 dayInfo: selectedInfo,
                 onAcceptDrop: (task) => _reschedule(task, _selectedDay),
+                emptyTasks: const AppEmptyState(
+                  icon: fu.FLucideIcons.calendar,
+                  message: 'Nothing scheduled this day',
+                  detail: 'Drop a task here or open day view after picking a date.',
+                ),
                 taskTiles: [
                   for (final task in selectedTasks)
                     Padding(
@@ -279,6 +295,18 @@ class _TasksCalendarViewState extends ConsumerState<TasksCalendarView> {
           ),
         ),
       ],
+    );
+
+    return CallbackShortcuts(
+      bindings: {
+        const SingleActivator(LogicalKeyboardKey.arrowLeft): _previous,
+        const SingleActivator(LogicalKeyboardKey.arrowRight): _next,
+        const SingleActivator(LogicalKeyboardKey.keyT): _goToday,
+        const SingleActivator(LogicalKeyboardKey.digit1): () => setState(() => _scope = _TasksCalendarScope.month),
+        const SingleActivator(LogicalKeyboardKey.digit2): () => setState(() => _scope = _TasksCalendarScope.week),
+        const SingleActivator(LogicalKeyboardKey.digit3): () => setState(() => _scope = _TasksCalendarScope.day),
+      },
+      child: Focus(autofocus: PlatformUtils.isDesktop, child: content),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'core/di/injection.dart';
 import 'core/services/desktop_lifecycle_service.dart';
 import 'core/utils/platform_utils.dart';
 import 'features/notifications/domain/services/notification_inbox_sync_service.dart';
+import 'features/projects/domain/services/project_template_service.dart';
 import 'features/settings/domain/services/settings_service.dart';
 import 'features/sync/domain/services/sync_auto_sync_service.dart';
 import 'features/sync/domain/services/sync_purge_service.dart';
@@ -40,6 +41,7 @@ void main(List<String> args) async {
 
   await getIt<SettingsService>().ensureDeviceId();
   await getIt<SyncPurgeService>().purgeExpiredTombstones();
+  await getIt<ProjectTemplateService>().ensureBuiltIns();
   await getIt<TaskNotificationService>().rescheduleAllReminders();
   await getIt<NotificationInboxSyncService>().init();
   getIt<SyncAutoSyncService>().init();

--- a/test/core/db/migration_harness_test.dart
+++ b/test/core/db/migration_harness_test.dart
@@ -5,19 +5,19 @@ import 'package:focus/features/tasks/domain/entities/task_status.dart';
 import 'package:focus/features/projects/domain/entities/project_status.dart';
 import 'package:sqlite3/sqlite3.dart';
 
-/// Phase 7 migration harness.
+/// Phase 8 migration harness.
 ///
-/// Captures the current (v9) schema via [AppDatabase.forTesting] and verifies
-/// that upgrading from a hand-built v1 schema reaches v9 without nested
+/// Captures the current (v10) schema via [AppDatabase.forTesting] and verifies
+/// that upgrading from a hand-built v1 schema reaches v10 without nested
 /// transaction statements, without losing rows, and with PM + recurrence +
-/// task-tag tombstone columns.
+/// task-tag tombstone + project template columns.
 void main() {
-  test('onCreate produces schema version 9 with expected tables', () async {
+  test('onCreate produces schema version 10 with expected tables', () async {
     final db = AppDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 9);
+    expect(version.read<int>('user_version'), 10);
 
     final tables = await db.customSelect("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").get();
     final names = tables.map((row) => row.read<String>('name')).toSet();
@@ -34,6 +34,7 @@ void main() {
         'task_tag_table',
         'milestone_table',
         'task_completion_table',
+        'project_template_table',
       }),
     );
 
@@ -78,6 +79,16 @@ void main() {
     final taskTagColNames = taskTagCols.map((r) => r.read<String>('name')).toSet();
     expect(taskTagColNames, containsAll({'task_id', 'tag_id', 'uuid', 'created_at', 'updated_at', 'deleted_at'}));
 
+    final templateCols = await db.customSelect('PRAGMA table_info(project_template_table)').get();
+    final templateColNames = templateCols.map((r) => r.read<String>('name')).toSet();
+    expect(
+      templateColNames,
+      containsAll({'uuid', 'name', 'description', 'is_builtin', 'payload_json', 'created_at', 'updated_at'}),
+    );
+
+    final templates = await db.select(db.projectTemplateTable).get();
+    expect(templates.where((t) => t.isBuiltin), hasLength(3));
+
     final indexes = await db
         .customSelect(
           "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'task_completion_task_occurrence_live_idx'",
@@ -114,7 +125,7 @@ void main() {
     });
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 9);
+    expect(version.read<int>('user_version'), 10);
 
     final tasks = await db.select(db.taskTable).get();
     expect(tasks, hasLength(1));
@@ -182,7 +193,7 @@ void main() {
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 9);
+    expect(version.read<int>('user_version'), 10);
 
     final project = (await db.select(db.projectTable).get()).single;
     expect(project.uuid, isNotEmpty);
@@ -229,7 +240,7 @@ void main() {
     addTearDown(db.close);
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 9);
+    expect(version.read<int>('user_version'), 10);
 
     final tasks = await db.select(db.taskTable).get();
     expect(tasks, hasLength(2));

--- a/test/domain/projects/project_template_payload_test.dart
+++ b/test/domain/projects/project_template_payload_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:focus/features/milestones/domain/entities/milestone.dart';
+import 'package:focus/features/projects/domain/entities/built_in_templates.dart';
+import 'package:focus/features/projects/domain/entities/project.dart';
+import 'package:focus/features/projects/domain/entities/project_template_payload.dart';
+import 'package:focus/features/tags/domain/entities/tag.dart';
+import 'package:focus/features/tasks/domain/entities/recurrence_rule.dart';
+import 'package:focus/features/tasks/domain/entities/task.dart';
+import 'package:focus/features/tasks/domain/entities/task_priority.dart';
+import 'package:focus/features/tasks/domain/entities/task_status.dart';
+
+void main() {
+  final now = DateTime.utc(2026, 8, 2, 12);
+
+  group('ProjectTemplatePayload', () {
+    test('round-trips through JSON', () {
+      final original = BuiltInTemplates.all(now: now).first.payload;
+      final restored = ProjectTemplatePayload.fromJsonString(original.toJsonString());
+      expect(restored.version, original.version);
+      expect(restored.defaultTitle, original.defaultTitle);
+      expect(restored.milestones.length, original.milestones.length);
+      expect(restored.tags.length, original.tags.length);
+      expect(restored.tasks.length, original.tasks.length);
+      expect(restored.tasks.map((t) => t.title), original.tasks.map((t) => t.title));
+    });
+
+    test('capture uses relative date offsets from project start', () {
+      final project = Project(
+        id: 1,
+        uuid: 'p1',
+        title: 'Launch',
+        description: 'Ship it',
+        createdAt: now,
+        updatedAt: now,
+        startDate: DateTime(2026, 8, 1),
+      );
+      final milestone = Milestone(
+        id: 10,
+        uuid: 'm1',
+        projectId: 1,
+        title: 'Beta',
+        targetDate: DateTime(2026, 8, 15),
+        createdAt: now,
+        updatedAt: now,
+      );
+      final task = Task(
+        id: 20,
+        uuid: 't1',
+        projectId: 1,
+        title: 'Build',
+        priority: TaskPriority.high,
+        status: TaskStatus.todo,
+        depth: 0,
+        sortOrder: 1000,
+        milestoneId: 10,
+        startDate: DateTime(2026, 8, 3),
+        endDate: DateTime(2026, 8, 10),
+        recurrenceRule: const RecurrenceRule(frequency: RecurrenceFrequency.weekly, interval: 1, byWeekday: [1]),
+        isHabit: true,
+        createdAt: now,
+        updatedAt: now,
+      );
+      final tag = Tag(id: 30, uuid: 'g1', name: 'launch', createdAt: now, updatedAt: now);
+      final payload = ProjectTemplatePayload.capture(
+        project: project,
+        tasks: [task],
+        milestones: [milestone],
+        tagsByTaskId: {
+          20: [tag],
+        },
+        fallbackNow: now,
+      );
+      expect(payload.defaultTitle, 'Launch');
+      expect(payload.milestones.single.targetOffsetDays, 14);
+      expect(payload.tasks.single.startOffsetDays, 2);
+      expect(payload.tasks.single.endOffsetDays, 9);
+      expect(payload.tasks.single.milestoneKey, isNotNull);
+      expect(payload.tasks.single.tagKeys, isNotEmpty);
+      expect(payload.tasks.single.isHabit, isTrue);
+      expect(payload.tasks.single.recurrenceRuleJson?['frequency'], 'weekly');
+      final roundTrip = ProjectTemplatePayload.fromJsonString(payload.toJsonString());
+      expect(roundTrip.tasks.single.resolveStart(DateTime(2026, 9, 1)), DateTime(2026, 9, 3));
+      expect(roundTrip.milestones.single.resolveDate(DateTime(2026, 9, 1)), DateTime(2026, 9, 15));
+    });
+
+    test('built-in templates include recurrence on at least one task', () {
+      final withRecurrence = BuiltInTemplates.all(
+        now: now,
+      ).expand((t) => t.payload.tasks).where((t) => t.recurrenceRuleJson != null).toList();
+      expect(withRecurrence, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch feat/phase-8-templates-docs into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
8401306 feat(projects): add project templates shortcuts and polish

### Files
- .agents/docs/architecture.md
- .agents/docs/audit_results.md
- .agents/docs/feature_plans.md
- .agents/docs/patterns.md
- AGENTS.md
- lib/core/di/injection.dart
- lib/core/services/db_service.dart
- lib/core/services/db_service.g.dart
- lib/core/widgets/action_menu_button.dart
- lib/core/widgets/app_empty_state.dart
- lib/core/widgets/keyboard_shortcuts.dart
- lib/features/projects/data/datasources/project_template_local_datasource.dart
- lib/features/projects/data/mappers/project_template_extensions.dart
- lib/features/projects/data/models/project_template_model.dart
- lib/features/projects/data/repositories/project_template_repository_impl.dart
- lib/features/projects/domain/entities/built_in_templates.dart
- lib/features/projects/domain/entities/project_template.dart
- lib/features/projects/domain/entities/project_template_extensions.dart
- lib/features/projects/domain/entities/project_template_payload.dart
- lib/features/projects/domain/repositories/i_project_template_repository.dart
- lib/features/projects/domain/services/project_template_service.dart
- lib/features/projects/presentation/commands/project_commands.dart
- lib/features/projects/presentation/providers/project_notifier_provider.part.dart
- lib/features/projects/presentation/providers/project_provider.g.dart
- lib/features/projects/presentation/providers/project_template_provider.dart
- lib/features/projects/presentation/providers/project_template_provider.g.dart
- lib/features/projects/presentation/screens/create_project_screen.dart
- lib/features/projects/presentation/screens/project_detail_screen.dart
- lib/features/projects/presentation/widgets/project_milestones_panel.dart
- lib/features/projects/presentation/widgets/project_template_picker.dart
- lib/features/projects/presentation/widgets/project_timeline_view.dart
- lib/features/tasks/presentation/widgets/tasks_board_view.dart
- lib/features/tasks/presentation/widgets/tasks_calendar_view.dart
- lib/main.dart
- test/core/db/migration_harness_test.dart
- test/domain/projects/project_template_payload_test.dart

### Diffstat
 .agents/docs/architecture.md                       |  13 +-
 .agents/docs/audit_results.md                      |  14 +-
 .agents/docs/feature_plans.md                      |  41 +-
 .agents/docs/patterns.md                           |  40 ++
 AGENTS.md                                          |   5 +-
 lib/core/di/injection.dart                         |  22 +-
 lib/core/services/db_service.dart                  |  39 +-
 lib/core/services/db_service.g.dart                | 630 +++++++++++++++++++++
 lib/core/widgets/action_menu_button.dart           |  36 +-
 lib/core/widgets/app_empty_state.dart              |  45 ++
 lib/core/widgets/keyboard_shortcuts.dart           |   6 +-
 .../project_template_local_datasource.dart         |  91 +++
 .../data/mappers/project_template_extensions.dart  |  44 ++
 .../data/models/project_template_model.dart        |  22 +
 .../project_template_repository_impl.dart          |  60 ++
 .../domain/entities/built_in_templates.dart        | 232 ++++++++
 .../projects/domain/entities/project_template.dart |  31 +
 .../entities/project_template_extensions.dart      |  26 +
 .../domain/entities/project_template_payload.dart  | 333 +++++++++++
 .../i_project_template_repository.dart             |  20 +
 .../domain/services/project_template_service.dart  | 232 ++++++++
 .../presentation/commands/project_commands.dart    |  35 +-
 .../providers/project_notifier_provider.part.dart  |   2 +
 .../presentation/providers/project_provider.g.dart |   2 +-
 .../providers/project_template_provider.dart       |  17 +
 .../providers/project_template_provider.g.dart     |  80 +++
 .../screens/create_project_screen.dart             |  60 +-
 .../screens/project_detail_screen.dart             |   2 +
 .../widgets/project_milestones_panel.dart          |  10 +-
 .../widgets/project_template_picker.dart           |  76 +++
 .../widgets/project_timeline_view.dart             |  10 +-
 .../presentation/widgets/tasks_board_view.dart     | 165 +++---
 .../presentation/widgets/tasks_calendar_view.dart  |  30 +-
 lib/main.dart                                      |   2 +
 test/core/db/migration_harness_test.dart           |  29 +-
 .../projects/project_template_payload_test.dart    |  93 +++
 36 files changed, 2448 insertions(+), 147 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
