### PR TITLE
fix(ui): Step 1 home cleanup and responsive CTA

### DIFF
--- a/lib/features/home/presentation/pages/home_screen.dart
+++ b/lib/features/home/presentation/pages/home_screen.dart
@@ -10,6 +10,8 @@ import 'package:focus/features/home/presentation/widgets/streak_badge.dart';
 
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/routing/routes.dart';
+import '../../../../core/utils/platform_utils.dart';
+import '../../../../core/widgets/constrained_content.dart';
 import '../../../projects/presentation/providers/project_provider.dart';
 import '../../../tasks/domain/entities/global_stats.dart';
 import '../../../tasks/presentation/providers/task_stats_provider.dart';
@@ -48,10 +50,12 @@ class HomeScreen extends ConsumerWidget {
       header: fu.FHeader(
         suffixes: [
           if (stats.currentStreak > 0) StreakBadge(streak: stats.currentStreak),
-          fu.FHeaderAction(
-            icon: Icon(fu.FLucideIcons.chartBar, size: AppConstants.size.icon.regular),
-            onPress: () => context.push(AppRoutes.reports.path),
-          ),
+          // Reports lives in the desktop sidebar; keep header entry on compact only.
+          if (context.isCompact)
+            fu.FHeaderAction(
+              icon: Icon(fu.FLucideIcons.chartBar, size: AppConstants.size.icon.regular),
+              onPress: () => context.push(AppRoutes.reports.path),
+            ),
           fu.FHeaderAction(
             icon: Icon(fu.FLucideIcons.settings, size: AppConstants.size.icon.regular),
             onPress: () => context.push(AppRoutes.settings.path),
@@ -73,22 +77,26 @@ class HomeScreen extends ConsumerWidget {
           ],
         ),
       ),
-      child: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          spacing: AppConstants.spacing.regular,
-          children: [
-            const QuickSessionButton(),
-            if (showOnboarding)
-              const HomeOnboardingCard()
-            else ...[
-              const TodayAgendaSection(),
-              SizedBox(height: AppConstants.spacing.small),
-              const HabitsStripSection(),
-              SizedBox(height: AppConstants.spacing.small),
-              const UpcomingCalendarCard(),
+      child: ConstrainedContent(
+        maxWidth: 800,
+        padding: EdgeInsets.zero,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: AppConstants.spacing.regular,
+            children: [
+              const QuickSessionButton(),
+              if (showOnboarding)
+                const HomeOnboardingCard()
+              else ...[
+                const TodayAgendaSection(),
+                SizedBox(height: AppConstants.spacing.small),
+                const HabitsStripSection(),
+                SizedBox(height: AppConstants.spacing.small),
+                const UpcomingCalendarCard(),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );

--- a/lib/features/home/presentation/widgets/agenda_task_tile.dart
+++ b/lib/features/home/presentation/widgets/agenda_task_tile.dart
@@ -46,7 +46,7 @@ class AgendaTaskTile extends ConsumerWidget {
       },
       child: fu.FCard(
         child: Padding(
-          padding: EdgeInsets.all(AppConstants.spacing.regular),
+          padding: EdgeInsets.all(AppConstants.spacing.large),
           child: Row(
             children: [
               fu.FCheckbox(value: item.isCompleted, onChange: item.isCompleted ? null : (_) => _onToggle()),
@@ -66,10 +66,16 @@ class AgendaTaskTile extends ConsumerWidget {
                       overflow: TextOverflow.ellipsis,
                     ),
                     SizedBox(height: AppConstants.spacing.extraSmall),
-                    Text(_subtitle, style: context.typography.xs.copyWith(color: _subtitleColor(context))),
+                    Text(
+                      _subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: context.typography.xs.copyWith(color: _subtitleColor(context)),
+                    ),
                   ],
                 ),
               ),
+              SizedBox(width: AppConstants.spacing.small),
               TaskPriorityBadge(priority: task.priority),
               if (!item.isCompleted && task.id != null) ...[
                 SizedBox(width: AppConstants.spacing.small),

--- a/lib/features/home/presentation/widgets/calendar_content.dart
+++ b/lib/features/home/presentation/widgets/calendar_content.dart
@@ -156,13 +156,18 @@ class _CalendarContentState extends ConsumerState<CalendarContent> {
                   color: context.colors.mutedForeground,
                 ),
               ),
-              Text(
-                UpcomingCalendarUtils.periodLabel(
-                  viewMode: CalendarViewMode.week,
-                  displayMonth: uiState.displayMonth,
-                  displayWeekStart: displayWeekStart,
+              Flexible(
+                child: Text(
+                  UpcomingCalendarUtils.periodLabel(
+                    viewMode: CalendarViewMode.week,
+                    displayMonth: uiState.displayMonth,
+                    displayWeekStart: displayWeekStart,
+                  ),
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: context.typography.sm.copyWith(fontWeight: FontWeight.w600),
                 ),
-                style: context.typography.sm.copyWith(fontWeight: FontWeight.w600),
               ),
               GestureDetector(
                 onTap: _nextWeek,

--- a/lib/features/home/presentation/widgets/habits_strip_section.dart
+++ b/lib/features/home/presentation/widgets/habits_strip_section.dart
@@ -30,13 +30,16 @@ class HabitsStripSection extends ConsumerWidget {
             if (items.isEmpty) {
               return const EmptySection(icon: fu.FLucideIcons.flame, message: 'No habits yet');
             }
-            return SizedBox(
-              height: 96,
-              child: ListView.separated(
-                scrollDirection: Axis.horizontal,
-                itemCount: items.length,
-                separatorBuilder: (_, _) => SizedBox(width: AppConstants.spacing.regular),
-                itemBuilder: (context, index) => HabitRing(item: items[index]),
+            return SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (var i = 0; i < items.length; i++) ...[
+                    if (i > 0) SizedBox(width: AppConstants.spacing.regular),
+                    HabitRing(item: items[i]),
+                  ],
+                ],
               ),
             );
           },

--- a/lib/features/home/presentation/widgets/quick_session_button.dart
+++ b/lib/features/home/presentation/widgets/quick_session_button.dart
@@ -18,10 +18,7 @@ class QuickSessionButton extends ConsumerWidget {
         onTap: () => FocusCommands.startQuickSession(context, ref),
         borderRadius: BorderRadius.circular(AppConstants.border.radius.regular),
         child: Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: AppConstants.spacing.regular,
-            vertical: AppConstants.spacing.regular,
-          ),
+          padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.large, vertical: AppConstants.spacing.large),
           child: Row(
             children: [
               Container(
@@ -40,6 +37,8 @@ class QuickSessionButton extends ConsumerWidget {
                   children: [
                     Text(
                       'Start Focus Session',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                       style: context.typography.lg.copyWith(
                         color: context.colors.background,
                         fontWeight: FontWeight.w700,
@@ -48,6 +47,8 @@ class QuickSessionButton extends ConsumerWidget {
                     SizedBox(height: AppConstants.spacing.extraSmall),
                     Text(
                       'Tap to begin a quick session',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                       style: context.typography.sm.copyWith(color: context.colors.background.withValues(alpha: 0.7)),
                     ),
                   ],


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch fix/ui-home-cleanup into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
00aeebf fix(ui): clean up home header padding and overflow

### Files
- lib/features/home/presentation/pages/home_screen.dart
- lib/features/home/presentation/widgets/agenda_task_tile.dart
- lib/features/home/presentation/widgets/calendar_content.dart
- lib/features/home/presentation/widgets/habits_strip_section.dart
- lib/features/home/presentation/widgets/quick_session_button.dart

### Diffstat
 .../home/presentation/pages/home_screen.dart       | 46 +++++++++++++---------
 .../presentation/widgets/agenda_task_tile.dart     | 10 ++++-
 .../presentation/widgets/calendar_content.dart     | 17 +++++---
 .../presentation/widgets/habits_strip_section.dart | 17 ++++----
 .../presentation/widgets/quick_session_button.dart |  9 +++--
 5 files changed, 61 insertions(+), 38 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
