### PR TITLE
fix(ui): harden filter popover and narrow toolbar

### DIFF
--- a/lib/core/widgets/filter_select.dart
+++ b/lib/core/widgets/filter_select.dart
@@ -1,6 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart';
 
+/// Provides a shared [groupId] so nested [FSelect] dropdowns stay inside an
+/// outer [FPopover] tap region (ForUI nested-popover contract).
+class FilterSelectGroup extends InheritedWidget {
+  final Object groupId;
+
+  const FilterSelectGroup({super.key, required this.groupId, required super.child});
+
+  static Object? maybeOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<FilterSelectGroup>()?.groupId;
+  }
+
+  @override
+  bool updateShouldNotify(FilterSelectGroup oldWidget) => groupId != oldWidget.groupId;
+}
+
 class FilterSelect<T> extends StatelessWidget {
   final T selected;
   final ValueChanged<T> onChanged;
@@ -8,6 +23,7 @@ class FilterSelect<T> extends StatelessWidget {
   final String hint;
   final String? allLabel; // Label for the "All" option, null to disable
   final String Function(T option)? labelBuilder;
+  final Object? groupId;
 
   const FilterSelect({
     super.key,
@@ -17,6 +33,7 @@ class FilterSelect<T> extends StatelessWidget {
     required this.hint,
     this.allLabel,
     this.labelBuilder,
+    this.groupId,
   });
 
   String _labelFor(T option) {
@@ -40,9 +57,12 @@ class FilterSelect<T> extends StatelessWidget {
       }
     }
 
+    final resolvedGroupId = groupId ?? FilterSelectGroup.maybeOf(context);
+
     return FSelect<T>(
       items: items,
       hint: hint,
+      contentGroupId: resolvedGroupId,
       control: FSelectControl.managed(initial: selected, onChange: (value) => onChanged(value as T)),
     );
   }

--- a/lib/core/widgets/list_toolbar.dart
+++ b/lib/core/widgets/list_toolbar.dart
@@ -1,16 +1,18 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:forui/forui.dart' as fu;
 
 import '../config/theme/app_theme.dart';
 import '../constants/app_constants.dart';
-import '../utils/platform_utils.dart';
 import 'app_search_bar.dart';
+import 'filter_select.dart';
 
 /// One-line list chrome: search + optional view switcher + filter (+ create).
 ///
-/// Compact shows filters in a bottom [fu.showFSheet]. Expanded shows them in
-/// an [fu.FPopover] anchored to the filter button. Active-filter chips render
-/// under the toolbar when [activeFilters] is non-empty.
+/// Narrow panes (< 400) show filters in a bottom [fu.showFSheet]. Wider panes
+/// show them in an [fu.FPopover] anchored to the filter button. Active-filter
+/// chips render under the toolbar when [activeFilters] is non-empty.
 ///
 /// Pass [viewModeControl] to slot a segmented List/Board/Calendar (or similar)
 /// control into the same toolbar row instead of stacking another filter row.
@@ -41,25 +43,44 @@ class ListToolbar extends StatelessWidget {
     return Column(
       crossAxisAlignment: .stretch,
       children: [
-        Row(
-          children: [
-            Expanded(
-              child: AppSearchBar(hint: searchHint, onChanged: onSearchChanged),
-            ),
-            if (viewModeControl != null) ...[SizedBox(width: AppConstants.spacing.small), viewModeControl!],
-            SizedBox(width: AppConstants.spacing.small),
-            _FilterTrigger(activeFilterCount: activeFilterCount, filterPanel: filterPanel),
-            if (onCreate != null) ...[
-              SizedBox(width: AppConstants.spacing.small),
-              fu.FButton(
-                size: .sm,
-                mainAxisSize: .min,
-                prefix: const Icon(fu.FLucideIcons.plus),
-                onPress: onCreate,
-                child: Text(createLabel),
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final narrow = constraints.maxWidth < 360;
+            return ListToolbarLayout(
+              iconOnly: narrow,
+              child: Row(
+                children: [
+                  Expanded(
+                    child: AppSearchBar(hint: searchHint, onChanged: onSearchChanged),
+                  ),
+                  if (viewModeControl != null) ...[SizedBox(width: AppConstants.spacing.small), viewModeControl!],
+                  SizedBox(width: AppConstants.spacing.small),
+                  _FilterTrigger(activeFilterCount: activeFilterCount, filterPanel: filterPanel),
+                  if (onCreate != null) ...[
+                    SizedBox(width: AppConstants.spacing.small),
+                    if (narrow)
+                      fu.FTooltip(
+                        tipBuilder: (context, _) => Text(createLabel),
+                        child: fu.FButton.icon(
+                          size: .sm,
+                          semanticsLabel: createLabel,
+                          onPress: onCreate,
+                          child: const Icon(fu.FLucideIcons.plus),
+                        ),
+                      )
+                    else
+                      fu.FButton(
+                        size: .sm,
+                        mainAxisSize: .min,
+                        prefix: const Icon(fu.FLucideIcons.plus),
+                        onPress: onCreate,
+                        child: Text(createLabel),
+                      ),
+                  ],
+                ],
               ),
-            ],
-          ],
+            );
+          },
         ),
         if (activeFilters.isNotEmpty) ...[
           SizedBox(height: AppConstants.spacing.small),
@@ -68,6 +89,20 @@ class ListToolbar extends StatelessWidget {
       ],
     );
   }
+}
+
+/// Density signal for toolbar children (e.g. [TasksViewModeToggle]).
+class ListToolbarLayout extends InheritedWidget {
+  final bool iconOnly;
+
+  const ListToolbarLayout({super.key, required this.iconOnly, required super.child});
+
+  static bool iconOnlyOf(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<ListToolbarLayout>()?.iconOnly ?? false;
+  }
+
+  @override
+  bool updateShouldNotify(ListToolbarLayout oldWidget) => iconOnly != oldWidget.iconOnly;
 }
 
 class _FilterTrigger extends StatefulWidget {
@@ -82,6 +117,7 @@ class _FilterTrigger extends StatefulWidget {
 
 class _FilterTriggerState extends State<_FilterTrigger> with SingleTickerProviderStateMixin {
   late final fu.FPopoverController _popoverController = fu.FPopoverController(vsync: this);
+  final Object _groupId = Object();
 
   @override
   void dispose() {
@@ -103,7 +139,7 @@ class _FilterTriggerState extends State<_FilterTrigger> with SingleTickerProvide
             children: [
               Text('Filters', style: context.typography.lg.copyWith(fontWeight: FontWeight.w700)),
               SizedBox(height: AppConstants.spacing.regular),
-              widget.filterPanel,
+              FilterSelectGroup(groupId: _groupId, child: widget.filterPanel),
             ],
           ),
         ),
@@ -113,25 +149,33 @@ class _FilterTriggerState extends State<_FilterTrigger> with SingleTickerProvide
 
   @override
   Widget build(BuildContext context) {
+    final paneWidth = MediaQuery.sizeOf(context).width;
+    final useSheet = paneWidth < 400;
+    final popoverMaxWidth = math.min(360.0, paneWidth - 32);
     final label = widget.activeFilterCount > 0 ? 'Filters (${widget.activeFilterCount})' : 'Filters';
     final button = fu.FButton(
       size: .sm,
       mainAxisSize: .min,
       variant: widget.activeFilterCount > 0 ? .secondary : .outline,
       prefix: const Icon(fu.FLucideIcons.listFilter),
-      onPress: context.isCompact ? _openSheet : _popoverController.toggle,
+      onPress: useSheet ? _openSheet : _popoverController.toggle,
       child: Text(label),
     );
 
-    if (context.isCompact) return button;
+    if (useSheet) return button;
 
     return fu.FPopover(
       control: fu.FPopoverControl.managed(controller: _popoverController),
+      groupId: _groupId,
+      hideRegion: fu.FPopoverHideRegion.excludeChild,
       popoverAnchor: .topRight,
       childAnchor: .bottomRight,
       popoverBuilder: (context, _) => ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 360),
-        child: Padding(padding: EdgeInsets.all(AppConstants.spacing.regular), child: widget.filterPanel),
+        constraints: BoxConstraints(maxWidth: popoverMaxWidth),
+        child: Padding(
+          padding: EdgeInsets.all(AppConstants.spacing.regular),
+          child: FilterSelectGroup(groupId: _groupId, child: widget.filterPanel),
+        ),
       ),
       child: button,
     );

--- a/lib/features/projects/presentation/screens/project_list_screen.dart
+++ b/lib/features/projects/presentation/screens/project_list_screen.dart
@@ -9,6 +9,7 @@ import '../../../../core/config/theme/app_theme.dart';
 import '../../../../core/routing/routes.dart';
 import '../../../../core/widgets/constrained_content.dart';
 import '../../../../core/widgets/list_toolbar.dart';
+import '../../domain/entities/project_list_filter_state.dart';
 import '../commands/project_commands.dart';
 import '../providers/project_provider.dart';
 import '../widgets/project_card.dart';
@@ -22,9 +23,18 @@ class ProjectListScreen extends ConsumerWidget {
 
   bool get _isEmbedded => onProjectSelected != null;
 
+  int _activeFilterCount(ProjectListFilterState filter) {
+    var count = 0;
+    if (filter.sortCriteria != ProjectSortCriteria.recentlyModified) count++;
+    if (filter.sortOrder != ProjectSortOrder.none) count++;
+    return count;
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final filteredAsync = ref.watch(filteredProjectListProvider);
+    final filter = ref.watch(projectListFilterProvider);
+    final activeCount = _activeFilterCount(filter);
 
     final content = ConstrainedContent(
       maxWidth: _isEmbedded ? double.infinity : 980,
@@ -40,6 +50,30 @@ class ProjectListScreen extends ConsumerWidget {
               ref.read(projectListFilterProvider.notifier).updateFilter(searchQuery: query);
             },
             filterPanel: const ProjectFilterPanel(),
+            activeFilterCount: activeCount,
+            activeFilters: [
+              if (filter.sortCriteria != ProjectSortCriteria.recentlyModified)
+                fu.FButton(
+                  size: .xs,
+                  mainAxisSize: .min,
+                  variant: .secondary,
+                  suffix: const Icon(fu.FLucideIcons.x),
+                  onPress: () => ref
+                      .read(projectListFilterProvider.notifier)
+                      .updateFilter(sortCriteria: ProjectSortCriteria.recentlyModified),
+                  child: Text(filter.sortCriteria.label),
+                ),
+              if (filter.sortOrder != ProjectSortOrder.none)
+                fu.FButton(
+                  size: .xs,
+                  mainAxisSize: .min,
+                  variant: .secondary,
+                  suffix: const Icon(fu.FLucideIcons.x),
+                  onPress: () =>
+                      ref.read(projectListFilterProvider.notifier).updateFilter(sortOrder: ProjectSortOrder.none),
+                  child: Text(filter.sortOrder.label),
+                ),
+            ],
             onCreate: () => ProjectCommands.create(context),
             createLabel: 'Create Project',
           ),

--- a/lib/features/tasks/presentation/widgets/tasks_view_mode_toggle.dart
+++ b/lib/features/tasks/presentation/widgets/tasks_view_mode_toggle.dart
@@ -3,28 +3,50 @@ import 'package:forui/forui.dart' as fu;
 
 import '../../../../core/config/theme/app_theme.dart';
 import '../../../../core/constants/app_constants.dart';
+import '../../../../core/widgets/list_toolbar.dart';
 import '../providers/tasks_view_mode_provider.dart';
 
 class TasksViewModeToggle extends StatelessWidget {
   final TasksViewMode mode;
   final ValueChanged<TasksViewMode> onChanged;
+  final bool? iconOnly;
 
-  const TasksViewModeToggle({super.key, required this.mode, required this.onChanged});
+  const TasksViewModeToggle({super.key, required this.mode, required this.onChanged, this.iconOnly});
+
+  IconData _iconFor(TasksViewMode value) => switch (value) {
+    TasksViewMode.list => fu.FLucideIcons.list,
+    TasksViewMode.board => fu.FLucideIcons.layoutGrid,
+    TasksViewMode.calendar => fu.FLucideIcons.calendar,
+  };
 
   @override
   Widget build(BuildContext context) {
+    final useIcons = iconOnly ?? ListToolbarLayout.iconOnlyOf(context);
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         for (final value in TasksViewMode.values) ...[
           if (value != TasksViewMode.values.first) SizedBox(width: AppConstants.spacing.extraSmall),
-          fu.FButton(
-            size: .sm,
-            mainAxisSize: .min,
-            variant: mode == value ? .secondary : .outline,
-            onPress: () => onChanged(value),
-            child: Text(value.label, style: context.typography.xs),
-          ),
+          if (useIcons)
+            fu.FTooltip(
+              tipBuilder: (context, _) => Text(value.label),
+              child: fu.FButton.icon(
+                size: .sm,
+                variant: mode == value ? .secondary : .outline,
+                semanticsLabel: value.label,
+                onPress: () => onChanged(value),
+                child: Icon(_iconFor(value)),
+              ),
+            )
+          else
+            fu.FButton(
+              size: .sm,
+              mainAxisSize: .min,
+              variant: mode == value ? .secondary : .outline,
+              onPress: () => onChanged(value),
+              child: Text(value.label, style: context.typography.xs),
+            ),
         ],
       ],
     );


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch fix/ui-filter-popover into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
41ffdf2 fix(ui): harden filter popover and narrow toolbar

### Files
- lib/core/widgets/filter_select.dart
- lib/core/widgets/list_toolbar.dart
- lib/features/projects/presentation/screens/project_list_screen.dart
- lib/features/tasks/presentation/widgets/tasks_view_mode_toggle.dart

### Diffstat
 lib/core/widgets/filter_select.dart                | 20 +++++
 lib/core/widgets/list_toolbar.dart                 | 98 ++++++++++++++++------
 .../presentation/screens/project_list_screen.dart  | 34 ++++++++
 .../widgets/tasks_view_mode_toggle.dart            | 38 +++++++--
 4 files changed, 155 insertions(+), 35 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
