### PR TITLE
feat(ui): add desktop hover cursors and tooltips

### DIFF
--- a/lib/core/widgets/app_card.dart
+++ b/lib/core/widgets/app_card.dart
@@ -3,7 +3,7 @@ import 'package:focus/core/config/theme/app_theme.dart';
 import 'package:focus/core/constants/app_constants.dart';
 import 'package:forui/forui.dart' as fu;
 
-class AppCard extends StatelessWidget {
+class AppCard extends StatefulWidget {
   final Widget title;
   final Widget? leading;
   final Widget? trailing;
@@ -13,6 +13,7 @@ class AppCard extends StatelessWidget {
   final List<Widget>? children;
   final VoidCallback? onTap;
   final bool isCompleted;
+  final MouseCursor mouseCursor;
 
   const AppCard({
     super.key,
@@ -25,59 +26,88 @@ class AppCard extends StatelessWidget {
     this.children,
     this.onTap,
     this.isCompleted = false,
+    this.mouseCursor = SystemMouseCursors.click,
   });
+
+  @override
+  State<AppCard> createState() => _AppCardState();
+}
+
+class _AppCardState extends State<AppCard> {
+  bool _hovered = false;
 
   @override
   Widget build(BuildContext context) {
     const double leadingWidth = 32.0;
+    final tappable = widget.onTap != null;
 
-    return GestureDetector(
-      onTap: onTap,
-      child: fu.FCard(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+    return MouseRegion(
+      cursor: tappable ? widget.mouseCursor : MouseCursor.defer,
+      onEnter: tappable ? (_) => setState(() => _hovered = true) : null,
+      onExit: tappable ? (_) => setState(() => _hovered = false) : null,
+      child: AnimatedContainer(
+        duration: AppConstants.animation.short,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(AppConstants.border.radius.regular),
+          color: _hovered ? context.colors.muted.withValues(alpha: 0.45) : Colors.transparent,
+        ),
+        child: GestureDetector(
+          onTap: widget.onTap,
+          child: fu.FCard(
+            child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    if (leading != null) SizedBox(width: leadingWidth, child: leading!),
-                    Expanded(
-                      child: DefaultTextStyle(
-                        style: context.typography.md.copyWith(
-                          fontWeight: isCompleted ? FontWeight.w400 : FontWeight.w600,
-                          color: isCompleted ? context.colors.mutedForeground : context.colors.foreground,
-                          decoration: isCompleted ? TextDecoration.lineThrough : null,
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        if (widget.leading != null) SizedBox(width: leadingWidth, child: widget.leading!),
+                        Expanded(
+                          child: DefaultTextStyle(
+                            style: context.typography.md.copyWith(
+                              fontWeight: widget.isCompleted ? FontWeight.w400 : FontWeight.w600,
+                              color: widget.isCompleted ? context.colors.mutedForeground : context.colors.foreground,
+                              decoration: widget.isCompleted ? TextDecoration.lineThrough : null,
+                            ),
+                            child: widget.title,
+                          ),
                         ),
-                        child: title,
+                        if (widget.trailing != null) ...[
+                          SizedBox(width: AppConstants.spacing.regular),
+                          widget.trailing!,
+                        ],
+                      ],
+                    ),
+                    Padding(
+                      padding: EdgeInsets.only(left: widget.leading != null ? leadingWidth : 0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          if (widget.subtitle != null) ...[
+                            SizedBox(height: AppConstants.spacing.extraSmall),
+                            widget.subtitle!,
+                          ],
+                          if (widget.content != null) ...[
+                            SizedBox(height: AppConstants.spacing.regular),
+                            widget.content!,
+                          ],
+                          if (widget.footerActions != null && widget.footerActions!.isNotEmpty) ...[
+                            SizedBox(height: AppConstants.spacing.regular),
+                            Row(mainAxisAlignment: MainAxisAlignment.end, children: widget.footerActions!),
+                          ],
+                        ],
                       ),
                     ),
-                    if (trailing != null) ...[SizedBox(width: AppConstants.spacing.regular), trailing!],
                   ],
                 ),
-
-                Padding(
-                  padding: EdgeInsets.only(left: leading != null ? leadingWidth : 0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      if (subtitle != null) ...[SizedBox(height: AppConstants.spacing.extraSmall), subtitle!],
-                      if (content != null) ...[SizedBox(height: AppConstants.spacing.regular), content!],
-                      if (footerActions != null && footerActions!.isNotEmpty) ...[
-                        SizedBox(height: AppConstants.spacing.regular),
-                        Row(mainAxisAlignment: MainAxisAlignment.end, children: footerActions!),
-                      ],
-                    ],
-                  ),
-                ),
+                ...?widget.children,
               ],
             ),
-            ...?children,
-          ],
+          ),
         ),
       ),
     );

--- a/lib/core/widgets/list_toolbar.dart
+++ b/lib/core/widgets/list_toolbar.dart
@@ -50,36 +50,38 @@ class ListToolbar extends StatelessWidget {
             final narrow = constraints.maxWidth < 360;
             return ListToolbarLayout(
               iconOnly: narrow,
-              child: Row(
-                children: [
-                  Expanded(
-                    child: AppSearchBar(hint: searchHint, onChanged: onSearchChanged, focusNode: searchFocusNode),
-                  ),
-                  if (viewModeControl != null) ...[SizedBox(width: AppConstants.spacing.small), viewModeControl!],
-                  SizedBox(width: AppConstants.spacing.small),
-                  _FilterTrigger(activeFilterCount: activeFilterCount, filterPanel: filterPanel),
-                  if (onCreate != null) ...[
+              child: FocusTraversalGroup(
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: AppSearchBar(hint: searchHint, onChanged: onSearchChanged, focusNode: searchFocusNode),
+                    ),
+                    if (viewModeControl != null) ...[SizedBox(width: AppConstants.spacing.small), viewModeControl!],
                     SizedBox(width: AppConstants.spacing.small),
-                    if (narrow)
-                      fu.FTooltip(
-                        tipBuilder: (context, _) => Text(createLabel),
-                        child: fu.FButton.icon(
+                    _FilterTrigger(activeFilterCount: activeFilterCount, filterPanel: filterPanel, iconOnly: narrow),
+                    if (onCreate != null) ...[
+                      SizedBox(width: AppConstants.spacing.small),
+                      if (narrow)
+                        fu.FTooltip(
+                          tipBuilder: (context, _) => Text(createLabel),
+                          child: fu.FButton.icon(
+                            size: .sm,
+                            semanticsLabel: createLabel,
+                            onPress: onCreate,
+                            child: const Icon(fu.FLucideIcons.plus),
+                          ),
+                        )
+                      else
+                        fu.FButton(
                           size: .sm,
-                          semanticsLabel: createLabel,
+                          mainAxisSize: .min,
+                          prefix: const Icon(fu.FLucideIcons.plus),
                           onPress: onCreate,
-                          child: const Icon(fu.FLucideIcons.plus),
+                          child: Text(createLabel),
                         ),
-                      )
-                    else
-                      fu.FButton(
-                        size: .sm,
-                        mainAxisSize: .min,
-                        prefix: const Icon(fu.FLucideIcons.plus),
-                        onPress: onCreate,
-                        child: Text(createLabel),
-                      ),
+                    ],
                   ],
-                ],
+                ),
               ),
             );
           },
@@ -110,8 +112,9 @@ class ListToolbarLayout extends InheritedWidget {
 class _FilterTrigger extends StatefulWidget {
   final int activeFilterCount;
   final Widget filterPanel;
+  final bool iconOnly;
 
-  const _FilterTrigger({required this.activeFilterCount, required this.filterPanel});
+  const _FilterTrigger({required this.activeFilterCount, required this.filterPanel, required this.iconOnly});
 
   @override
   State<_FilterTrigger> createState() => _FilterTriggerState();
@@ -155,14 +158,30 @@ class _FilterTriggerState extends State<_FilterTrigger> with SingleTickerProvide
     final useSheet = paneWidth < 400;
     final popoverMaxWidth = math.min(360.0, paneWidth - 32);
     final label = widget.activeFilterCount > 0 ? 'Filters (${widget.activeFilterCount})' : 'Filters';
-    final button = fu.FButton(
-      size: .sm,
-      mainAxisSize: .min,
-      variant: widget.activeFilterCount > 0 ? .secondary : .outline,
-      prefix: const Icon(fu.FLucideIcons.listFilter),
-      onPress: useSheet ? _openSheet : _popoverController.toggle,
-      child: Text(label),
-    );
+    final onPress = useSheet ? _openSheet : _popoverController.toggle;
+
+    final Widget button;
+    if (widget.iconOnly) {
+      button = fu.FTooltip(
+        tipBuilder: (context, _) => Text(label),
+        child: fu.FButton.icon(
+          size: .sm,
+          variant: widget.activeFilterCount > 0 ? .secondary : .outline,
+          semanticsLabel: label,
+          onPress: onPress,
+          child: const Icon(fu.FLucideIcons.listFilter),
+        ),
+      );
+    } else {
+      button = fu.FButton(
+        size: .sm,
+        mainAxisSize: .min,
+        variant: widget.activeFilterCount > 0 ? .secondary : .outline,
+        prefix: const Icon(fu.FLucideIcons.listFilter),
+        onPress: onPress,
+        child: Text(label),
+      );
+    }
 
     if (useSheet) return button;
 

--- a/lib/features/home/presentation/pages/home_screen.dart
+++ b/lib/features/home/presentation/pages/home_screen.dart
@@ -52,13 +52,21 @@ class HomeScreen extends ConsumerWidget {
           if (stats.currentStreak > 0) StreakBadge(streak: stats.currentStreak),
           // Reports lives in the desktop sidebar; keep header entry on compact only.
           if (context.isCompact)
-            fu.FHeaderAction(
-              icon: Icon(fu.FLucideIcons.chartBar, size: AppConstants.size.icon.regular),
-              onPress: () => context.push(AppRoutes.reports.path),
+            fu.FTooltip(
+              tipBuilder: (context, _) => const Text('Reports'),
+              child: fu.FHeaderAction(
+                icon: Icon(fu.FLucideIcons.chartBar, size: AppConstants.size.icon.regular),
+                semanticsLabel: 'Reports',
+                onPress: () => context.push(AppRoutes.reports.path),
+              ),
             ),
-          fu.FHeaderAction(
-            icon: Icon(fu.FLucideIcons.settings, size: AppConstants.size.icon.regular),
-            onPress: () => context.push(AppRoutes.settings.path),
+          fu.FTooltip(
+            tipBuilder: (context, _) => const Text('Settings'),
+            child: fu.FHeaderAction(
+              icon: Icon(fu.FLucideIcons.settings, size: AppConstants.size.icon.regular),
+              semanticsLabel: 'Settings',
+              onPress: () => context.push(AppRoutes.settings.path),
+            ),
           ),
         ],
         title: Row(

--- a/lib/features/home/presentation/widgets/agenda_task_tile.dart
+++ b/lib/features/home/presentation/widgets/agenda_task_tile.dart
@@ -12,80 +12,102 @@ import '../../../tasks/domain/entities/today_agenda_item.dart';
 import '../../../tasks/presentation/commands/task_commands.dart';
 import '../../../tasks/presentation/widgets/task_priority_badge.dart';
 
-class AgendaTaskTile extends ConsumerWidget {
+class AgendaTaskTile extends ConsumerStatefulWidget {
   final TodayAgendaItem item;
 
   const AgendaTaskTile({super.key, required this.item});
 
+  @override
+  ConsumerState<AgendaTaskTile> createState() => _AgendaTaskTileState();
+}
+
+class _AgendaTaskTileState extends ConsumerState<AgendaTaskTile> {
+  bool _hovered = false;
+
   String get _subtitle {
-    return switch (item.kind) {
-      TodayAgendaKind.overdue => item.occurrenceDate.toRelativeDueString(),
+    return switch (widget.item.kind) {
+      TodayAgendaKind.overdue => widget.item.occurrenceDate.toRelativeDueString(),
       TodayAgendaKind.dueToday => 'Due today',
       TodayAgendaKind.habitOccurrence => 'Habit',
     };
   }
 
   Color _subtitleColor(BuildContext context) {
-    if (item.kind == TodayAgendaKind.overdue) return context.colors.destructive;
+    if (widget.item.kind == TodayAgendaKind.overdue) return context.colors.destructive;
     return context.colors.mutedForeground;
   }
 
   Future<void> _onToggle() async {
-    if (item.isCompleted) return;
-    await TaskCommands.completeAgendaItem(item);
+    if (widget.item.isCompleted) return;
+    await TaskCommands.completeAgendaItem(widget.item);
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final task = item.task;
+  Widget build(BuildContext context) {
+    final task = widget.item.task;
 
-    return GestureDetector(
-      onTap: () {
-        if (task.id == null) return;
-        context.push(AppRoutes.taskDetailPath(task.id!), extra: {'projectId': task.projectId});
-      },
-      child: fu.FCard(
-        child: Padding(
-          padding: EdgeInsets.all(AppConstants.spacing.large),
-          child: Row(
-            children: [
-              fu.FCheckbox(value: item.isCompleted, onChange: item.isCompleted ? null : (_) => _onToggle()),
-              SizedBox(width: AppConstants.spacing.regular),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      task.title,
-                      style: context.typography.sm.copyWith(
-                        fontWeight: FontWeight.w500,
-                        color: item.isCompleted ? context.colors.mutedForeground : context.colors.foreground,
-                        decoration: item.isCompleted ? TextDecoration.lineThrough : null,
-                      ),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      child: AnimatedContainer(
+        duration: AppConstants.animation.short,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(AppConstants.border.radius.regular),
+          color: _hovered ? context.colors.muted.withValues(alpha: 0.45) : Colors.transparent,
+        ),
+        child: GestureDetector(
+          onTap: () {
+            if (task.id == null) return;
+            context.push(AppRoutes.taskDetailPath(task.id!), extra: {'projectId': task.projectId});
+          },
+          child: fu.FCard(
+            child: Padding(
+              padding: EdgeInsets.all(AppConstants.spacing.large),
+              child: Row(
+                children: [
+                  fu.FCheckbox(
+                    value: widget.item.isCompleted,
+                    onChange: widget.item.isCompleted ? null : (_) => _onToggle(),
+                  ),
+                  SizedBox(width: AppConstants.spacing.regular),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          task.title,
+                          style: context.typography.sm.copyWith(
+                            fontWeight: FontWeight.w500,
+                            color: widget.item.isCompleted ? context.colors.mutedForeground : context.colors.foreground,
+                            decoration: widget.item.isCompleted ? TextDecoration.lineThrough : null,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        SizedBox(height: AppConstants.spacing.extraSmall),
+                        Text(
+                          _subtitle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: context.typography.xs.copyWith(color: _subtitleColor(context)),
+                        ),
+                      ],
                     ),
-                    SizedBox(height: AppConstants.spacing.extraSmall),
-                    Text(
-                      _subtitle,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: context.typography.xs.copyWith(color: _subtitleColor(context)),
+                  ),
+                  SizedBox(width: AppConstants.spacing.small),
+                  TaskPriorityBadge(priority: task.priority),
+                  if (!widget.item.isCompleted && task.id != null) ...[
+                    SizedBox(width: AppConstants.spacing.small),
+                    fu.FButton(
+                      variant: .ghost,
+                      onPress: () => FocusCommands.start(context, ref, taskId: task.id!),
+                      child: Icon(fu.FLucideIcons.play, size: AppConstants.size.icon.extraSmall),
                     ),
                   ],
-                ),
+                ],
               ),
-              SizedBox(width: AppConstants.spacing.small),
-              TaskPriorityBadge(priority: task.priority),
-              if (!item.isCompleted && task.id != null) ...[
-                SizedBox(width: AppConstants.spacing.small),
-                fu.FButton(
-                  variant: .ghost,
-                  onPress: () => FocusCommands.start(context, ref, taskId: task.id!),
-                  child: Icon(fu.FLucideIcons.play, size: AppConstants.size.icon.extraSmall),
-                ),
-              ],
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/features/projects/presentation/screens/project_detail_screen.dart
+++ b/lib/features/projects/presentation/screens/project_detail_screen.dart
@@ -269,17 +269,25 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
         prefixes: [fu.FHeaderAction.back(onPress: () => context.pop())],
         title: Text('Project Details'),
         suffixes: [
-          fu.FHeaderAction(
-            icon: Icon(fu.FLucideIcons.search),
-            onPress: () {
-              _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.easeOut);
-              setState(() => _tab = ProjectDetailTab.tasks);
-              _searchFocusNode.requestFocus();
-            },
+          fu.FTooltip(
+            tipBuilder: (context, _) => const Text('Search tasks'),
+            child: fu.FHeaderAction(
+              icon: Icon(fu.FLucideIcons.search),
+              semanticsLabel: 'Search tasks',
+              onPress: () {
+                _scrollController.animateTo(0, duration: const Duration(milliseconds: 300), curve: Curves.easeOut);
+                setState(() => _tab = ProjectDetailTab.tasks);
+                _searchFocusNode.requestFocus();
+              },
+            ),
           ),
-          fu.FHeaderAction(
-            icon: const Icon(fu.FLucideIcons.plus),
-            onPress: () => TaskCommands.create(context, projectId: widget.projectId),
+          fu.FTooltip(
+            tipBuilder: (context, _) => const Text('Create task'),
+            child: fu.FHeaderAction(
+              icon: const Icon(fu.FLucideIcons.plus),
+              semanticsLabel: 'Create task',
+              onPress: () => TaskCommands.create(context, projectId: widget.projectId),
+            ),
           ),
           projectAsync.maybeWhen(
             data: (project) {

--- a/lib/features/projects/presentation/screens/project_list_screen.dart
+++ b/lib/features/projects/presentation/screens/project_list_screen.dart
@@ -150,7 +150,14 @@ class ProjectListScreen extends ConsumerWidget {
         ],
         title: Text('Projects', style: context.typography.xl2.copyWith(fontWeight: FontWeight.w700)),
         suffixes: [
-          fu.FHeaderAction(icon: const Icon(fu.FLucideIcons.plus), onPress: () => ProjectCommands.create(context)),
+          fu.FTooltip(
+            tipBuilder: (context, _) => const Text('Create project'),
+            child: fu.FHeaderAction(
+              icon: const Icon(fu.FLucideIcons.plus),
+              semanticsLabel: 'Create project',
+              onPress: () => ProjectCommands.create(context),
+            ),
+          ),
         ],
       ),
       child: content,

--- a/lib/features/reports/presentation/screens/reports_screen.dart
+++ b/lib/features/reports/presentation/screens/reports_screen.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../../../../core/config/theme/app_theme.dart';
 import '../../../../core/constants/app_constants.dart';
 import '../../../../core/routing/routes.dart';
+import '../../../../core/widgets/constrained_content.dart';
 import '../../../home/presentation/widgets/global_stats_row.dart';
 import '../../../home/presentation/widgets/section_header.dart';
 import '../../../home/presentation/widgets/today_summary_card.dart';
@@ -45,29 +46,32 @@ class ReportsScreen extends ConsumerWidget {
         title: Text('Reports', style: context.typography.xl2.copyWith(fontWeight: FontWeight.w700)),
         suffixes: const [ReportsCsvExportButton()],
       ),
-      child: SingleChildScrollView(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          spacing: AppConstants.spacing.regular,
-          children: [
-            TodaySummaryCard(stats: stats),
-            SizedBox(height: AppConstants.spacing.regular),
-            SectionHeader(title: 'Overall Stats'),
-            GlobalStatsRow(stats: stats),
-            SizedBox(height: AppConstants.spacing.regular),
-            const YearActivityGraph(),
-            SizedBox(height: AppConstants.spacing.regular),
-            const ProductivityInsightsSection(),
-            SizedBox(height: AppConstants.spacing.large),
-            const HabitConsistencySection(),
-            SizedBox(height: AppConstants.spacing.large),
-            const EstimateAccuracySection(),
-            SizedBox(height: AppConstants.spacing.large),
-            const TimeBreakdownSection(),
-            SizedBox(height: AppConstants.spacing.large),
-            const TaskThroughputSection(),
-            SizedBox(height: AppConstants.spacing.regular),
-          ],
+      child: ConstrainedContent(
+        maxWidth: 800,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            spacing: AppConstants.spacing.regular,
+            children: [
+              TodaySummaryCard(stats: stats),
+              SizedBox(height: AppConstants.spacing.regular),
+              SectionHeader(title: 'Overall Stats'),
+              GlobalStatsRow(stats: stats),
+              SizedBox(height: AppConstants.spacing.regular),
+              const YearActivityGraph(),
+              SizedBox(height: AppConstants.spacing.regular),
+              const ProductivityInsightsSection(),
+              SizedBox(height: AppConstants.spacing.large),
+              const HabitConsistencySection(),
+              SizedBox(height: AppConstants.spacing.large),
+              const EstimateAccuracySection(),
+              SizedBox(height: AppConstants.spacing.large),
+              const TimeBreakdownSection(),
+              SizedBox(height: AppConstants.spacing.large),
+              const TaskThroughputSection(),
+              SizedBox(height: AppConstants.spacing.regular),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/features/reports/presentation/widgets/reports_csv_export_button.dart
+++ b/lib/features/reports/presentation/widgets/reports_csv_export_button.dart
@@ -18,9 +18,13 @@ class ReportsCsvExportButton extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return fu.FHeaderAction(
-      icon: Icon(fu.FLucideIcons.download, size: AppConstants.size.icon.regular),
-      onPress: () => _export(context, ref),
+    return fu.FTooltip(
+      tipBuilder: (context, _) => const Text('Export CSV'),
+      child: fu.FHeaderAction(
+        icon: Icon(fu.FLucideIcons.download, size: AppConstants.size.icon.regular),
+        semanticsLabel: 'Export CSV',
+        onPress: () => _export(context, ref),
+      ),
     );
   }
 

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/config/theme/app_theme.dart';
 import '../../../../core/routing/routes.dart';
+import '../../../../core/widgets/constrained_content.dart';
 import '../providers/settings_provider.dart';
 import '../widgets/settings_content.dart';
 
@@ -31,13 +32,16 @@ class SettingsScreen extends ConsumerWidget {
         ],
         title: Text('Settings', style: context.typography.xl2.copyWith(fontWeight: FontWeight.w700)),
       ),
-      child: prefsAsync.when(
-        loading: () => const Center(child: fu.FCircularProgress()),
-        error: (err, _) => Center(child: Text('Error: $err')),
-        data: (prefs) => timerAsync.when(
+      child: ConstrainedContent(
+        maxWidth: 800,
+        child: prefsAsync.when(
           loading: () => const Center(child: fu.FCircularProgress()),
           error: (err, _) => Center(child: Text('Error: $err')),
-          data: (timerPrefs) => SettingsContent(prefs: prefs, timerPrefs: timerPrefs),
+          data: (prefs) => timerAsync.when(
+            loading: () => const Center(child: fu.FCircularProgress()),
+            error: (err, _) => Center(child: Text('Error: $err')),
+            data: (timerPrefs) => SettingsContent(prefs: prefs, timerPrefs: timerPrefs),
+          ),
         ),
       ),
     );

--- a/lib/features/tasks/presentation/screens/all_tasks_screen.dart
+++ b/lib/features/tasks/presentation/screens/all_tasks_screen.dart
@@ -52,9 +52,13 @@ class AllTasksScreen extends ConsumerWidget {
         ],
         title: Text('Tasks', style: context.typography.xl2.copyWith(fontWeight: FontWeight.w700)),
         suffixes: [
-          fu.FHeaderAction(
-            icon: const Icon(fu.FLucideIcons.plus),
-            onPress: () => context.push(AppRoutes.createTaskWithProject.path),
+          fu.FTooltip(
+            tipBuilder: (context, _) => const Text('Create task'),
+            child: fu.FHeaderAction(
+              icon: const Icon(fu.FLucideIcons.plus),
+              semanticsLabel: 'Create task',
+              onPress: () => context.push(AppRoutes.createTaskWithProject.path),
+            ),
           ),
         ],
       ),

--- a/lib/features/tasks/presentation/widgets/tasks_board_view.dart
+++ b/lib/features/tasks/presentation/widgets/tasks_board_view.dart
@@ -501,7 +501,7 @@ class _ColumnGapDropTarget extends StatelessWidget {
   }
 }
 
-class _BoardCard extends StatelessWidget {
+class _BoardCard extends StatefulWidget {
   final Task task;
   final bool isSelected;
   final VoidCallback onTap;
@@ -522,28 +522,45 @@ class _BoardCard extends StatelessWidget {
     required this.onAcceptWithDetails,
   });
 
+  @override
+  State<_BoardCard> createState() => _BoardCardState();
+}
+
+class _BoardCardState extends State<_BoardCard> {
+  bool _dragging = false;
+
   Widget _buildDraggable({required Widget child, required Widget feedback}) {
+    void started() {
+      setState(() => _dragging = true);
+      widget.onDragStarted();
+    }
+
+    void ended() {
+      if (_dragging) setState(() => _dragging = false);
+      widget.onDragEnded();
+    }
+
     if (PlatformUtils.isDesktop) {
       return Draggable<Task>(
-        data: task,
+        data: widget.task,
         feedback: feedback,
         childWhenDragging: Opacity(opacity: 0.35, child: child),
-        onDragStarted: onDragStarted,
-        onDragEnd: (_) => onDragEnded(),
-        onDraggableCanceled: (_, _) => onDragEnded(),
-        onDragUpdate: (details) => onDragUpdate(details.globalPosition),
+        onDragStarted: started,
+        onDragEnd: (_) => ended(),
+        onDraggableCanceled: (_, _) => ended(),
+        onDragUpdate: (details) => widget.onDragUpdate(details.globalPosition),
         child: child,
       );
     }
 
     return LongPressDraggable<Task>(
-      data: task,
+      data: widget.task,
       feedback: feedback,
       childWhenDragging: Opacity(opacity: 0.35, child: child),
-      onDragStarted: onDragStarted,
-      onDragEnd: (_) => onDragEnded(),
-      onDraggableCanceled: (_, _) => onDragEnded(),
-      onDragUpdate: (details) => onDragUpdate(details.globalPosition),
+      onDragStarted: started,
+      onDragEnd: (_) => ended(),
+      onDraggableCanceled: (_, _) => ended(),
+      onDragUpdate: (details) => widget.onDragUpdate(details.globalPosition),
       child: child,
     );
   }
@@ -551,13 +568,14 @@ class _BoardCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final card = AppCard(
-      onTap: onTap,
-      isCompleted: task.isCompleted,
-      title: Text(task.title, maxLines: 2, overflow: TextOverflow.ellipsis),
-      trailing: TaskPriorityBadge(priority: task.priority),
-      subtitle: (task.description != null && task.description!.isNotEmpty)
+      onTap: widget.onTap,
+      isCompleted: widget.task.isCompleted,
+      mouseCursor: _dragging ? SystemMouseCursors.grabbing : SystemMouseCursors.grab,
+      title: Text(widget.task.title, maxLines: 2, overflow: TextOverflow.ellipsis),
+      trailing: TaskPriorityBadge(priority: widget.task.priority),
+      subtitle: (widget.task.description != null && widget.task.description!.isNotEmpty)
           ? Text(
-              task.description!,
+              widget.task.description!,
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
               style: context.typography.xs.copyWith(color: context.colors.mutedForeground),
@@ -575,26 +593,37 @@ class _BoardCard extends StatelessWidget {
       duration: const Duration(milliseconds: 120),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(AppConstants.border.radius.regular),
-        border: Border.all(color: isSelected ? context.colors.primary : Colors.transparent, width: 1.5),
+        border: Border.all(color: widget.isSelected ? context.colors.primary : Colors.transparent, width: 1.5),
       ),
       child: card,
     );
 
-    return DragTarget<Task>(
-      onWillAcceptWithDetails: (details) => details.data.id != task.id,
-      onMove: (details) {
-        final box = context.findRenderObject() as RenderBox?;
-        if (box == null) return;
-        onHoverWithDetails(details, box);
+    return Focus(
+      canRequestFocus: true,
+      onKeyEvent: (node, event) {
+        if (event is KeyDownEvent &&
+            (event.logicalKey == LogicalKeyboardKey.enter || event.logicalKey == LogicalKeyboardKey.space)) {
+          widget.onTap();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
       },
-      onAcceptWithDetails: (details) {
-        final box = context.findRenderObject() as RenderBox?;
-        if (box == null) return;
-        onAcceptWithDetails(details, box);
-      },
-      builder: (context, candidateData, _) {
-        return _buildDraggable(child: wrapped, feedback: feedback);
-      },
+      child: DragTarget<Task>(
+        onWillAcceptWithDetails: (details) => details.data.id != widget.task.id,
+        onMove: (details) {
+          final box = context.findRenderObject() as RenderBox?;
+          if (box == null) return;
+          widget.onHoverWithDetails(details, box);
+        },
+        onAcceptWithDetails: (details) {
+          final box = context.findRenderObject() as RenderBox?;
+          if (box == null) return;
+          widget.onAcceptWithDetails(details, box);
+        },
+        builder: (context, candidateData, _) {
+          return _buildDraggable(child: wrapped, feedback: feedback);
+        },
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch feat/ui-desktop-polish into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
a209d9c feat(ui): add desktop hover cursors and tooltips

### Files
- lib/core/widgets/app_card.dart
- lib/core/widgets/list_toolbar.dart
- lib/features/home/presentation/pages/home_screen.dart
- lib/features/home/presentation/widgets/agenda_task_tile.dart
- lib/features/projects/presentation/screens/project_detail_screen.dart
- lib/features/projects/presentation/screens/project_list_screen.dart
- lib/features/reports/presentation/screens/reports_screen.dart
- lib/features/reports/presentation/widgets/reports_csv_export_button.dart
- lib/features/settings/presentation/screens/settings_screen.dart
- lib/features/tasks/presentation/screens/all_tasks_screen.dart
- lib/features/tasks/presentation/widgets/tasks_board_view.dart

### Diffstat
 lib/core/widgets/app_card.dart                     | 106 +++++++++++-------
 lib/core/widgets/list_toolbar.dart                 |  87 +++++++++------
 .../home/presentation/pages/home_screen.dart       |  20 +++-
 .../presentation/widgets/agenda_task_tile.dart     | 124 ++++++++++++---------
 .../screens/project_detail_screen.dart             |  28 +++--
 .../presentation/screens/project_list_screen.dart  |   9 +-
 .../presentation/screens/reports_screen.dart       |  50 +++++----
 .../widgets/reports_csv_export_button.dart         |  10 +-
 .../presentation/screens/settings_screen.dart      |  14 ++-
 .../presentation/screens/all_tasks_screen.dart     |  10 +-
 .../presentation/widgets/tasks_board_view.dart     |  93 ++++++++++------
 11 files changed, 345 insertions(+), 206 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
