### PR TITLE
fix(session): move end-session into scaffold footer

### DIFF
--- a/lib/features/session/presentation/screens/focus_session_screen.dart
+++ b/lib/features/session/presentation/screens/focus_session_screen.dart
@@ -12,6 +12,7 @@ import '../widgets/circular_timer.dart';
 import '../widgets/completion_overlay.dart';
 import '../widgets/focus_task_info.dart';
 import '../widgets/focus_controls_with_callback.dart';
+import '../widgets/focus_end_session_button.dart';
 
 class FocusSessionScreen extends ConsumerStatefulWidget {
   const FocusSessionScreen({super.key});
@@ -70,48 +71,54 @@ class _FocusSessionScreenState extends ConsumerState<FocusSessionScreen> {
           children: [
             FScaffold(
               header: FHeader.nested(prefixes: [FHeaderAction.back(onPress: () => context.pop())]),
-              child: Center(
-                child: Column(
-                  children: [
-                    AnimatedOpacity(
-                      duration: AppConstants.animation.medium,
-                      opacity: screenState.isControlsVisible ? 1.0 : 0.0,
-                      child: const FocusTaskInfo(),
-                    ),
-                    SizedBox(height: AppConstants.spacing.small),
-                    // Phase indicator with animated transition
-                    if (progress != null) ...[
-                      (() {
-                        final label = progress.isFocusPhase ? 'FOCUS' : 'BREAK';
-                        return AnimatedOpacity(
+              footer: FocusEndSessionButton(
+                onCompleteTask: _onCompleteTask,
+                controlsVisible: screenState.isControlsVisible,
+              ),
+              child: Column(
+                children: [
+                  AnimatedOpacity(
+                    duration: AppConstants.animation.medium,
+                    opacity: screenState.isControlsVisible ? 1.0 : 0.0,
+                    child: const FocusTaskInfo(),
+                  ),
+                  SizedBox(height: AppConstants.spacing.small),
+                  // Phase indicator with animated transition
+                  if (progress != null) ...[
+                    (() {
+                      final label = progress.isFocusPhase ? 'FOCUS' : 'BREAK';
+                      return AnimatedOpacity(
+                        duration: AppConstants.animation.medium,
+                        opacity: screenState.isControlsVisible ? 1.0 : 0.0,
+                        child: AnimatedSwitcher(
                           duration: AppConstants.animation.medium,
-                          opacity: screenState.isControlsVisible ? 1.0 : 0.0,
-                          child: AnimatedSwitcher(
-                            duration: AppConstants.animation.medium,
-                            switchInCurve: Curves.easeOut,
-                            switchOutCurve: Curves.easeIn,
-                            child: FBadge(key: ValueKey(label), variant: .secondary, child: Text(label)),
-                          ),
-                        );
-                      })(),
-                    ],
-                    SizedBox(height: AppConstants.spacing.regular),
-                    // Ambience sound marquee + mute button
-                    AnimatedOpacity(
-                      duration: AppConstants.animation.medium,
-                      opacity: screenState.isControlsVisible ? 1.0 : 0.0,
-                      child: const AmbienceMarqueeRow(),
-                    ),
-                    const Spacer(flex: 1),
-                    const CircularTimer(),
-                    SizedBox(height: AppConstants.spacing.extraLarge),
-                    FocusControlsWithCallback(
-                      onCompleteTask: _onCompleteTask,
-                      controlsVisible: screenState.isControlsVisible,
-                    ),
-                    const Spacer(flex: 2),
+                          switchInCurve: Curves.easeOut,
+                          switchOutCurve: Curves.easeIn,
+                          child: FBadge(key: ValueKey(label), variant: .secondary, child: Text(label)),
+                        ),
+                      );
+                    })(),
                   ],
-                ),
+                  SizedBox(height: AppConstants.spacing.regular),
+                  // Ambience sound marquee + mute button
+                  AnimatedOpacity(
+                    duration: AppConstants.animation.medium,
+                    opacity: screenState.isControlsVisible ? 1.0 : 0.0,
+                    child: const AmbienceMarqueeRow(),
+                  ),
+                  Expanded(
+                    child: Center(
+                      child: Column(
+                        mainAxisSize: .min,
+                        children: [
+                          const CircularTimer(),
+                          SizedBox(height: AppConstants.spacing.extraLarge),
+                          FocusControlsWithCallback(controlsVisible: screenState.isControlsVisible),
+                        ],
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
 

--- a/lib/features/session/presentation/widgets/focus_controls_with_callback.dart
+++ b/lib/features/session/presentation/widgets/focus_controls_with_callback.dart
@@ -11,134 +11,94 @@ import '../providers/focus_screen_provider.dart';
 import '../providers/focus_session_provider.dart';
 import 'focus_circle_icon_button.dart';
 
+/// Transport controls (stop / play-pause / skip) for an active focus session.
 class FocusControlsWithCallback extends ConsumerWidget {
-  final VoidCallback onCompleteTask;
   final bool controlsVisible;
 
-  const FocusControlsWithCallback({super.key, required this.onCompleteTask, required this.controlsVisible});
+  const FocusControlsWithCallback({super.key, required this.controlsVisible});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final progress = ref.watch(focusProgressProvider);
-    final session = ref.watch(focusTimerProvider);
-    final isQuickSession = session?.isQuickSession ?? false;
 
     if (progress == null) return const SizedBox.shrink();
 
     final notifier = ref.read(focusTimerProvider.notifier);
     final showTransport = !progress.isIdle && !progress.isCompleted;
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        SizedBox(
-          width: 240,
-          height: 72,
-          child: Stack(
-            alignment: Alignment.center,
-            clipBehavior: Clip.none,
-            children: [
-              AnimatedPositioned(
-                duration: AppConstants.animation.medium,
-                curve: Curves.easeInOut,
-                left: showTransport ? 0 : 98,
-                top: -8,
-                child: AnimatedOpacity(
-                  duration: AppConstants.animation.medium,
-                  opacity: (showTransport && controlsVisible) ? 1.0 : 0.0,
-                  child: AnimatedScale(
-                    duration: AppConstants.animation.medium,
-                    scale: showTransport ? 1.0 : 0.0,
-                    child: IgnorePointer(
-                      ignoring: !showTransport || !controlsVisible,
-                      child: FocusCircleIconButton(
-                        icon: FLucideIcons.square,
-                        size: 44,
-                        color: context.colors.mutedForeground,
-                        backgroundColor: context.colors.muted,
-                        onTap: () {
-                          ref.read(focusScreenProvider.notifier).onUserInteraction();
-                          _confirmEnd(context, ref);
-                        },
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-              AnimatedPositioned(
-                duration: AppConstants.animation.medium,
-                curve: Curves.easeInOut,
-                right: showTransport ? 0 : 98,
-                top: -8,
-                child: AnimatedOpacity(
-                  duration: AppConstants.animation.medium,
-                  opacity: (showTransport && controlsVisible) ? 1.0 : 0.0,
-                  child: AnimatedScale(
-                    duration: AppConstants.animation.medium,
-                    scale: showTransport ? 1.0 : 0.0,
-                    child: IgnorePointer(
-                      ignoring: !showTransport || !controlsVisible,
-                      child: FocusCircleIconButton(
-                        icon: FLucideIcons.skipForward,
-                        size: 44,
-                        color: context.colors.mutedForeground,
-                        backgroundColor: context.colors.muted,
-                        onTap: () {
-                          ref.read(focusScreenProvider.notifier).onUserInteraction();
-                          notifier.skipToNextPhase();
-                        },
-                      ),
-                    ),
-                  ),
-                ),
-              ),
-              FocusCircleIconButton(
-                icon: _centerIcon(progress),
-                size: 64,
-                color: context.colors.primaryForeground,
-                backgroundColor: context.colors.primary,
-                onTap: () {
-                  ref.read(focusScreenProvider.notifier).onUserInteraction();
-                  notifier.togglePlayPause();
-                },
-              ),
-            ],
-          ),
-        ),
-        SizedBox(height: AppConstants.spacing.extraLarge),
-        AnimatedOpacity(
-          duration: AppConstants.animation.medium,
-          opacity: controlsVisible ? 1.0 : 0.0,
-          child: AnimatedSwitcher(
+    return SizedBox(
+      width: 240,
+      height: 72,
+      child: Stack(
+        alignment: Alignment.center,
+        clipBehavior: Clip.none,
+        children: [
+          AnimatedPositioned(
             duration: AppConstants.animation.medium,
-            switchInCurve: Curves.easeOut,
-            switchOutCurve: Curves.easeIn,
-            transitionBuilder: (child, animation) => FadeTransition(
-              opacity: animation,
-              child: SlideTransition(
-                position: Tween<Offset>(begin: const Offset(0, 0.2), end: Offset.zero).animate(animation),
-                child: child,
+            curve: Curves.easeInOut,
+            left: showTransport ? 0 : 98,
+            top: -8,
+            child: AnimatedOpacity(
+              duration: AppConstants.animation.medium,
+              opacity: (showTransport && controlsVisible) ? 1.0 : 0.0,
+              child: AnimatedScale(
+                duration: AppConstants.animation.medium,
+                scale: showTransport ? 1.0 : 0.0,
+                child: IgnorePointer(
+                  ignoring: !showTransport || !controlsVisible,
+                  child: FocusCircleIconButton(
+                    icon: FLucideIcons.square,
+                    size: 44,
+                    color: context.colors.mutedForeground,
+                    backgroundColor: context.colors.muted,
+                    onTap: () {
+                      ref.read(focusScreenProvider.notifier).onUserInteraction();
+                      _confirmEnd(context, ref);
+                    },
+                  ),
+                ),
               ),
             ),
-            child: showTransport
-                ? FButton(
-                    key: const ValueKey('complete-btn'),
-                    variant: .outline,
-                    onPress: () {
-                      ref.read(focusScreenProvider.notifier).onUserInteraction();
-                      if (isQuickSession) {
-                        ref.read(focusTimerProvider.notifier).completeSessionEarly();
-                      } else {
-                        onCompleteTask();
-                      }
-                    },
-                    prefix: Icon(isQuickSession ? FLucideIcons.check : FLucideIcons.checkCheck),
-                    child: Text(isQuickSession ? 'End Session' : 'Complete Task'),
-                  )
-                : const SizedBox.shrink(key: ValueKey('empty-btn')),
           ),
-        ),
-      ],
+          AnimatedPositioned(
+            duration: AppConstants.animation.medium,
+            curve: Curves.easeInOut,
+            right: showTransport ? 0 : 98,
+            top: -8,
+            child: AnimatedOpacity(
+              duration: AppConstants.animation.medium,
+              opacity: (showTransport && controlsVisible) ? 1.0 : 0.0,
+              child: AnimatedScale(
+                duration: AppConstants.animation.medium,
+                scale: showTransport ? 1.0 : 0.0,
+                child: IgnorePointer(
+                  ignoring: !showTransport || !controlsVisible,
+                  child: FocusCircleIconButton(
+                    icon: FLucideIcons.skipForward,
+                    size: 44,
+                    color: context.colors.mutedForeground,
+                    backgroundColor: context.colors.muted,
+                    onTap: () {
+                      ref.read(focusScreenProvider.notifier).onUserInteraction();
+                      notifier.skipToNextPhase();
+                    },
+                  ),
+                ),
+              ),
+            ),
+          ),
+          FocusCircleIconButton(
+            icon: _centerIcon(progress),
+            size: 64,
+            color: context.colors.primaryForeground,
+            backgroundColor: context.colors.primary,
+            onTap: () {
+              ref.read(focusScreenProvider.notifier).onUserInteraction();
+              notifier.togglePlayPause();
+            },
+          ),
+        ],
+      ),
     );
   }
 

--- a/lib/features/session/presentation/widgets/focus_end_session_button.dart
+++ b/lib/features/session/presentation/widgets/focus_end_session_button.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:forui/forui.dart';
+
+import '../../../../core/constants/app_constants.dart';
+import '../providers/focus_progress_provider.dart';
+import '../providers/focus_screen_provider.dart';
+import '../providers/focus_session_provider.dart';
+
+/// Footer action to end a quick session or complete the linked task.
+class FocusEndSessionButton extends ConsumerWidget {
+  final VoidCallback onCompleteTask;
+  final bool controlsVisible;
+
+  const FocusEndSessionButton({super.key, required this.onCompleteTask, required this.controlsVisible});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final progress = ref.watch(focusProgressProvider);
+    final session = ref.watch(focusTimerProvider);
+    final isQuickSession = session?.isQuickSession ?? false;
+
+    if (progress == null) return const SizedBox.shrink();
+
+    final showAction = !progress.isIdle && !progress.isCompleted;
+
+    return AnimatedOpacity(
+      duration: AppConstants.animation.medium,
+      opacity: controlsVisible ? 1.0 : 0.0,
+      child: IgnorePointer(
+        ignoring: !controlsVisible || !showAction,
+        child: AnimatedSwitcher(
+          duration: AppConstants.animation.medium,
+          switchInCurve: Curves.easeOut,
+          switchOutCurve: Curves.easeIn,
+          transitionBuilder: (child, animation) => FadeTransition(
+            opacity: animation,
+            child: SlideTransition(
+              position: Tween<Offset>(begin: const Offset(0, 0.2), end: Offset.zero).animate(animation),
+              child: child,
+            ),
+          ),
+          child: showAction
+              ? Padding(
+                  key: const ValueKey('complete-btn'),
+                  padding: EdgeInsets.all(AppConstants.spacing.large),
+                  child: FButton(
+                    variant: .outline,
+                    onPress: () {
+                      ref.read(focusScreenProvider.notifier).onUserInteraction();
+                      if (isQuickSession) {
+                        ref.read(focusTimerProvider.notifier).completeSessionEarly();
+                      } else {
+                        onCompleteTask();
+                      }
+                    },
+                    prefix: Icon(isQuickSession ? FLucideIcons.check : FLucideIcons.checkCheck),
+                    child: Text(isQuickSession ? 'End Session' : 'Complete Task'),
+                  ),
+                )
+              : const SizedBox.shrink(key: ValueKey('empty-btn')),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch fix/focus-session-layout into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
60fbbfe fix(session): move end-session into scaffold footer

### Files
- lib/features/session/presentation/screens/focus_session_screen.dart
- lib/features/session/presentation/widgets/focus_controls_with_callback.dart
- lib/features/session/presentation/widgets/focus_end_session_button.dart

### Diffstat
 .../presentation/screens/focus_session_screen.dart |  87 ++++++-----
 .../widgets/focus_controls_with_callback.dart      | 170 ++++++++-------------
 .../widgets/focus_end_session_button.dart          |  66 ++++++++
 3 files changed, 178 insertions(+), 145 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
