### PR TITLE
feat(ui): polish mobile filters and touch targets

### DIFF
--- a/.agents/docs/patterns.md
+++ b/.agents/docs/patterns.md
@@ -501,6 +501,56 @@ UI hooks:
 Use `AppEmptyState` for board/calendar agenda/timeline/milestones empty surfaces.
 Home may keep `EmptySection` or migrate to `AppEmptyState` — prefer the core widget for new views.
 
+## ListToolbar Overflow Pattern
+
+`ListToolbar` keeps search + optional view switcher + filter (+ create) on one row.
+
+```dart
+ListToolbar(
+  searchHint: 'Search tasks...',
+  onSearchChanged: (q) => notifier.updateFilter(searchQuery: q),
+  filterPanel: const AllTasksFilterPanel(),
+  activeFilterCount: count,
+  activeFilters: chips,
+  onReset: () => notifier.reset(), // sheet Reset button
+  viewModeControl: TasksViewModeToggle(...), // optional
+);
+```
+
+Overflow rules:
+- Pane width `< 360`: icon-only create/filter (with `FTooltip`) via `ListToolbarLayout.iconOnly`.
+- Window width `< 400`: filters open in a bottom `FSheet` (drag handle + Reset/Done).
+- Wider panes: filters open in an `FPopover` anchored to the filter button.
+- Active-filter chips always render under the toolbar row when non-empty.
+
+## Adaptive Drag Pattern
+
+Board (and similar) cards use immediate drag on desktop and long-press drag on touch:
+
+```dart
+Widget _buildDraggable({required Widget child, required Widget feedback}) {
+  if (PlatformUtils.isDesktop) {
+    return Draggable<Task>(
+      data: task,
+      feedback: feedback,
+      childWhenDragging: Opacity(opacity: 0.35, child: child),
+      child: child,
+    );
+  }
+  return LongPressDraggable<Task>(
+    data: task,
+    feedback: feedback,
+    childWhenDragging: Opacity(opacity: 0.35, child: child),
+    child: child,
+  );
+}
+```
+
+Gotchas:
+- Desktop: `SystemMouseCursors.grab` / `grabbing` on board cards.
+- Touch: long-press avoids fighting vertical scroll / page swipe.
+- Pair with edge auto-scroll while dragging in compact PageView boards.
+
 ## Mandatory Follow-Up
 
 When a new pattern is introduced in production code, add it here with:

--- a/lib/core/widgets/app_card.dart
+++ b/lib/core/widgets/app_card.dart
@@ -38,7 +38,7 @@ class _AppCardState extends State<AppCard> {
 
   @override
   Widget build(BuildContext context) {
-    const double leadingWidth = 32.0;
+    const double leadingSlot = 44.0;
     final tappable = widget.onTap != null;
 
     return MouseRegion(
@@ -64,7 +64,12 @@ class _AppCardState extends State<AppCard> {
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        if (widget.leading != null) SizedBox(width: leadingWidth, child: widget.leading!),
+                        if (widget.leading != null)
+                          SizedBox(
+                            width: leadingSlot,
+                            height: leadingSlot,
+                            child: Center(child: widget.leading!),
+                          ),
                         Expanded(
                           child: DefaultTextStyle(
                             style: context.typography.md.copyWith(
@@ -82,7 +87,7 @@ class _AppCardState extends State<AppCard> {
                       ],
                     ),
                     Padding(
-                      padding: EdgeInsets.only(left: widget.leading != null ? leadingWidth : 0),
+                      padding: EdgeInsets.only(left: widget.leading != null ? leadingSlot : 0),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         mainAxisSize: MainAxisSize.min,

--- a/lib/core/widgets/calendar/calendar_week_day_cell.dart
+++ b/lib/core/widgets/calendar/calendar_week_day_cell.dart
@@ -25,60 +25,63 @@ class CalendarWeekDayCell extends StatelessWidget {
     final dayLabel = DateTimeConstants.shortWeekdayNames[date.weekday - 1];
     final indicatorCount = (taskCount + (sessionCount > 0 ? 1 : 0)).clamp(0, 3);
 
-    return Container(
-      height: 64,
-      padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.small, vertical: AppConstants.spacing.small),
-      decoration: BoxDecoration(
-        color: isSelected
-            ? context.colors.primary
-            : isToday
-            ? context.colors.primary.withValues(alpha: 0.1)
-            : context.colors.muted.withValues(alpha: 0.18),
-        borderRadius: BorderRadius.circular(AppConstants.border.radius.regular),
-      ),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text(
-            dayLabel,
-            style: context.typography.xs.copyWith(
-              color: isSelected ? context.colors.primaryForeground : context.colors.mutedForeground,
-              fontWeight: FontWeight.w500,
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minHeight: 64, minWidth: 44),
+      child: Container(
+        padding: EdgeInsets.symmetric(horizontal: AppConstants.spacing.small, vertical: AppConstants.spacing.small),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? context.colors.primary
+              : isToday
+              ? context.colors.primary.withValues(alpha: 0.1)
+              : context.colors.muted.withValues(alpha: 0.18),
+          borderRadius: BorderRadius.circular(AppConstants.border.radius.regular),
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              dayLabel,
+              style: context.typography.xs.copyWith(
+                color: isSelected ? context.colors.primaryForeground : context.colors.mutedForeground,
+                fontWeight: FontWeight.w500,
+              ),
             ),
-          ),
-          SizedBox(height: AppConstants.spacing.extraSmall),
-          Text(
-            '${date.day}',
-            style: context.typography.sm.copyWith(
-              color: isSelected ? context.colors.primaryForeground : context.colors.foreground,
-              fontWeight: FontWeight.w700,
+            SizedBox(height: AppConstants.spacing.extraSmall),
+            Text(
+              '${date.day}',
+              style: context.typography.sm.copyWith(
+                color: isSelected ? context.colors.primaryForeground : context.colors.foreground,
+                fontWeight: FontWeight.w700,
+              ),
             ),
-          ),
-          SizedBox(height: AppConstants.spacing.extraSmall),
-          if (indicatorCount > 0)
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                for (var i = 0; i < indicatorCount; i++) ...[
-                  Container(
-                    width: 4,
-                    height: 4,
-                    decoration: BoxDecoration(
-                      color: isSelected
-                          ? context.colors.primaryForeground.withValues(alpha: 0.85)
-                          : (i == 0 && sessionCount > 0 && taskCount == 0)
-                          ? context.colors.secondary
-                          : context.colors.primary,
-                      shape: BoxShape.circle,
+            SizedBox(height: AppConstants.spacing.extraSmall),
+            if (indicatorCount > 0)
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (var i = 0; i < indicatorCount; i++) ...[
+                    Container(
+                      width: 4,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: isSelected
+                            ? context.colors.primaryForeground.withValues(alpha: 0.85)
+                            : (i == 0 && sessionCount > 0 && taskCount == 0)
+                            ? context.colors.secondary
+                            : context.colors.primary,
+                        shape: BoxShape.circle,
+                      ),
                     ),
-                  ),
-                  if (i < indicatorCount - 1) SizedBox(width: AppConstants.spacing.extraSmall),
+                    if (i < indicatorCount - 1) SizedBox(width: AppConstants.spacing.extraSmall),
+                  ],
                 ],
-              ],
-            )
-          else
-            const SizedBox(height: 4),
-        ],
+              )
+            else
+              const SizedBox(height: 4),
+          ],
+        ),
       ),
     );
   }

--- a/lib/core/widgets/list_toolbar.dart
+++ b/lib/core/widgets/list_toolbar.dart
@@ -26,6 +26,7 @@ class ListToolbar extends StatelessWidget {
   final String createLabel;
   final Widget? viewModeControl;
   final FocusNode? searchFocusNode;
+  final VoidCallback? onReset;
 
   const ListToolbar({
     super.key,
@@ -38,6 +39,7 @@ class ListToolbar extends StatelessWidget {
     this.createLabel = 'Create',
     this.viewModeControl,
     this.searchFocusNode,
+    this.onReset,
   });
 
   @override
@@ -58,7 +60,12 @@ class ListToolbar extends StatelessWidget {
                     ),
                     if (viewModeControl != null) ...[SizedBox(width: AppConstants.spacing.small), viewModeControl!],
                     SizedBox(width: AppConstants.spacing.small),
-                    _FilterTrigger(activeFilterCount: activeFilterCount, filterPanel: filterPanel, iconOnly: narrow),
+                    _FilterTrigger(
+                      activeFilterCount: activeFilterCount,
+                      filterPanel: filterPanel,
+                      iconOnly: narrow,
+                      onReset: onReset,
+                    ),
                     if (onCreate != null) ...[
                       SizedBox(width: AppConstants.spacing.small),
                       if (narrow)
@@ -113,8 +120,14 @@ class _FilterTrigger extends StatefulWidget {
   final int activeFilterCount;
   final Widget filterPanel;
   final bool iconOnly;
+  final VoidCallback? onReset;
 
-  const _FilterTrigger({required this.activeFilterCount, required this.filterPanel, required this.iconOnly});
+  const _FilterTrigger({
+    required this.activeFilterCount,
+    required this.filterPanel,
+    required this.iconOnly,
+    this.onReset,
+  });
 
   @override
   State<_FilterTrigger> createState() => _FilterTriggerState();
@@ -135,16 +148,51 @@ class _FilterTriggerState extends State<_FilterTrigger> with SingleTickerProvide
       context: context,
       side: .btt,
       mainAxisMaxRatio: 0.7,
-      builder: (context) => SafeArea(
+      builder: (sheetContext) => SafeArea(
         child: Padding(
-          padding: EdgeInsets.all(AppConstants.spacing.regular),
+          padding: EdgeInsets.fromLTRB(
+            AppConstants.spacing.regular,
+            AppConstants.spacing.small,
+            AppConstants.spacing.regular,
+            AppConstants.spacing.regular,
+          ),
           child: Column(
             mainAxisSize: .min,
             crossAxisAlignment: .stretch,
             children: [
-              Text('Filters', style: context.typography.lg.copyWith(fontWeight: FontWeight.w700)),
+              Center(
+                child: Container(
+                  width: 36,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: sheetContext.colors.mutedForeground.withValues(alpha: 0.35),
+                    borderRadius: BorderRadius.circular(999),
+                  ),
+                ),
+              ),
+              SizedBox(height: AppConstants.spacing.regular),
+              Text('Filters', style: sheetContext.typography.lg.copyWith(fontWeight: FontWeight.w700)),
               SizedBox(height: AppConstants.spacing.regular),
               FilterSelectGroup(groupId: _groupId, child: widget.filterPanel),
+              SizedBox(height: AppConstants.spacing.regular),
+              Row(
+                children: [
+                  if (widget.onReset != null)
+                    Expanded(
+                      child: fu.FButton(
+                        variant: .outline,
+                        onPress: () {
+                          widget.onReset!();
+                        },
+                        child: const Text('Reset'),
+                      ),
+                    ),
+                  if (widget.onReset != null) SizedBox(width: AppConstants.spacing.small),
+                  Expanded(
+                    child: fu.FButton(onPress: () => Navigator.of(sheetContext).pop(), child: const Text('Done')),
+                  ),
+                ],
+              ),
             ],
           ),
         ),

--- a/lib/core/widgets/sort_filter_chips.dart
+++ b/lib/core/widgets/sort_filter_chips.dart
@@ -44,10 +44,13 @@ class SortFilterChips<T extends SortCriteria> extends StatelessWidget {
           spacing: AppConstants.spacing.small,
           children: [
             for (final criteria in criteriaOptions)
-              FButton(
-                variant: selectedCriteria == criteria ? .secondary : .outline,
-                onPress: () => onChanged(criteria),
-                child: Text(criteria.label, style: context.typography.xs),
+              ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 44),
+                child: FButton(
+                  variant: selectedCriteria == criteria ? .secondary : .outline,
+                  onPress: () => onChanged(criteria),
+                  child: Text(criteria.label, style: context.typography.xs),
+                ),
               ),
           ],
         ),

--- a/lib/features/home/presentation/widgets/agenda_task_tile.dart
+++ b/lib/features/home/presentation/widgets/agenda_task_tile.dart
@@ -66,11 +66,17 @@ class _AgendaTaskTileState extends ConsumerState<AgendaTaskTile> {
               padding: EdgeInsets.all(AppConstants.spacing.large),
               child: Row(
                 children: [
-                  fu.FCheckbox(
-                    value: widget.item.isCompleted,
-                    onChange: widget.item.isCompleted ? null : (_) => _onToggle(),
+                  SizedBox(
+                    width: 44,
+                    height: 44,
+                    child: Center(
+                      child: fu.FCheckbox(
+                        value: widget.item.isCompleted,
+                        onChange: widget.item.isCompleted ? null : (_) => _onToggle(),
+                      ),
+                    ),
                   ),
-                  SizedBox(width: AppConstants.spacing.regular),
+                  SizedBox(width: AppConstants.spacing.small),
                   Expanded(
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/projects/presentation/providers/project_list_filter_provider.part.dart
+++ b/lib/features/projects/presentation/providers/project_list_filter_provider.part.dart
@@ -24,4 +24,8 @@ class ProjectListFilter extends _$ProjectListFilter {
   void clearStatusFilter() {
     state = state.copyWith(statusFilter: null);
   }
+
+  void reset() {
+    state = const ProjectListFilterState();
+  }
 }

--- a/lib/features/projects/presentation/providers/project_provider.g.dart
+++ b/lib/features/projects/presentation/providers/project_provider.g.dart
@@ -37,7 +37,7 @@ final class ProjectListFilterProvider extends $NotifierProvider<ProjectListFilte
   }
 }
 
-String _$projectListFilterHash() => r'1bde76ced7bafe610c8d65a86b6c344528bdf76a';
+String _$projectListFilterHash() => r'f163a35a4b18c82b242119466b56527657f7c179';
 
 abstract class _$ProjectListFilter extends $Notifier<ProjectListFilterState> {
   ProjectListFilterState build();

--- a/lib/features/projects/presentation/screens/project_detail_screen.dart
+++ b/lib/features/projects/presentation/screens/project_detail_screen.dart
@@ -65,42 +65,55 @@ class _ProjectDetailScreenState extends ConsumerState<ProjectDetailScreen> {
       onSearchChanged: (query) => notifier.updateFilter(searchQuery: query),
       filterPanel: ProjectTasksFilterPanel(projectIdString: _projectIdString),
       activeFilterCount: _activeFilterCount(filter),
+      onReset: () => notifier.reset(),
       activeFilters: [
         if (filter.priorityFilter != null)
-          fu.FButton(
-            size: .xs,
-            mainAxisSize: .min,
-            variant: .secondary,
-            suffix: const Icon(fu.FLucideIcons.x),
-            onPress: () => notifier.updateFilter(priorityFilter: null),
-            child: Text(filter.priorityFilter!.label),
+          ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: 44),
+            child: fu.FButton(
+              size: .xs,
+              mainAxisSize: .min,
+              variant: .secondary,
+              suffix: const Icon(fu.FLucideIcons.x),
+              onPress: () => notifier.updateFilter(priorityFilter: null),
+              child: Text(filter.priorityFilter!.label),
+            ),
           ),
         if (filter.completionFilter != TaskCompletionFilter.all)
-          fu.FButton(
-            size: .xs,
-            mainAxisSize: .min,
-            variant: .secondary,
-            suffix: const Icon(fu.FLucideIcons.x),
-            onPress: () => notifier.updateFilter(completionFilter: TaskCompletionFilter.all),
-            child: Text(filter.completionFilter.label),
+          ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: 44),
+            child: fu.FButton(
+              size: .xs,
+              mainAxisSize: .min,
+              variant: .secondary,
+              suffix: const Icon(fu.FLucideIcons.x),
+              onPress: () => notifier.updateFilter(completionFilter: TaskCompletionFilter.all),
+              child: Text(filter.completionFilter.label),
+            ),
           ),
         if (filter.sortCriteria != TaskSortCriteria.recentlyModified)
-          fu.FButton(
-            size: .xs,
-            mainAxisSize: .min,
-            variant: .secondary,
-            suffix: const Icon(fu.FLucideIcons.x),
-            onPress: () => notifier.updateFilter(sortCriteria: TaskSortCriteria.recentlyModified),
-            child: Text(filter.sortCriteria.label),
+          ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: 44),
+            child: fu.FButton(
+              size: .xs,
+              mainAxisSize: .min,
+              variant: .secondary,
+              suffix: const Icon(fu.FLucideIcons.x),
+              onPress: () => notifier.updateFilter(sortCriteria: TaskSortCriteria.recentlyModified),
+              child: Text(filter.sortCriteria.label),
+            ),
           ),
         if (filter.sortOrder != TaskSortOrder.none)
-          fu.FButton(
-            size: .xs,
-            mainAxisSize: .min,
-            variant: .secondary,
-            suffix: const Icon(fu.FLucideIcons.x),
-            onPress: () => notifier.updateFilter(sortOrder: TaskSortOrder.none),
-            child: Text(filter.sortOrder.label),
+          ConstrainedBox(
+            constraints: const BoxConstraints(minHeight: 44),
+            child: fu.FButton(
+              size: .xs,
+              mainAxisSize: .min,
+              variant: .secondary,
+              suffix: const Icon(fu.FLucideIcons.x),
+              onPress: () => notifier.updateFilter(sortOrder: TaskSortOrder.none),
+              child: Text(filter.sortOrder.label),
+            ),
           ),
       ],
     );

--- a/lib/features/projects/presentation/screens/project_list_screen.dart
+++ b/lib/features/projects/presentation/screens/project_list_screen.dart
@@ -51,27 +51,34 @@ class ProjectListScreen extends ConsumerWidget {
             },
             filterPanel: const ProjectFilterPanel(),
             activeFilterCount: activeCount,
+            onReset: () => ref.read(projectListFilterProvider.notifier).reset(),
             activeFilters: [
               if (filter.sortCriteria != ProjectSortCriteria.recentlyModified)
-                fu.FButton(
-                  size: .xs,
-                  mainAxisSize: .min,
-                  variant: .secondary,
-                  suffix: const Icon(fu.FLucideIcons.x),
-                  onPress: () => ref
-                      .read(projectListFilterProvider.notifier)
-                      .updateFilter(sortCriteria: ProjectSortCriteria.recentlyModified),
-                  child: Text(filter.sortCriteria.label),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 44),
+                  child: fu.FButton(
+                    size: .xs,
+                    mainAxisSize: .min,
+                    variant: .secondary,
+                    suffix: const Icon(fu.FLucideIcons.x),
+                    onPress: () => ref
+                        .read(projectListFilterProvider.notifier)
+                        .updateFilter(sortCriteria: ProjectSortCriteria.recentlyModified),
+                    child: Text(filter.sortCriteria.label),
+                  ),
                 ),
               if (filter.sortOrder != ProjectSortOrder.none)
-                fu.FButton(
-                  size: .xs,
-                  mainAxisSize: .min,
-                  variant: .secondary,
-                  suffix: const Icon(fu.FLucideIcons.x),
-                  onPress: () =>
-                      ref.read(projectListFilterProvider.notifier).updateFilter(sortOrder: ProjectSortOrder.none),
-                  child: Text(filter.sortOrder.label),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(minHeight: 44),
+                  child: fu.FButton(
+                    size: .xs,
+                    mainAxisSize: .min,
+                    variant: .secondary,
+                    suffix: const Icon(fu.FLucideIcons.x),
+                    onPress: () =>
+                        ref.read(projectListFilterProvider.notifier).updateFilter(sortOrder: ProjectSortOrder.none),
+                    child: Text(filter.sortOrder.label),
+                  ),
                 ),
             ],
             onCreate: _isEmbedded ? () => ProjectCommands.create(context) : null,

--- a/lib/features/tasks/presentation/providers/all_tasks_provider.dart
+++ b/lib/features/tasks/presentation/providers/all_tasks_provider.dart
@@ -44,4 +44,8 @@ class AllTasksFilter extends _$AllTasksFilter {
   void clearStatusFilter() {
     state = state.copyWith(statusFilter: null);
   }
+
+  void reset() {
+    state = const AllTasksFilterState();
+  }
 }

--- a/lib/features/tasks/presentation/providers/all_tasks_provider.g.dart
+++ b/lib/features/tasks/presentation/providers/all_tasks_provider.g.dart
@@ -37,7 +37,7 @@ final class AllTasksFilterProvider extends $NotifierProvider<AllTasksFilter, All
   }
 }
 
-String _$allTasksFilterHash() => r'2131da495617e008bdce4b52d4e9a5259106856d';
+String _$allTasksFilterHash() => r'7db6a5912648cca33e102316879cd8d7c152b6dc';
 
 abstract class _$AllTasksFilter extends $Notifier<AllTasksFilterState> {
   AllTasksFilterState build();

--- a/lib/features/tasks/presentation/providers/task_provider.g.dart
+++ b/lib/features/tasks/presentation/providers/task_provider.g.dart
@@ -52,7 +52,7 @@ final class TaskListFilterProvider extends $NotifierProvider<TaskListFilter, Tas
   }
 }
 
-String _$taskListFilterHash() => r'9f69f2f8a9bf678421a4eebe1d07b9568b9a66dd';
+String _$taskListFilterHash() => r'99b58694e9dc7ca9609c43b08b151b3cc1ad27b2';
 
 final class TaskListFilterFamily extends $Family
     with $ClassFamilyOverride<TaskListFilter, TaskListFilterState, TaskListFilterState, TaskListFilterState, String> {

--- a/lib/features/tasks/presentation/widgets/all_tasks_content.dart
+++ b/lib/features/tasks/presentation/widgets/all_tasks_content.dart
@@ -49,25 +49,33 @@ class AllTasksContent extends ConsumerWidget {
           ),
           filterPanel: const AllTasksFilterPanel(),
           activeFilterCount: activeCount,
+          onReset: () => ref.read(allTasksFilterProvider.notifier).reset(),
           activeFilters: [
             if (filter.priorityFilter != null)
-              fu.FButton(
-                size: .xs,
-                mainAxisSize: .min,
-                variant: .secondary,
-                suffix: const Icon(fu.FLucideIcons.x),
-                onPress: () => ref.read(allTasksFilterProvider.notifier).updateFilter(priorityFilter: null),
-                child: Text(filter.priorityFilter!.label),
+              ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 44),
+                child: fu.FButton(
+                  size: .xs,
+                  mainAxisSize: .min,
+                  variant: .secondary,
+                  suffix: const Icon(fu.FLucideIcons.x),
+                  onPress: () => ref.read(allTasksFilterProvider.notifier).updateFilter(priorityFilter: null),
+                  child: Text(filter.priorityFilter!.label),
+                ),
               ),
             if (filter.completionFilter != TaskCompletionFilter.all)
-              fu.FButton(
-                size: .xs,
-                mainAxisSize: .min,
-                variant: .secondary,
-                suffix: const Icon(fu.FLucideIcons.x),
-                onPress: () =>
-                    ref.read(allTasksFilterProvider.notifier).updateFilter(completionFilter: TaskCompletionFilter.all),
-                child: Text(filter.completionFilter.label),
+              ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 44),
+                child: fu.FButton(
+                  size: .xs,
+                  mainAxisSize: .min,
+                  variant: .secondary,
+                  suffix: const Icon(fu.FLucideIcons.x),
+                  onPress: () => ref
+                      .read(allTasksFilterProvider.notifier)
+                      .updateFilter(completionFilter: TaskCompletionFilter.all),
+                  child: Text(filter.completionFilter.label),
+                ),
               ),
           ],
           onCreate: isEmbedded ? () => context.push(AppRoutes.createTaskWithProject.path) : null,

--- a/lib/features/tasks/presentation/widgets/all_tasks_filter_panel.dart
+++ b/lib/features/tasks/presentation/widgets/all_tasks_filter_panel.dart
@@ -47,12 +47,15 @@ class AllTasksFilterPanel extends ConsumerWidget {
           runSpacing: AppConstants.spacing.small,
           children: [
             for (final f in TaskCompletionFilter.values)
-              fu.FButton(
-                size: .sm,
-                mainAxisSize: .min,
-                variant: filter.completionFilter == f ? .secondary : .outline,
-                onPress: () => notifier.updateFilter(completionFilter: f),
-                child: Text(f.label, style: context.typography.xs),
+              ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 44),
+                child: fu.FButton(
+                  size: .sm,
+                  mainAxisSize: .min,
+                  variant: filter.completionFilter == f ? .secondary : .outline,
+                  onPress: () => notifier.updateFilter(completionFilter: f),
+                  child: Text(f.label, style: context.typography.xs),
+                ),
               ),
           ],
         ),

--- a/lib/features/tasks/presentation/widgets/project_tasks_filter_panel.dart
+++ b/lib/features/tasks/presentation/widgets/project_tasks_filter_panel.dart
@@ -49,12 +49,15 @@ class ProjectTasksFilterPanel extends ConsumerWidget {
           runSpacing: AppConstants.spacing.small,
           children: [
             for (final f in TaskCompletionFilter.values)
-              fu.FButton(
-                size: .sm,
-                mainAxisSize: .min,
-                variant: filter.completionFilter == f ? .secondary : .outline,
-                onPress: () => notifier.updateFilter(completionFilter: f),
-                child: Text(f.label, style: context.typography.xs),
+              ConstrainedBox(
+                constraints: const BoxConstraints(minHeight: 44),
+                child: fu.FButton(
+                  size: .sm,
+                  mainAxisSize: .min,
+                  variant: filter.completionFilter == f ? .secondary : .outline,
+                  onPress: () => notifier.updateFilter(completionFilter: f),
+                  child: Text(f.label, style: context.typography.xs),
+                ),
               ),
           ],
         ),


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch feat/ui-mobile-polish into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
5f8b1ea feat(ui): polish mobile filters and touch targets

### Files
- .agents/docs/patterns.md
- lib/core/widgets/app_card.dart
- lib/core/widgets/calendar/calendar_week_day_cell.dart
- lib/core/widgets/list_toolbar.dart
- lib/core/widgets/sort_filter_chips.dart
- lib/features/home/presentation/widgets/agenda_task_tile.dart
- lib/features/projects/presentation/providers/project_list_filter_provider.part.dart
- lib/features/projects/presentation/providers/project_provider.g.dart
- lib/features/projects/presentation/screens/project_detail_screen.dart
- lib/features/projects/presentation/screens/project_list_screen.dart
- lib/features/tasks/presentation/providers/all_tasks_provider.dart
- lib/features/tasks/presentation/providers/all_tasks_provider.g.dart
- lib/features/tasks/presentation/providers/task_provider.g.dart
- lib/features/tasks/presentation/widgets/all_tasks_content.dart
- lib/features/tasks/presentation/widgets/all_tasks_filter_panel.dart
- lib/features/tasks/presentation/widgets/project_tasks_filter_panel.dart

### Diffstat
 .agents/docs/patterns.md                           |  50 ++++++++++
 lib/core/widgets/app_card.dart                     |  11 ++-
 .../widgets/calendar/calendar_week_day_cell.dart   | 103 +++++++++++----------
 lib/core/widgets/list_toolbar.dart                 |  58 +++++++++++-
 lib/core/widgets/sort_filter_chips.dart            |  11 ++-
 .../presentation/widgets/agenda_task_tile.dart     |  14 ++-
 .../project_list_filter_provider.part.dart         |   4 +
 .../presentation/providers/project_provider.g.dart |   2 +-
 .../screens/project_detail_screen.dart             |  69 ++++++++------
 .../presentation/screens/project_list_screen.dart  |  41 ++++----
 .../presentation/providers/all_tasks_provider.dart |   4 +
 .../providers/all_tasks_provider.g.dart            |   2 +-
 .../presentation/providers/task_provider.g.dart    |   2 +-
 .../presentation/widgets/all_tasks_content.dart    |  38 +++++---
 .../widgets/all_tasks_filter_panel.dart            |  15 +--
 .../widgets/project_tasks_filter_panel.dart        |  15 +--
 16 files changed, 298 insertions(+), 141 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
