### PR TITLE
fix(ui): harden task detail pop and activity graph dispose

### DIFF
--- a/lib/features/home/presentation/widgets/year_activity_graph.dart
+++ b/lib/features/home/presentation/widgets/year_activity_graph.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:forui/forui.dart';
@@ -23,6 +25,8 @@ class YearActivityGraph extends ConsumerStatefulWidget {
 class _YearActivityGraphState extends ConsumerState<YearActivityGraph> {
   late final ScrollController _scrollController;
   OverlayEntry? _tooltip;
+  Timer? _tooltipTimer;
+  TappedDateNotifier? _tappedDateNotifier;
 
   @override
   void initState() {
@@ -32,8 +36,19 @@ class _YearActivityGraphState extends ConsumerState<YearActivityGraph> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _tappedDateNotifier ??= ref.read(tappedDateProvider.notifier);
+  }
+
+  @override
   void dispose() {
-    _removeTooltip();
+    _tooltipTimer?.cancel();
+    _tooltip?.remove();
+    _tooltip?.dispose();
+    _tooltip = null;
+    // Clear selection without WidgetRef (unsafe during dispose).
+    _tappedDateNotifier?.setDate(null);
     _scrollController.dispose();
     super.dispose();
   }
@@ -85,14 +100,17 @@ class _YearActivityGraphState extends ConsumerState<YearActivityGraph> {
     );
     overlay.insert(_tooltip!);
 
-    Future.delayed(ActivityGraphConstants.tooltipDuration, _removeTooltip);
+    _tooltipTimer = Timer(ActivityGraphConstants.tooltipDuration, _removeTooltip);
   }
 
   void _removeTooltip() {
+    _tooltipTimer?.cancel();
+    _tooltipTimer = null;
     _tooltip?.remove();
     _tooltip?.dispose();
     _tooltip = null;
-    if (mounted && ref.read(tappedDateProvider) != null) {
+    if (!mounted) return;
+    if (ref.read(tappedDateProvider) != null) {
       ref.read(tappedDateProvider.notifier).setDate(null);
     }
   }

--- a/lib/features/tasks/presentation/screens/task_detail_screen.dart
+++ b/lib/features/tasks/presentation/screens/task_detail_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/widgets/action_menu_button.dart';
 import '../../../../core/constants/app_constants.dart';
+import '../../../../core/routing/routes.dart';
 import '../../../home/presentation/widgets/section_header.dart';
 import '../../../projects/presentation/providers/project_provider.dart';
 import '../../../session/domain/entities/session_state.dart';
@@ -31,6 +32,14 @@ class TaskDetailScreen extends ConsumerWidget {
 
   String get _projectIdString => projectId.toString();
 
+  void _safePop(BuildContext context) {
+    if (context.canPop()) {
+      context.pop();
+    } else {
+      context.go(AppRoutes.tasks.path);
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final allTasksAsync = ref.watch(tasksByProjectProvider(_projectIdString));
@@ -48,7 +57,7 @@ class TaskDetailScreen extends ConsumerWidget {
           return fu.FScaffold(
             header: fu.FHeader.nested(
               title: const Text('Task Details'),
-              prefixes: [fu.FHeaderAction.back(onPress: () => context.pop())],
+              prefixes: [fu.FHeaderAction.back(onPress: () => _safePop(context))],
             ),
             child: const Center(child: Text('Task not found')),
           );
@@ -136,12 +145,12 @@ class TaskDetailScreen extends ConsumerWidget {
         return fu.FScaffold(
           header: fu.FHeader.nested(
             title: const Text('Task Details'),
-            prefixes: [fu.FHeaderAction.back(onPress: () => context.pop())],
+            prefixes: [fu.FHeaderAction.back(onPress: () => _safePop(context))],
             suffixes: [
               ActionMenuButton(
                 onEdit: () => TaskCommands.edit(context, task),
                 onDelete: () =>
-                    TaskCommands.delete(context, ref, task, _projectIdString, onDeleted: () => context.pop()),
+                    TaskCommands.delete(context, ref, task, _projectIdString, onDeleted: () => _safePop(context)),
               ),
             ],
           ),


### PR DESCRIPTION
## Summary
- This PR groups related changes from branch fix/ui-crashes into an atomic review unit.

## Why
- Improve maintainability and review quality through focused, conventional changes.

## What Changed
### Commits
313d5aa fix(ui): harden task detail pop and activity graph dispose

### Files
- lib/features/home/presentation/widgets/year_activity_graph.dart
- lib/features/tasks/presentation/screens/task_detail_screen.dart

### Diffstat
 .../presentation/widgets/year_activity_graph.dart  | 24 +++++++++++++++++++---
 .../presentation/screens/task_detail_screen.dart   | 15 +++++++++++---
 2 files changed, 33 insertions(+), 6 deletions(-)

## Testing
- [ ] flutter analyze
- [ ] dart format . --line-length=120
- [ ] flutter test
- [ ] Manual smoke test for changed flows

## Reviewer Notes
- Changes were grouped atomically by intent.
- Conventional commit titles were used for semantic versioning.
