### PR TITLE
fix(ui): make ConstrainedContent breakpoint-aware

### DIFF
--- a/lib/core/widgets/constrained_content.dart
+++ b/lib/core/widgets/constrained_content.dart
@@ -1,6 +1,21 @@
+import 'dart:math' as math;
+
 import 'package:flutter/widgets.dart';
 
+import '../utils/platform_utils.dart';
+
+/// Centers content with a max width and padding.
+///
+/// When [maxWidth] is left at [defaultMaxWidth] (800), width is resolved from
+/// form factor:
+///  - compact: unconstrained (full parent width)
+///  - expanded: `min(1120, viewportWidth * 0.72)`
+///
+/// Explicit [maxWidth] values (including [double.infinity] for embedded panes)
+/// are honored as-is.
 class ConstrainedContent extends StatelessWidget {
+  static const double defaultMaxWidth = 800;
+
   final Widget child;
   final double maxWidth;
   final EdgeInsets padding;
@@ -8,15 +23,22 @@ class ConstrainedContent extends StatelessWidget {
   const ConstrainedContent({
     super.key,
     required this.child,
-    this.maxWidth = 800,
+    this.maxWidth = defaultMaxWidth,
     this.padding = const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
   });
+
+  double _resolveMaxWidth(BuildContext context) {
+    if (maxWidth != defaultMaxWidth) return maxWidth;
+    if (context.isCompact) return double.infinity;
+    final viewportWidth = MediaQuery.sizeOf(context).width;
+    return math.min(1120.0, viewportWidth * 0.72);
+  }
 
   @override
   Widget build(BuildContext context) {
     return Center(
       child: ConstrainedBox(
-        constraints: BoxConstraints(maxWidth: maxWidth),
+        constraints: BoxConstraints(maxWidth: _resolveMaxWidth(context)),
         child: Padding(padding: padding, child: child),
       ),
     );


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch fix/content-width into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
c39d42c fix(ui): make ConstrainedContent breakpoint-aware

### Files
- lib/core/widgets/constrained_content.dart

### Diffstat
 lib/core/widgets/constrained_content.dart | 26 ++++++++++++++++++++++++--
 1 file changed, 24 insertions(+), 2 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
