### PR TITLE
fix(notifications): fix Material crash on reminder cards

### DIFF
--- a/lib/features/notifications/presentation/widgets/notification_item_card.dart
+++ b/lib/features/notifications/presentation/widgets/notification_item_card.dart
@@ -36,7 +36,10 @@ class NotificationItemCard extends StatelessWidget {
     return Padding(
       padding: EdgeInsets.only(bottom: AppConstants.spacing.small),
       child: fu.FCard(
-        child: onTap == null ? content : InkWell(onTap: onTap, borderRadius: BorderRadius.circular(12), child: content),
+        // GestureDetector matches AppCard — FCard has no Material ancestor for InkWell.
+        child: onTap == null
+            ? content
+            : GestureDetector(onTap: onTap, behavior: HitTestBehavior.opaque, child: content),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch fix/notifications-material into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
f400e26 fix(notifications): replace InkWell with GestureDetector on cards

### Files
- lib/features/notifications/presentation/widgets/notification_item_card.dart

### Diffstat
 .../notifications/presentation/widgets/notification_item_card.dart   | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
